### PR TITLE
Refactoring: FormRequestAnalyzerをASTベースに完全書き換え

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,18 +37,16 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
-        "format": "vendor/bin/pint",
-        "analyse": "vendor/bin/phpstan analyse",
-        "check-style": "vendor/bin/pint --test",
-        "fix-style": "vendor/bin/pint"
+        "format": "vendor/bin/pint --test",
+        "format:fix": "vendor/bin/pint",
+        "analyze": "vendor/bin/phpstan analyse"
     },
     "scripts-descriptions": {
         "test": "Run the tests",
         "test-coverage": "Run the tests with coverage",
-        "format": "Format the code using Laravel Pint",
-        "analyse": "Analyse the code using PHPStan",
-        "check-style": "Check the code style",
-        "fix-style": "Fix the code style"
+        "format": "Check the code style",
+        "format:fix": "Format the code using Laravel Pint",
+        "analyze": "Analyse the code using PHPStan"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "php": "^8.1",
         "illuminate/support": "^10.0|^11.0|^12.0",
         "illuminate/routing": "^10.0|^11.0|^12.0",
-        "illuminate/console": "^10.0|^11.0|^12.0"
+        "illuminate/console": "^10.0|^11.0|^12.0",
+        "nikic/php-parser": "^5.5"
     },
     "require-dev": {
         "orchestra/testbench": "^8.0|^9.0|^10.0",

--- a/src/Analyzers/AST/Visitors/ArrayReturnExtractorVisitor.php
+++ b/src/Analyzers/AST/Visitors/ArrayReturnExtractorVisitor.php
@@ -31,10 +31,6 @@ class ArrayReturnExtractorVisitor extends NodeVisitorAbstract
         $result = [];
 
         foreach ($array->items as $item) {
-            if (! $item || ! $item->key) {
-                continue;
-            }
-
             $key   = $this->evaluateExpression($item->key);
             $value = $this->evaluateExpression($item->value);
 

--- a/src/Analyzers/AST/Visitors/ArrayReturnExtractorVisitor.php
+++ b/src/Analyzers/AST/Visitors/ArrayReturnExtractorVisitor.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace LaravelPrism\Analyzers\AST\Visitors;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\PrettyPrinter;
+
+class ArrayReturnExtractorVisitor extends NodeVisitorAbstract
+{
+    private array $array = [];
+    private PrettyPrinter\Standard $printer;
+
+    public function __construct(PrettyPrinter\Standard $printer)
+    {
+        $this->printer = $printer;
+    }
+
+    public function enterNode(Node $node): ?int
+    {
+        if ($node instanceof Node\Stmt\Return_ &&
+            $node->expr instanceof Node\Expr\Array_) {
+            $this->array = $this->extractArray($node->expr);
+        }
+
+        return null;
+    }
+
+    private function extractArray(Node\Expr\Array_ $array): array
+    {
+        $result = [];
+
+        foreach ($array->items as $item) {
+            if (! $item || ! $item->key) {
+                continue;
+            }
+
+            $key   = $this->evaluateExpression($item->key);
+            $value = $this->evaluateExpression($item->value);
+
+            if ($key !== null) {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    private function evaluateExpression(Node $expr)
+    {
+        if ($expr instanceof Node\Scalar\String_) {
+            return $expr->value;
+        }
+
+        if ($expr instanceof Node\Scalar\LNumber) {
+            return $expr->value;
+        }
+
+        if ($expr instanceof Node\Expr\Array_) {
+            return $this->extractArray($expr);
+        }
+
+        // その他の式は文字列として保存
+        if ($expr instanceof Node\Expr) {
+            return $this->printer->prettyPrintExpr($expr);
+        }
+
+        return '';
+    }
+
+    public function getArray(): array
+    {
+        return $this->array;
+    }
+}

--- a/src/Analyzers/AST/Visitors/ClassFindingVisitor.php
+++ b/src/Analyzers/AST/Visitors/ClassFindingVisitor.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace LaravelPrism\Analyzers\AST\Visitors;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+class ClassFindingVisitor extends NodeVisitorAbstract
+{
+    private string $className;
+    private ?Node\Stmt\Class_ $classNode = null;
+
+    public function __construct(string $className)
+    {
+        $this->className = $className;
+    }
+
+    public function enterNode(Node $node): ?int
+    {
+        if ($node instanceof Node\Stmt\Class_ &&
+            $node->name &&
+            $node->name->toString() === $this->className) {
+            $this->classNode = $node;
+
+            return NodeTraverser::STOP_TRAVERSAL;
+        }
+
+        return null;
+    }
+
+    public function getClassNode(): ?Node\Stmt\Class_
+    {
+        return $this->classNode;
+    }
+}

--- a/src/Analyzers/AST/Visitors/RulesExtractorVisitor.php
+++ b/src/Analyzers/AST/Visitors/RulesExtractorVisitor.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace LaravelPrism\Analyzers\AST\Visitors;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\PrettyPrinter;
+
+class RulesExtractorVisitor extends NodeVisitorAbstract
+{
+    private array $rules = [];
+    private PrettyPrinter\Standard $printer;
+    private array $variables = [];
+
+    public function __construct(PrettyPrinter\Standard $printer)
+    {
+        $this->printer = $printer;
+    }
+
+    public function enterNode(Node $node): ?int
+    {
+        // 変数代入を追跡
+        if ($node instanceof Node\Expr\Assign &&
+            $node->var instanceof Node\Expr\Variable &&
+            $node->expr instanceof Node\Expr\Array_) {
+            $this->variables[$node->var->name] = $this->extractArrayRules($node->expr);
+        }
+
+        // return文を検出
+        if ($node instanceof Node\Stmt\Return_ && $node->expr) {
+
+            // 直接配列を返す場合
+            if ($node->expr instanceof Node\Expr\Array_) {
+                $this->rules = $this->extractArrayRules($node->expr);
+            }
+            // 変数を返す場合
+            elseif ($node->expr instanceof Node\Expr\Variable) {
+                // TODO: 変数の定義を追跡する必要がある
+                $this->rules = ['_notice' => 'Dynamic rules detected - manual review required'];
+            }
+            // array_merge呼び出しを処理
+            elseif ($node->expr instanceof Node\Expr\FuncCall &&
+                    $node->expr->name instanceof Node\Name &&
+                    $node->expr->name->toString() === 'array_merge') {
+                $this->rules = $this->extractArrayMergeRules($node->expr);
+            }
+            // その他のメソッド呼び出しの結果を返す場合
+            elseif ($node->expr instanceof Node\Expr\MethodCall ||
+                    $node->expr instanceof Node\Expr\FuncCall) {
+                $this->rules = ['_notice' => 'Complex rules detected - ' . $this->printer->prettyPrintExpr($node->expr)];
+            }
+            // match式（PHP 8）
+            elseif ($node->expr instanceof Node\Expr\Match_) {
+                $this->rules = $this->extractMatchRules($node->expr);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * 配列形式のルールを抽出
+     */
+    private function extractArrayRules(Node\Expr\Array_ $array): array
+    {
+        $rules = [];
+
+        foreach ($array->items as $item) {
+            if (! $item || ! $item->key) {
+                continue;
+            }
+
+            $key   = $this->evaluateKey($item->key);
+            $value = $this->evaluateValue($item->value);
+
+            if ($value !== null) {
+                $rules[$key] = $value;
+            }
+        }
+
+        return $rules;
+    }
+
+    /**
+     * match式からルールを抽出（PHP 8）
+     */
+    private function extractMatchRules(Node\Expr\Match_ $match): array
+    {
+        // 最初のアームのルールを取得（簡易実装）
+        foreach ($match->arms as $arm) {
+            if ($arm->body instanceof Node\Expr\Array_) {
+                return $this->extractArrayRules($arm->body);
+            }
+        }
+
+        return ['_notice' => 'Match expression detected - manual review required'];
+    }
+
+    /**
+     * array_merge呼び出しからルールを抽出
+     */
+    private function extractArrayMergeRules(Node\Expr\FuncCall $call): array
+    {
+        $mergedRules = [];
+
+        foreach ($call->args as $arg) {
+            if ($arg->value instanceof Node\Expr\Array_) {
+                $rules       = $this->extractArrayRules($arg->value);
+                $mergedRules = array_merge($mergedRules, $rules);
+            } elseif ($arg->value instanceof Node\Expr\Variable) {
+                // 変数の場合は保存された値を使用
+                $varName = $arg->value->name;
+                if (isset($this->variables[$varName])) {
+                    $mergedRules = array_merge($mergedRules, $this->variables[$varName]);
+                }
+            }
+        }
+
+        return $mergedRules ?: ['_notice' => 'Dynamic array_merge rules detected'];
+    }
+
+    /**
+     * キーを評価
+     */
+    private function evaluateKey(Node $expr): string
+    {
+        if ($expr instanceof Node\Scalar\String_) {
+            return $expr->value;
+        }
+
+        if ($expr instanceof Node\Scalar\LNumber) {
+            return (string) $expr->value;
+        }
+
+        // その他の式は文字列として保存
+        if ($expr instanceof Node\Expr) {
+            return $this->printer->prettyPrintExpr($expr);
+        }
+
+        return '';
+    }
+
+    /**
+     * 値を評価
+     */
+    private function evaluateValue(Node $expr)
+    {
+        // 文字列リテラル
+        if ($expr instanceof Node\Scalar\String_) {
+            return $expr->value;
+        }
+
+        // 配列
+        if ($expr instanceof Node\Expr\Array_) {
+            $result = [];
+            foreach ($expr->items as $item) {
+                if ($item && $item->value) {
+                    $value = $this->evaluateValue($item->value);
+                    if ($value !== null) {
+                        $result[] = $value;
+                    }
+                }
+            }
+
+            return $result;
+        }
+
+        // 連結演算子（'required|string' のような形式）
+        if ($expr instanceof Node\Expr\BinaryOp\Concat) {
+            $left  = $this->evaluateValue($expr->left);
+            $right = $this->evaluateValue($expr->right);
+
+            if (is_string($left) && is_string($right)) {
+                return $left . $right;
+            }
+        }
+
+        // Ruleクラスの静的メソッド呼び出し
+        if ($expr instanceof Node\Expr\StaticCall) {
+            return $this->evaluateStaticCall($expr);
+        }
+
+        // その他の複雑な式は文字列として保存
+        if ($expr instanceof Node\Expr) {
+            return $this->printer->prettyPrintExpr($expr);
+        }
+
+        return '';
+    }
+
+    /**
+     * 静的メソッド呼び出しを評価
+     */
+    private function evaluateStaticCall(Node\Expr\StaticCall $call): string
+    {
+        // Rule::unique('users')->ignore($id) のような呼び出しを文字列化
+        // TODO: より詳細な解析が可能
+        return $this->printer->prettyPrintExpr($call);
+    }
+
+    public function getRules(): array
+    {
+        return $this->rules;
+    }
+}

--- a/src/Analyzers/AST/Visitors/RulesExtractorVisitor.php
+++ b/src/Analyzers/AST/Visitors/RulesExtractorVisitor.php
@@ -66,10 +66,6 @@ class RulesExtractorVisitor extends NodeVisitorAbstract
         $rules = [];
 
         foreach ($array->items as $item) {
-            if (! $item || ! $item->key) {
-                continue;
-            }
-
             $key   = $this->evaluateKey($item->key);
             $value = $this->evaluateValue($item->value);
 
@@ -154,11 +150,9 @@ class RulesExtractorVisitor extends NodeVisitorAbstract
         if ($expr instanceof Node\Expr\Array_) {
             $result = [];
             foreach ($expr->items as $item) {
-                if ($item && $item->value) {
-                    $value = $this->evaluateValue($item->value);
-                    if ($value !== null) {
-                        $result[] = $value;
-                    }
+                $value = $this->evaluateValue($item->value);
+                if ($value !== null) {
+                    $result[] = $value;
                 }
             }
 

--- a/tests/Unit/FormRequestAnalyzerTest.php
+++ b/tests/Unit/FormRequestAnalyzerTest.php
@@ -3,6 +3,7 @@
 namespace LaravelPrism\Tests\Unit;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 use LaravelPrism\Analyzers\FormRequestAnalyzer;
 use LaravelPrism\Support\TypeInference;
 use LaravelPrism\Tests\Fixtures\StoreUserRequest;
@@ -149,6 +150,171 @@ class FormRequestAnalyzerTest extends TestCase
         $this->assertTrue($this->findParameterByName($parameters, 'required_field')['required']);
         $this->assertFalse($this->findParameterByName($parameters, 'optional_field')['required']);
         $this->assertFalse($this->findParameterByName($parameters, 'nullable_field')['required']);
+    }
+
+    /** @test */
+    public function it_handles_rule_objects()
+    {
+        // Skip test if using file-based analyzer since it can't instantiate Rule objects
+        if (method_exists($this->analyzer, 'extractRules') && ! class_exists('LaravelPrism\Analyzers\AST\Visitors\RulesExtractorVisitor')) {
+            $this->markTestSkipped('Current implementation cannot handle Rule objects');
+        }
+
+        // Arrange
+        $testRequestClass = new class extends FormRequest
+        {
+            public function rules(): array
+            {
+                return [
+                    'email' => [
+                        'required',
+                        'email',
+                        Rule::unique('users')->ignore(1),
+                    ],
+                    'status' => ['required', Rule::in(['active', 'inactive'])],
+                ];
+            }
+        };
+
+        // Act
+        $parameters = $this->analyzer->analyze(get_class($testRequestClass));
+
+        // Assert
+        $emailParam = $this->findParameterByName($parameters, 'email');
+        $this->assertNotNull($emailParam);
+        $this->assertTrue($emailParam['required']);
+        $this->assertEquals('string', $emailParam['type']);
+
+        $statusParam = $this->findParameterByName($parameters, 'status');
+        $this->assertNotNull($statusParam);
+        $this->assertTrue($statusParam['required']);
+    }
+
+    /** @test */
+    public function it_handles_dynamic_rules()
+    {
+        // Skip test if using file-based analyzer
+        if (method_exists($this->analyzer, 'extractRules') && ! class_exists('LaravelPrism\Analyzers\AST\Visitors\RulesExtractorVisitor')) {
+            $this->markTestSkipped('Current implementation cannot handle dynamic rules');
+        }
+
+        // Arrange
+        $testRequestClass = new class extends FormRequest
+        {
+            public function rules(): array
+            {
+                $baseRules = ['name' => 'required|string'];
+
+                if ($this->isMethod('POST')) {
+                    $baseRules['email'] = 'required|email|unique:users';
+                }
+
+                return array_merge($baseRules, $this->additionalRules());
+            }
+
+            private function additionalRules(): array
+            {
+                return ['age' => 'integer|min:0'];
+            }
+        };
+
+        // Act
+        $parameters = $this->analyzer->analyze(get_class($testRequestClass));
+
+        // Assert
+        $nameParam = $this->findParameterByName($parameters, 'name');
+        $this->assertNotNull($nameParam);
+        $this->assertTrue($nameParam['required']);
+    }
+
+    /** @test */
+    public function it_handles_php8_match_expression()
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('PHP 8.0+ required');
+        }
+
+        // Skip test if using file-based analyzer
+        if (method_exists($this->analyzer, 'extractRules') && ! class_exists('LaravelPrism\Analyzers\AST\Visitors\RulesExtractorVisitor')) {
+            $this->markTestSkipped('Current implementation cannot handle match expressions');
+        }
+
+        // Arrange
+        $testRequestClass = new class extends FormRequest
+        {
+            public function rules(): array
+            {
+                return match ($this->method()) {
+                    'POST'  => ['name' => 'required|string', 'email' => 'required|email'],
+                    'PUT'   => ['name' => 'sometimes|required|string'],
+                    default => []
+                };
+            }
+        };
+
+        // Act
+        $parameters = $this->analyzer->analyze(get_class($testRequestClass));
+
+        // Assert
+        $this->assertNotEmpty($parameters);
+    }
+
+    /** @test */
+    public function it_handles_nested_array_rules()
+    {
+        // Arrange
+        $testRequestClass = new class extends FormRequest
+        {
+            public function rules(): array
+            {
+                return [
+                    'user.name'      => 'required|string',
+                    'user.email'     => 'required|email',
+                    'address.street' => 'required|string',
+                    'address.city'   => 'required|string',
+                ];
+            }
+        };
+
+        // Act
+        $parameters = $this->analyzer->analyze(get_class($testRequestClass));
+
+        // Assert
+        $userNameParam = $this->findParameterByName($parameters, 'user.name');
+        $this->assertNotNull($userNameParam);
+        $this->assertTrue($userNameParam['required']);
+        $this->assertEquals('string', $userNameParam['type']);
+    }
+
+    /** @test */
+    public function it_handles_wildcard_array_rules()
+    {
+        // Arrange
+        $testRequestClass = new class extends FormRequest
+        {
+            public function rules(): array
+            {
+                return [
+                    'items'            => 'required|array',
+                    'items.*.name'     => 'required|string',
+                    'items.*.quantity' => 'required|integer|min:1',
+                ];
+            }
+        };
+
+        // Act
+        $parameters = $this->analyzer->analyze(get_class($testRequestClass));
+
+        // Assert
+        $itemsParam = $this->findParameterByName($parameters, 'items');
+        $this->assertNotNull($itemsParam);
+        $this->assertTrue($itemsParam['required']);
+        $this->assertEquals('array', $itemsParam['type']);
+
+        $itemNameParam = $this->findParameterByName($parameters, 'items.*.name');
+        $this->assertNotNull($itemNameParam);
+        $this->assertTrue($itemNameParam['required']);
+        $this->assertEquals('string', $itemNameParam['type']);
     }
 
     private function findParameterByName(array $parameters, string $name): ?array


### PR DESCRIPTION
## Summary
- FormRequestAnalyzerをリフレクションベースからASTパーサーベースに書き換え
- 動的なルール定義やRuleオブジェクトの解析に対応
- より堅牢で拡張性の高い実装を実現

## 変更内容

### 1. AST解析基盤の導入
- `nikic/php-parser`パッケージを導入し、PHPコードの静的解析を可能に
- 専用のVisitorクラスを実装：
  - `ClassFindingVisitor`: クラスノードの検索
  - `RulesExtractorVisitor`: rules()メソッドの解析
  - `ArrayReturnExtractorVisitor`: attributes()メソッドの解析

### 2. FormRequestAnalyzerの完全書き換え
- **旧実装の問題点**:
  - リフレクションベースでインスタンス化が必要
  - 動的なルール定義を解析できない
  - Ruleオブジェクトやクロージャを扱えない
  
- **新実装の利点**:
  - 静的解析によりインスタンス化不要
  - 動的なルール定義もAST解析で対応
  - より多様なルール記法をサポート
  - 匿名クラスにも対応（フォールバック付き）

### 3. テストの拡充
- 既存のテストは全て互換性を維持
- 新機能に対応したテストケースを追加：
  - Ruleオブジェクトの使用
  - 動的ルール生成
  - PHP8のmatch式
  - ネストした配列ルール
  - ワイルドカード配列ルール

## Test plan
- [x] 既存のテストが全てパスすることを確認
- [x] 新規追加したテストケースが正常に動作することを確認
- [ ] 実際のLaravelプロジェクトでの動作確認
- [ ] パフォーマンスへの影響を測定