### PR TITLE
New Feature: エラーレスポンスの自動文書化機能を実装

### DIFF
--- a/src/Generators/ErrorResponseGenerator.php
+++ b/src/Generators/ErrorResponseGenerator.php
@@ -5,28 +5,28 @@ namespace LaravelPrism\Generators;
 class ErrorResponseGenerator
 {
     protected ValidationMessageGenerator $messageGenerator;
-    
+
     public function __construct(ValidationMessageGenerator $messageGenerator)
     {
         $this->messageGenerator = $messageGenerator;
     }
-    
+
     /**
      * エラーレスポンスのスキーマを生成
      */
-    public function generateErrorResponses(array $formRequestData = null): array
+    public function generateErrorResponses(?array $formRequestData = null): array
     {
         $responses = [];
-        
+
         // 401 Unauthorized
         $responses['401'] = $this->generateUnauthorizedResponse();
-        
+
         // 403 Forbidden
         $responses['403'] = $this->generateForbiddenResponse();
-        
+
         // 404 Not Found
         $responses['404'] = $this->generateNotFoundResponse();
-        
+
         // 422 Validation Error（FormRequestがある場合のみ）
         if ($formRequestData && isset($formRequestData['rules'])) {
             $responses['422'] = $this->generateValidationErrorResponse(
@@ -34,13 +34,13 @@ class ErrorResponseGenerator
                 $formRequestData['messages'] ?? []
             );
         }
-        
+
         // 500 Internal Server Error
         $responses['500'] = $this->generateInternalServerErrorResponse();
-        
+
         return $responses;
     }
-    
+
     /**
      * 401 Unauthorized レスポンス
      */
@@ -63,7 +63,7 @@ class ErrorResponseGenerator
             ],
         ];
     }
-    
+
     /**
      * 403 Forbidden レスポンス
      */
@@ -86,7 +86,7 @@ class ErrorResponseGenerator
             ],
         ];
     }
-    
+
     /**
      * 404 Not Found レスポンス
      */
@@ -109,7 +109,7 @@ class ErrorResponseGenerator
             ],
         ];
     }
-    
+
     /**
      * 422 Validation Error レスポンス
      */
@@ -118,26 +118,26 @@ class ErrorResponseGenerator
         // 各フィールドのエラーメッセージを生成
         $fieldErrors = [];
         $errorExamples = [];
-        
+
         foreach ($rules as $field => $fieldRules) {
             // 特殊なフィールド（_noticeなど）はスキップ
             if (str_starts_with($field, '_')) {
                 continue;
             }
-            
+
             $fieldErrors[$field] = [
                 'type' => 'array',
                 'items' => [
                     'type' => 'string',
                 ],
-                'description' => 'Validation errors for the ' . $field . ' field',
+                'description' => 'Validation errors for the '.$field.' field',
             ];
-            
+
             // サンプルメッセージを生成
             $sampleMessage = $this->messageGenerator->generateSampleMessage($field, $fieldRules);
             $errorExamples[$field] = [$sampleMessage];
         }
-        
+
         return [
             'description' => 'Validation Error',
             'content' => [
@@ -160,7 +160,7 @@ class ErrorResponseGenerator
             ],
         ];
     }
-    
+
     /**
      * 500 Internal Server Error レスポンス
      */
@@ -183,33 +183,33 @@ class ErrorResponseGenerator
             ],
         ];
     }
-    
+
     /**
      * 特定のHTTPメソッドに基づいてデフォルトのエラーレスポンスを選択
      */
     public function getDefaultErrorResponses(string $method, bool $requiresAuth = false, bool $hasValidation = false): array
     {
         $responses = [];
-        
+
         // 認証が必要な場合
         if ($requiresAuth) {
             $responses['401'] = $this->generateUnauthorizedResponse();
             $responses['403'] = $this->generateForbiddenResponse();
         }
-        
+
         // バリデーションがある場合（POST, PUT, PATCH）
         if ($hasValidation && in_array(strtoupper($method), ['POST', 'PUT', 'PATCH'])) {
             // 422はFormRequestから生成されるので、ここでは含めない
         }
-        
+
         // GETリクエストや特定リソースへのアクセス
         if (in_array(strtoupper($method), ['GET', 'PUT', 'PATCH', 'DELETE'])) {
             $responses['404'] = $this->generateNotFoundResponse();
         }
-        
+
         // 全てのリクエストで可能性のあるエラー
         $responses['500'] = $this->generateInternalServerErrorResponse();
-        
+
         return $responses;
     }
 }

--- a/src/Generators/ErrorResponseGenerator.php
+++ b/src/Generators/ErrorResponseGenerator.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace LaravelPrism\Generators;
+
+class ErrorResponseGenerator
+{
+    protected ValidationMessageGenerator $messageGenerator;
+    
+    public function __construct(ValidationMessageGenerator $messageGenerator)
+    {
+        $this->messageGenerator = $messageGenerator;
+    }
+    
+    /**
+     * エラーレスポンスのスキーマを生成
+     */
+    public function generateErrorResponses(array $formRequestData = null): array
+    {
+        $responses = [];
+        
+        // 401 Unauthorized
+        $responses['401'] = $this->generateUnauthorizedResponse();
+        
+        // 403 Forbidden
+        $responses['403'] = $this->generateForbiddenResponse();
+        
+        // 404 Not Found
+        $responses['404'] = $this->generateNotFoundResponse();
+        
+        // 422 Validation Error（FormRequestがある場合のみ）
+        if ($formRequestData && isset($formRequestData['rules'])) {
+            $responses['422'] = $this->generateValidationErrorResponse(
+                $formRequestData['rules'],
+                $formRequestData['messages'] ?? []
+            );
+        }
+        
+        // 500 Internal Server Error
+        $responses['500'] = $this->generateInternalServerErrorResponse();
+        
+        return $responses;
+    }
+    
+    /**
+     * 401 Unauthorized レスポンス
+     */
+    protected function generateUnauthorizedResponse(): array
+    {
+        return [
+            'description' => 'Unauthorized',
+            'content' => [
+                'application/json' => [
+                    'schema' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'message' => [
+                                'type' => 'string',
+                                'example' => 'Unauthenticated.',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+    
+    /**
+     * 403 Forbidden レスポンス
+     */
+    protected function generateForbiddenResponse(): array
+    {
+        return [
+            'description' => 'Forbidden',
+            'content' => [
+                'application/json' => [
+                    'schema' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'message' => [
+                                'type' => 'string',
+                                'example' => 'This action is unauthorized.',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+    
+    /**
+     * 404 Not Found レスポンス
+     */
+    protected function generateNotFoundResponse(): array
+    {
+        return [
+            'description' => 'Not Found',
+            'content' => [
+                'application/json' => [
+                    'schema' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'message' => [
+                                'type' => 'string',
+                                'example' => 'Resource not found.',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+    
+    /**
+     * 422 Validation Error レスポンス
+     */
+    protected function generateValidationErrorResponse(array $rules, array $customMessages = []): array
+    {
+        // 各フィールドのエラーメッセージを生成
+        $fieldErrors = [];
+        $errorExamples = [];
+        
+        foreach ($rules as $field => $fieldRules) {
+            // 特殊なフィールド（_noticeなど）はスキップ
+            if (str_starts_with($field, '_')) {
+                continue;
+            }
+            
+            $fieldErrors[$field] = [
+                'type' => 'array',
+                'items' => [
+                    'type' => 'string',
+                ],
+                'description' => 'Validation errors for the ' . $field . ' field',
+            ];
+            
+            // サンプルメッセージを生成
+            $sampleMessage = $this->messageGenerator->generateSampleMessage($field, $fieldRules);
+            $errorExamples[$field] = [$sampleMessage];
+        }
+        
+        return [
+            'description' => 'Validation Error',
+            'content' => [
+                'application/json' => [
+                    'schema' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'message' => [
+                                'type' => 'string',
+                                'example' => 'The given data was invalid.',
+                            ],
+                            'errors' => [
+                                'type' => 'object',
+                                'properties' => $fieldErrors,
+                                'example' => $errorExamples,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+    
+    /**
+     * 500 Internal Server Error レスポンス
+     */
+    protected function generateInternalServerErrorResponse(): array
+    {
+        return [
+            'description' => 'Internal Server Error',
+            'content' => [
+                'application/json' => [
+                    'schema' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'message' => [
+                                'type' => 'string',
+                                'example' => 'Server Error',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+    
+    /**
+     * 特定のHTTPメソッドに基づいてデフォルトのエラーレスポンスを選択
+     */
+    public function getDefaultErrorResponses(string $method, bool $requiresAuth = false, bool $hasValidation = false): array
+    {
+        $responses = [];
+        
+        // 認証が必要な場合
+        if ($requiresAuth) {
+            $responses['401'] = $this->generateUnauthorizedResponse();
+            $responses['403'] = $this->generateForbiddenResponse();
+        }
+        
+        // バリデーションがある場合（POST, PUT, PATCH）
+        if ($hasValidation && in_array(strtoupper($method), ['POST', 'PUT', 'PATCH'])) {
+            // 422はFormRequestから生成されるので、ここでは含めない
+        }
+        
+        // GETリクエストや特定リソースへのアクセス
+        if (in_array(strtoupper($method), ['GET', 'PUT', 'PATCH', 'DELETE'])) {
+            $responses['404'] = $this->generateNotFoundResponse();
+        }
+        
+        // 全てのリクエストで可能性のあるエラー
+        $responses['500'] = $this->generateInternalServerErrorResponse();
+        
+        return $responses;
+    }
+}

--- a/src/Generators/OpenApiGenerator.php
+++ b/src/Generators/OpenApiGenerator.php
@@ -147,11 +147,11 @@ class OpenApiGenerator
 
         // エラーレスポンスを生成
         $errorResponses = $this->generateErrorResponses($route, $controllerInfo);
-        
+
         // マージ（array_mergeは数値キーを再インデックスするので + を使用）
         return $responses + $errorResponses;
     }
-    
+
     /**
      * エラーレスポンスを生成
      */
@@ -159,34 +159,34 @@ class OpenApiGenerator
     {
         $method = strtolower($route['httpMethods'][0]);
         $requiresAuth = $this->requiresAuth($route);
-        
+
         // FormRequestがある場合は、そのルールから422エラーを生成
         $formRequestData = null;
-        if (!empty($controllerInfo['formRequest'])) {
+        if (! empty($controllerInfo['formRequest'])) {
             $formRequestData = $this->requestAnalyzer->analyzeWithDetails($controllerInfo['formRequest']);
         }
-        
+
         // エラーレスポンスを生成
         $allErrorResponses = $this->errorResponseGenerator->generateErrorResponses($formRequestData);
-        
+
         // デフォルトのエラーレスポンスを取得
         $defaultErrorResponses = $this->errorResponseGenerator->getDefaultErrorResponses(
             $method,
             $requiresAuth,
-            !empty($formRequestData)
+            ! empty($formRequestData)
         );
-        
+
         // FormRequestがない場合は、デフォルトのエラーレスポンスのみを使用
         if (empty($formRequestData)) {
             return $defaultErrorResponses;
         }
-        
+
         // FormRequestがある場合は、422エラーも含める
         $responses = $defaultErrorResponses;
         if (isset($allErrorResponses['422'])) {
             $responses['422'] = $allErrorResponses['422'];
         }
-        
+
         return $responses;
     }
 

--- a/src/Generators/ValidationMessageGenerator.php
+++ b/src/Generators/ValidationMessageGenerator.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace LaravelPrism\Generators;
+
+use LaravelPrism\Support\ValidationRules;
+use Illuminate\Support\Str;
+
+class ValidationMessageGenerator
+{
+    /**
+     * バリデーションルールから可能なエラーメッセージを生成
+     */
+    public function generateMessages(array $rules, array $customMessages = []): array
+    {
+        $messages = [];
+        
+        foreach ($rules as $field => $fieldRules) {
+            $messages[$field] = $this->generateFieldMessages($field, $fieldRules, $customMessages);
+        }
+        
+        return $messages;
+    }
+    
+    /**
+     * フィールドごとのエラーメッセージを生成
+     */
+    protected function generateFieldMessages(string $field, $rules, array $customMessages): array
+    {
+        $messages = [];
+        
+        // ルールを配列に正規化
+        if (is_string($rules)) {
+            $rules = explode('|', $rules);
+        }
+        
+        $fieldType = ValidationRules::inferFieldType($rules);
+        $humanField = $this->humanizeFieldName($field);
+        
+        foreach ($rules as $rule) {
+            // Rule::unique() のようなオブジェクトの場合はスキップ
+            if (!is_string($rule)) {
+                continue;
+            }
+            
+            $ruleName = ValidationRules::extractRuleName($rule);
+            $parameters = ValidationRules::extractRuleParameters($rule);
+            
+            // カスタムメッセージがある場合
+            $customKey = $field . '.' . $ruleName;
+            if (isset($customMessages[$customKey])) {
+                $messages[] = $customMessages[$customKey];
+                continue;
+            }
+            
+            // デフォルトメッセージテンプレートを使用
+            $template = ValidationRules::getMessageTemplate($ruleName, $fieldType);
+            if ($template) {
+                $message = $this->replacePlaceholders($template, $field, $humanField, $parameters);
+                $messages[] = $message;
+            }
+        }
+        
+        return array_unique($messages);
+    }
+    
+    /**
+     * フィールド名を人間が読みやすい形式に変換
+     */
+    protected function humanizeFieldName(string $field): string
+    {
+        return Str::title(str_replace(['_', '.'], ' ', $field));
+    }
+    
+    /**
+     * メッセージテンプレートのプレースホルダーを置換
+     */
+    protected function replacePlaceholders(string $template, string $field, string $humanField, array $parameters): string
+    {
+        $replacements = [
+            ':attribute' => $humanField,
+            ':Attribute' => Str::ucfirst($humanField),
+        ];
+        
+        // パラメータの置換
+        if (!empty($parameters)) {
+            $replacements[':min'] = $parameters[0] ?? '';
+            $replacements[':max'] = $parameters[0] ?? '';
+            $replacements[':size'] = $parameters[0] ?? '';
+            $replacements[':value'] = $parameters[0] ?? '';
+            $replacements[':other'] = $this->humanizeFieldName($parameters[0] ?? '');
+            $replacements[':format'] = $parameters[0] ?? '';
+            $replacements[':values'] = implode(', ', $parameters);
+        }
+        
+        return strtr($template, $replacements);
+    }
+    
+    /**
+     * フィールドごとのサンプルメッセージを1つ生成（OpenAPIの例として使用）
+     */
+    public function generateSampleMessage(string $field, $rules): string
+    {
+        $messages = $this->generateFieldMessages($field, $rules, []);
+        
+        // 最も一般的なエラー（required）を優先
+        foreach ($messages as $message) {
+            if (str_contains($message, 'required')) {
+                return $message;
+            }
+        }
+        
+        // それ以外は最初のメッセージを返す
+        return $messages[0] ?? "The {$field} field is invalid.";
+    }
+}

--- a/src/Generators/ValidationMessageGenerator.php
+++ b/src/Generators/ValidationMessageGenerator.php
@@ -2,8 +2,8 @@
 
 namespace LaravelPrism\Generators;
 
-use LaravelPrism\Support\ValidationRules;
 use Illuminate\Support\Str;
+use LaravelPrism\Support\ValidationRules;
 
 class ValidationMessageGenerator
 {
@@ -13,45 +13,46 @@ class ValidationMessageGenerator
     public function generateMessages(array $rules, array $customMessages = []): array
     {
         $messages = [];
-        
+
         foreach ($rules as $field => $fieldRules) {
             $messages[$field] = $this->generateFieldMessages($field, $fieldRules, $customMessages);
         }
-        
+
         return $messages;
     }
-    
+
     /**
      * フィールドごとのエラーメッセージを生成
      */
     protected function generateFieldMessages(string $field, $rules, array $customMessages): array
     {
         $messages = [];
-        
+
         // ルールを配列に正規化
         if (is_string($rules)) {
             $rules = explode('|', $rules);
         }
-        
+
         $fieldType = ValidationRules::inferFieldType($rules);
         $humanField = $this->humanizeFieldName($field);
-        
+
         foreach ($rules as $rule) {
             // Rule::unique() のようなオブジェクトの場合はスキップ
-            if (!is_string($rule)) {
+            if (! is_string($rule)) {
                 continue;
             }
-            
+
             $ruleName = ValidationRules::extractRuleName($rule);
             $parameters = ValidationRules::extractRuleParameters($rule);
-            
+
             // カスタムメッセージがある場合
-            $customKey = $field . '.' . $ruleName;
+            $customKey = $field.'.'.$ruleName;
             if (isset($customMessages[$customKey])) {
                 $messages[] = $customMessages[$customKey];
+
                 continue;
             }
-            
+
             // デフォルトメッセージテンプレートを使用
             $template = ValidationRules::getMessageTemplate($ruleName, $fieldType);
             if ($template) {
@@ -59,10 +60,10 @@ class ValidationMessageGenerator
                 $messages[] = $message;
             }
         }
-        
+
         return array_unique($messages);
     }
-    
+
     /**
      * フィールド名を人間が読みやすい形式に変換
      */
@@ -70,7 +71,7 @@ class ValidationMessageGenerator
     {
         return Str::title(str_replace(['_', '.'], ' ', $field));
     }
-    
+
     /**
      * メッセージテンプレートのプレースホルダーを置換
      */
@@ -80,9 +81,9 @@ class ValidationMessageGenerator
             ':attribute' => $humanField,
             ':Attribute' => Str::ucfirst($humanField),
         ];
-        
+
         // パラメータの置換
-        if (!empty($parameters)) {
+        if (! empty($parameters)) {
             $replacements[':min'] = $parameters[0] ?? '';
             $replacements[':max'] = $parameters[0] ?? '';
             $replacements[':size'] = $parameters[0] ?? '';
@@ -91,24 +92,24 @@ class ValidationMessageGenerator
             $replacements[':format'] = $parameters[0] ?? '';
             $replacements[':values'] = implode(', ', $parameters);
         }
-        
+
         return strtr($template, $replacements);
     }
-    
+
     /**
      * フィールドごとのサンプルメッセージを1つ生成（OpenAPIの例として使用）
      */
     public function generateSampleMessage(string $field, $rules): string
     {
         $messages = $this->generateFieldMessages($field, $rules, []);
-        
+
         // 最も一般的なエラー（required）を優先
         foreach ($messages as $message) {
             if (str_contains($message, 'required')) {
                 return $message;
             }
         }
-        
+
         // それ以外は最初のメッセージを返す
         return $messages[0] ?? "The {$field} field is invalid.";
     }

--- a/src/PrismServiceProvider.php
+++ b/src/PrismServiceProvider.php
@@ -8,8 +8,10 @@ use LaravelPrism\Analyzers\FormRequestAnalyzer;
 use LaravelPrism\Analyzers\ResourceAnalyzer;
 use LaravelPrism\Analyzers\RouteAnalyzer;
 use LaravelPrism\Console\GenerateDocsCommand;
+use LaravelPrism\Generators\ErrorResponseGenerator;
 use LaravelPrism\Generators\OpenApiGenerator;
 use LaravelPrism\Generators\SchemaGenerator;
+use LaravelPrism\Generators\ValidationMessageGenerator;
 use LaravelPrism\Support\TypeInference;
 
 class PrismServiceProvider extends ServiceProvider
@@ -28,6 +30,8 @@ class PrismServiceProvider extends ServiceProvider
         $this->app->singleton(ResourceAnalyzer::class);
         $this->app->singleton(ControllerAnalyzer::class);
         $this->app->singleton(SchemaGenerator::class);
+        $this->app->singleton(ValidationMessageGenerator::class);
+        $this->app->singleton(ErrorResponseGenerator::class);
         $this->app->singleton(OpenApiGenerator::class);
 
         // コマンドの登録

--- a/src/Support/ValidationRules.php
+++ b/src/Support/ValidationRules.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace LaravelPrism\Support;
+
+class ValidationRules
+{
+    /**
+     * バリデーションルールからエラーメッセージのテンプレートを取得
+     */
+    protected static array $messageTemplates = [
+        'required' => 'The :attribute field is required.',
+        'required_if' => 'The :attribute field is required when :other is :value.',
+        'required_unless' => 'The :attribute field is required unless :other is in :values.',
+        'required_with' => 'The :attribute field is required when :values is present.',
+        'required_without' => 'The :attribute field is required when :values is not present.',
+        'email' => 'The :attribute must be a valid email address.',
+        'unique' => 'The :attribute has already been taken.',
+        'exists' => 'The selected :attribute is invalid.',
+        'string' => 'The :attribute must be a string.',
+        'integer' => 'The :attribute must be an integer.',
+        'numeric' => 'The :attribute must be a number.',
+        'boolean' => 'The :attribute field must be true or false.',
+        'array' => 'The :attribute must be an array.',
+        'date' => 'The :attribute is not a valid date.',
+        'date_format' => 'The :attribute does not match the format :format.',
+        'min' => [
+            'numeric' => 'The :attribute must be at least :min.',
+            'string' => 'The :attribute must be at least :min characters.',
+            'array' => 'The :attribute must have at least :min items.',
+        ],
+        'max' => [
+            'numeric' => 'The :attribute may not be greater than :max.',
+            'string' => 'The :attribute may not be greater than :max characters.',
+            'array' => 'The :attribute may not have more than :max items.',
+        ],
+        'between' => [
+            'numeric' => 'The :attribute must be between :min and :max.',
+            'string' => 'The :attribute must be between :min and :max characters.',
+            'array' => 'The :attribute must have between :min and :max items.',
+        ],
+        'in' => 'The selected :attribute is invalid.',
+        'not_in' => 'The selected :attribute is invalid.',
+        'regex' => 'The :attribute format is invalid.',
+        'confirmed' => 'The :attribute confirmation does not match.',
+        'same' => 'The :attribute and :other must match.',
+        'different' => 'The :attribute and :other must be different.',
+        'size' => [
+            'numeric' => 'The :attribute must be :size.',
+            'string' => 'The :attribute must be :size characters.',
+            'array' => 'The :attribute must contain :size items.',
+        ],
+        'url' => 'The :attribute format is invalid.',
+        'ip' => 'The :attribute must be a valid IP address.',
+        'json' => 'The :attribute must be a valid JSON string.',
+        'alpha' => 'The :attribute may only contain letters.',
+        'alpha_num' => 'The :attribute may only contain letters and numbers.',
+        'alpha_dash' => 'The :attribute may only contain letters, numbers, dashes and underscores.',
+    ];
+    
+    /**
+     * ルール名を抽出（パラメータを除去）
+     */
+    public static function extractRuleName(string $rule): string
+    {
+        $parts = explode(':', $rule);
+        return $parts[0];
+    }
+    
+    /**
+     * ルールのパラメータを抽出
+     */
+    public static function extractRuleParameters(string $rule): array
+    {
+        if (!str_contains($rule, ':')) {
+            return [];
+        }
+        
+        $parts = explode(':', $rule, 2);
+        return explode(',', $parts[1]);
+    }
+    
+    /**
+     * ルールに対応するメッセージテンプレートを取得
+     */
+    public static function getMessageTemplate(string $ruleName, string $fieldType = 'string'): ?string
+    {
+        if (!isset(self::$messageTemplates[$ruleName])) {
+            return null;
+        }
+        
+        $template = self::$messageTemplates[$ruleName];
+        
+        // 型によって異なるメッセージがある場合
+        if (is_array($template)) {
+            return $template[$fieldType] ?? $template['string'] ?? null;
+        }
+        
+        return $template;
+    }
+    
+    /**
+     * フィールドタイプを推測
+     */
+    public static function inferFieldType(array $rules): string
+    {
+        foreach ($rules as $rule) {
+            $ruleName = self::extractRuleName($rule);
+            
+            if (in_array($ruleName, ['integer', 'numeric'])) {
+                return 'numeric';
+            }
+            if ($ruleName === 'array') {
+                return 'array';
+            }
+        }
+        
+        return 'string';
+    }
+}

--- a/src/Support/ValidationRules.php
+++ b/src/Support/ValidationRules.php
@@ -56,48 +56,50 @@ class ValidationRules
         'alpha_num' => 'The :attribute may only contain letters and numbers.',
         'alpha_dash' => 'The :attribute may only contain letters, numbers, dashes and underscores.',
     ];
-    
+
     /**
      * ルール名を抽出（パラメータを除去）
      */
     public static function extractRuleName(string $rule): string
     {
         $parts = explode(':', $rule);
+
         return $parts[0];
     }
-    
+
     /**
      * ルールのパラメータを抽出
      */
     public static function extractRuleParameters(string $rule): array
     {
-        if (!str_contains($rule, ':')) {
+        if (! str_contains($rule, ':')) {
             return [];
         }
-        
+
         $parts = explode(':', $rule, 2);
+
         return explode(',', $parts[1]);
     }
-    
+
     /**
      * ルールに対応するメッセージテンプレートを取得
      */
     public static function getMessageTemplate(string $ruleName, string $fieldType = 'string'): ?string
     {
-        if (!isset(self::$messageTemplates[$ruleName])) {
+        if (! isset(self::$messageTemplates[$ruleName])) {
             return null;
         }
-        
+
         $template = self::$messageTemplates[$ruleName];
-        
+
         // 型によって異なるメッセージがある場合
         if (is_array($template)) {
             return $template[$fieldType] ?? $template['string'] ?? null;
         }
-        
+
         return $template;
     }
-    
+
     /**
      * フィールドタイプを推測
      */
@@ -105,7 +107,7 @@ class ValidationRules
     {
         foreach ($rules as $rule) {
             $ruleName = self::extractRuleName($rule);
-            
+
             if (in_array($ruleName, ['integer', 'numeric'])) {
                 return 'numeric';
             }
@@ -113,7 +115,7 @@ class ValidationRules
                 return 'array';
             }
         }
-        
+
         return 'string';
     }
 }

--- a/tests/Feature/ErrorResponseIntegrationTest.php
+++ b/tests/Feature/ErrorResponseIntegrationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace LaravelPrism\Tests\Feature;
+
+use LaravelPrism\Tests\TestCase;
+use Illuminate\Support\Facades\Route;
+
+class ErrorResponseIntegrationTest extends TestCase
+{
+    /** @test */
+    public function it_includes_error_responses_in_generated_openapi_spec()
+    {
+        // テスト用のルートを作成
+        Route::post('api/users', 'LaravelPrism\Tests\Fixtures\Controllers\UserController@store')->name('users.store');
+        Route::get('api/users/{user}', 'LaravelPrism\Tests\Fixtures\Controllers\UserController@show')
+            ->middleware('auth:sanctum')
+            ->name('users.show');
+        
+        // OpenAPI仕様を生成
+        $this->artisan('prism:generate')->assertExitCode(0);
+        
+        // 生成されたファイルを読み込む
+        $openapi = json_decode(file_get_contents(storage_path('app/prism/openapi.json')), true);
+        
+        // POST /api/users のエラーレスポンスを確認
+        $postResponses = $openapi['paths']['/api/users']['post']['responses'];
+        
+        // デバッグ出力
+        if (!isset($postResponses['422'])) {
+            $this->fail('422 response not found. Available responses: ' . implode(', ', array_keys($postResponses)));
+        }
+        $this->assertArrayHasKey('422', $postResponses);
+        $this->assertArrayHasKey('500', $postResponses);
+        
+        // 422エラーの詳細を確認
+        $validationError = $postResponses['422'];
+        $this->assertEquals('Validation Error', $validationError['description']);
+        $this->assertArrayHasKey('content', $validationError);
+        $this->assertArrayHasKey('application/json', $validationError['content']);
+        $this->assertArrayHasKey('schema', $validationError['content']['application/json']);
+        
+        $errorSchema = $validationError['content']['application/json']['schema'];
+        $this->assertArrayHasKey('properties', $errorSchema);
+        $this->assertArrayHasKey('message', $errorSchema['properties']);
+        $this->assertArrayHasKey('errors', $errorSchema['properties']);
+        
+        // GET /api/users/{user} のエラーレスポンスを確認（認証必須）
+        $getResponses = $openapi['paths']['/api/users/{user}']['get']['responses'];
+        $this->assertArrayHasKey('401', $getResponses);
+        $this->assertArrayHasKey('403', $getResponses);
+        $this->assertArrayHasKey('404', $getResponses);
+        $this->assertArrayHasKey('500', $getResponses);
+    }
+}

--- a/tests/Feature/ErrorResponseIntegrationTest.php
+++ b/tests/Feature/ErrorResponseIntegrationTest.php
@@ -2,8 +2,8 @@
 
 namespace LaravelPrism\Tests\Feature;
 
-use LaravelPrism\Tests\TestCase;
 use Illuminate\Support\Facades\Route;
+use LaravelPrism\Tests\TestCase;
 
 class ErrorResponseIntegrationTest extends TestCase
 {
@@ -15,35 +15,35 @@ class ErrorResponseIntegrationTest extends TestCase
         Route::get('api/users/{user}', 'LaravelPrism\Tests\Fixtures\Controllers\UserController@show')
             ->middleware('auth:sanctum')
             ->name('users.show');
-        
+
         // OpenAPI仕様を生成
         $this->artisan('prism:generate')->assertExitCode(0);
-        
+
         // 生成されたファイルを読み込む
         $openapi = json_decode(file_get_contents(storage_path('app/prism/openapi.json')), true);
-        
+
         // POST /api/users のエラーレスポンスを確認
         $postResponses = $openapi['paths']['/api/users']['post']['responses'];
-        
+
         // デバッグ出力
-        if (!isset($postResponses['422'])) {
-            $this->fail('422 response not found. Available responses: ' . implode(', ', array_keys($postResponses)));
+        if (! isset($postResponses['422'])) {
+            $this->fail('422 response not found. Available responses: '.implode(', ', array_keys($postResponses)));
         }
         $this->assertArrayHasKey('422', $postResponses);
         $this->assertArrayHasKey('500', $postResponses);
-        
+
         // 422エラーの詳細を確認
         $validationError = $postResponses['422'];
         $this->assertEquals('Validation Error', $validationError['description']);
         $this->assertArrayHasKey('content', $validationError);
         $this->assertArrayHasKey('application/json', $validationError['content']);
         $this->assertArrayHasKey('schema', $validationError['content']['application/json']);
-        
+
         $errorSchema = $validationError['content']['application/json']['schema'];
         $this->assertArrayHasKey('properties', $errorSchema);
         $this->assertArrayHasKey('message', $errorSchema['properties']);
         $this->assertArrayHasKey('errors', $errorSchema['properties']);
-        
+
         // GET /api/users/{user} のエラーレスポンスを確認（認証必須）
         $getResponses = $openapi['paths']['/api/users/{user}']['get']['responses'];
         $this->assertArrayHasKey('401', $getResponses);

--- a/tests/Fixtures/Controllers/UserController.php
+++ b/tests/Fixtures/Controllers/UserController.php
@@ -2,13 +2,22 @@
 
 namespace LaravelPrism\Tests\Fixtures\Controllers;
 
+use LaravelPrism\Tests\Fixtures\StoreUserRequest;
+use LaravelPrism\Tests\Fixtures\UserResource;
+
 class UserController
 {
     public function index() {}
 
-    public function store() {}
+    public function store(StoreUserRequest $request) 
+    {
+        return new UserResource([]);
+    }
 
-    public function show($user) {}
+    public function show($user) 
+    {
+        return new UserResource([]);
+    }
 
     public function update($post, $comment = null) {}
 }

--- a/tests/Fixtures/Controllers/UserController.php
+++ b/tests/Fixtures/Controllers/UserController.php
@@ -9,12 +9,12 @@ class UserController
 {
     public function index() {}
 
-    public function store(StoreUserRequest $request) 
+    public function store(StoreUserRequest $request)
     {
         return new UserResource([]);
     }
 
-    public function show($user) 
+    public function show($user)
     {
         return new UserResource([]);
     }

--- a/tests/Unit/Generators/ErrorResponseGeneratorTest.php
+++ b/tests/Unit/Generators/ErrorResponseGeneratorTest.php
@@ -9,24 +9,24 @@ use LaravelPrism\Tests\TestCase;
 class ErrorResponseGeneratorTest extends TestCase
 {
     private ErrorResponseGenerator $generator;
-    
+
     protected function setUp(): void
     {
         parent::setUp();
-        $messageGenerator = new ValidationMessageGenerator();
+        $messageGenerator = new ValidationMessageGenerator;
         $this->generator = new ErrorResponseGenerator($messageGenerator);
     }
-    
+
     /** @test */
     public function it_generates_401_unauthorized_response()
     {
         $responses = $this->generator->generateErrorResponses();
-        
+
         $this->assertArrayHasKey('401', $responses);
         $this->assertEquals('Unauthorized', $responses['401']['description']);
         $this->assertArrayHasKey('content', $responses['401']);
     }
-    
+
     /** @test */
     public function it_generates_422_validation_error_response_with_form_request()
     {
@@ -36,20 +36,20 @@ class ErrorResponseGeneratorTest extends TestCase
                 'password' => 'required|min:8',
             ],
         ];
-        
+
         $responses = $this->generator->generateErrorResponses($formRequestData);
-        
+
         $this->assertArrayHasKey('422', $responses);
         $this->assertEquals('Validation Error', $responses['422']['description']);
-        
+
         $schema = $responses['422']['content']['application/json']['schema'];
         $this->assertArrayHasKey('errors', $schema['properties']);
-        
+
         $errorProperties = $schema['properties']['errors']['properties'];
         $this->assertArrayHasKey('email', $errorProperties);
         $this->assertArrayHasKey('password', $errorProperties);
     }
-    
+
     /** @test */
     public function it_includes_error_examples_in_422_response()
     {
@@ -58,37 +58,37 @@ class ErrorResponseGeneratorTest extends TestCase
                 'email' => 'required|email',
             ],
         ];
-        
+
         $responses = $this->generator->generateErrorResponses($formRequestData);
         $example = $responses['422']['content']['application/json']['schema']['properties']['errors']['example'];
-        
+
         $this->assertArrayHasKey('email', $example);
         $this->assertIsArray($example['email']);
         $this->assertEquals('The Email field is required.', $example['email'][0]);
     }
-    
+
     /** @test */
     public function it_generates_default_error_responses_for_authenticated_routes()
     {
         $responses = $this->generator->getDefaultErrorResponses('GET', true, false);
-        
+
         $this->assertArrayHasKey('401', $responses);
         $this->assertArrayHasKey('403', $responses);
         $this->assertArrayHasKey('404', $responses);
         $this->assertArrayHasKey('500', $responses);
     }
-    
+
     /** @test */
     public function it_excludes_auth_errors_for_public_routes()
     {
         $responses = $this->generator->getDefaultErrorResponses('GET', false, false);
-        
+
         $this->assertArrayNotHasKey('401', $responses);
         $this->assertArrayNotHasKey('403', $responses);
         $this->assertArrayHasKey('404', $responses);
         $this->assertArrayHasKey('500', $responses);
     }
-    
+
     /** @test */
     public function it_handles_custom_validation_messages()
     {
@@ -100,9 +100,9 @@ class ErrorResponseGeneratorTest extends TestCase
                 'email.required' => 'We need your email address!',
             ],
         ];
-        
+
         $responses = $this->generator->generateErrorResponses($formRequestData);
-        
+
         // カスタムメッセージが使用されることを確認
         // （実際の実装では ValidationMessageGenerator で処理される）
         $this->assertArrayHasKey('422', $responses);

--- a/tests/Unit/Generators/ErrorResponseGeneratorTest.php
+++ b/tests/Unit/Generators/ErrorResponseGeneratorTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace LaravelPrism\Tests\Unit\Generators;
+
+use LaravelPrism\Generators\ErrorResponseGenerator;
+use LaravelPrism\Generators\ValidationMessageGenerator;
+use LaravelPrism\Tests\TestCase;
+
+class ErrorResponseGeneratorTest extends TestCase
+{
+    private ErrorResponseGenerator $generator;
+    
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $messageGenerator = new ValidationMessageGenerator();
+        $this->generator = new ErrorResponseGenerator($messageGenerator);
+    }
+    
+    /** @test */
+    public function it_generates_401_unauthorized_response()
+    {
+        $responses = $this->generator->generateErrorResponses();
+        
+        $this->assertArrayHasKey('401', $responses);
+        $this->assertEquals('Unauthorized', $responses['401']['description']);
+        $this->assertArrayHasKey('content', $responses['401']);
+    }
+    
+    /** @test */
+    public function it_generates_422_validation_error_response_with_form_request()
+    {
+        $formRequestData = [
+            'rules' => [
+                'email' => 'required|email',
+                'password' => 'required|min:8',
+            ],
+        ];
+        
+        $responses = $this->generator->generateErrorResponses($formRequestData);
+        
+        $this->assertArrayHasKey('422', $responses);
+        $this->assertEquals('Validation Error', $responses['422']['description']);
+        
+        $schema = $responses['422']['content']['application/json']['schema'];
+        $this->assertArrayHasKey('errors', $schema['properties']);
+        
+        $errorProperties = $schema['properties']['errors']['properties'];
+        $this->assertArrayHasKey('email', $errorProperties);
+        $this->assertArrayHasKey('password', $errorProperties);
+    }
+    
+    /** @test */
+    public function it_includes_error_examples_in_422_response()
+    {
+        $formRequestData = [
+            'rules' => [
+                'email' => 'required|email',
+            ],
+        ];
+        
+        $responses = $this->generator->generateErrorResponses($formRequestData);
+        $example = $responses['422']['content']['application/json']['schema']['properties']['errors']['example'];
+        
+        $this->assertArrayHasKey('email', $example);
+        $this->assertIsArray($example['email']);
+        $this->assertEquals('The Email field is required.', $example['email'][0]);
+    }
+    
+    /** @test */
+    public function it_generates_default_error_responses_for_authenticated_routes()
+    {
+        $responses = $this->generator->getDefaultErrorResponses('GET', true, false);
+        
+        $this->assertArrayHasKey('401', $responses);
+        $this->assertArrayHasKey('403', $responses);
+        $this->assertArrayHasKey('404', $responses);
+        $this->assertArrayHasKey('500', $responses);
+    }
+    
+    /** @test */
+    public function it_excludes_auth_errors_for_public_routes()
+    {
+        $responses = $this->generator->getDefaultErrorResponses('GET', false, false);
+        
+        $this->assertArrayNotHasKey('401', $responses);
+        $this->assertArrayNotHasKey('403', $responses);
+        $this->assertArrayHasKey('404', $responses);
+        $this->assertArrayHasKey('500', $responses);
+    }
+    
+    /** @test */
+    public function it_handles_custom_validation_messages()
+    {
+        $formRequestData = [
+            'rules' => [
+                'email' => 'required|email',
+            ],
+            'messages' => [
+                'email.required' => 'We need your email address!',
+            ],
+        ];
+        
+        $responses = $this->generator->generateErrorResponses($formRequestData);
+        
+        // カスタムメッセージが使用されることを確認
+        // （実際の実装では ValidationMessageGenerator で処理される）
+        $this->assertArrayHasKey('422', $responses);
+    }
+}

--- a/tests/Unit/Generators/ValidationMessageGeneratorTest.php
+++ b/tests/Unit/Generators/ValidationMessageGeneratorTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace LaravelPrism\Tests\Unit\Generators;
+
+use LaravelPrism\Generators\ValidationMessageGenerator;
+use LaravelPrism\Tests\TestCase;
+
+class ValidationMessageGeneratorTest extends TestCase
+{
+    private ValidationMessageGenerator $generator;
+    
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->generator = new ValidationMessageGenerator();
+    }
+    
+    /** @test */
+    public function it_generates_messages_for_required_rule()
+    {
+        $rules = ['name' => 'required|string'];
+        $messages = $this->generator->generateMessages($rules);
+        
+        $this->assertContains('The Name field is required.', $messages['name']);
+    }
+    
+    /** @test */
+    public function it_generates_messages_for_email_rule()
+    {
+        $rules = ['email' => 'required|email'];
+        $messages = $this->generator->generateMessages($rules);
+        
+        $this->assertContains('The Email must be a valid email address.', $messages['email']);
+    }
+    
+    /** @test */
+    public function it_generates_messages_for_min_rule_with_different_types()
+    {
+        // 文字列の場合
+        $rules = ['name' => 'string|min:3'];
+        $messages = $this->generator->generateMessages($rules);
+        $this->assertContains('The Name must be at least 3 characters.', $messages['name']);
+        
+        // 数値の場合
+        $rules = ['age' => 'integer|min:18'];
+        $messages = $this->generator->generateMessages($rules);
+        $this->assertContains('The Age must be at least 18.', $messages['age']);
+        
+        // 配列の場合
+        $rules = ['tags' => 'array|min:2'];
+        $messages = $this->generator->generateMessages($rules);
+        $this->assertContains('The Tags must have at least 2 items.', $messages['tags']);
+    }
+    
+    /** @test */
+    public function it_uses_custom_messages_when_provided()
+    {
+        $rules = ['email' => 'required|email'];
+        $customMessages = ['email.required' => 'メールアドレスは必須です。'];
+        
+        $messages = $this->generator->generateMessages($rules, $customMessages);
+        
+        $this->assertContains('メールアドレスは必須です。', $messages['email']);
+    }
+    
+    /** @test */
+    public function it_humanizes_field_names()
+    {
+        $rules = [
+            'first_name' => 'required',
+            'user.email' => 'required',
+        ];
+        
+        $messages = $this->generator->generateMessages($rules);
+        
+        $this->assertContains('The First Name field is required.', $messages['first_name']);
+        $this->assertContains('The User Email field is required.', $messages['user.email']);
+    }
+    
+    /** @test */
+    public function it_generates_sample_message()
+    {
+        $sampleMessage = $this->generator->generateSampleMessage('email', 'required|email');
+        
+        $this->assertEquals('The Email field is required.', $sampleMessage);
+    }
+}

--- a/tests/Unit/Generators/ValidationMessageGeneratorTest.php
+++ b/tests/Unit/Generators/ValidationMessageGeneratorTest.php
@@ -8,31 +8,31 @@ use LaravelPrism\Tests\TestCase;
 class ValidationMessageGeneratorTest extends TestCase
 {
     private ValidationMessageGenerator $generator;
-    
+
     protected function setUp(): void
     {
         parent::setUp();
-        $this->generator = new ValidationMessageGenerator();
+        $this->generator = new ValidationMessageGenerator;
     }
-    
+
     /** @test */
     public function it_generates_messages_for_required_rule()
     {
         $rules = ['name' => 'required|string'];
         $messages = $this->generator->generateMessages($rules);
-        
+
         $this->assertContains('The Name field is required.', $messages['name']);
     }
-    
+
     /** @test */
     public function it_generates_messages_for_email_rule()
     {
         $rules = ['email' => 'required|email'];
         $messages = $this->generator->generateMessages($rules);
-        
+
         $this->assertContains('The Email must be a valid email address.', $messages['email']);
     }
-    
+
     /** @test */
     public function it_generates_messages_for_min_rule_with_different_types()
     {
@@ -40,29 +40,29 @@ class ValidationMessageGeneratorTest extends TestCase
         $rules = ['name' => 'string|min:3'];
         $messages = $this->generator->generateMessages($rules);
         $this->assertContains('The Name must be at least 3 characters.', $messages['name']);
-        
+
         // 数値の場合
         $rules = ['age' => 'integer|min:18'];
         $messages = $this->generator->generateMessages($rules);
         $this->assertContains('The Age must be at least 18.', $messages['age']);
-        
+
         // 配列の場合
         $rules = ['tags' => 'array|min:2'];
         $messages = $this->generator->generateMessages($rules);
         $this->assertContains('The Tags must have at least 2 items.', $messages['tags']);
     }
-    
+
     /** @test */
     public function it_uses_custom_messages_when_provided()
     {
         $rules = ['email' => 'required|email'];
         $customMessages = ['email.required' => 'メールアドレスは必須です。'];
-        
+
         $messages = $this->generator->generateMessages($rules, $customMessages);
-        
+
         $this->assertContains('メールアドレスは必須です。', $messages['email']);
     }
-    
+
     /** @test */
     public function it_humanizes_field_names()
     {
@@ -70,18 +70,18 @@ class ValidationMessageGeneratorTest extends TestCase
             'first_name' => 'required',
             'user.email' => 'required',
         ];
-        
+
         $messages = $this->generator->generateMessages($rules);
-        
+
         $this->assertContains('The First Name field is required.', $messages['first_name']);
         $this->assertContains('The User Email field is required.', $messages['user.email']);
     }
-    
+
     /** @test */
     public function it_generates_sample_message()
     {
         $sampleMessage = $this->generator->generateSampleMessage('email', 'required|email');
-        
+
         $this->assertEquals('The Email field is required.', $sampleMessage);
     }
 }


### PR DESCRIPTION
# 概要

FormRequestのバリデーションルールから422エラーレスポンスを自動生成し、その他の一般的なHTTPエラー（401, 403, 404, 500）も含めてOpenAPI仕様に追加する機能を実装しました。

## 変更内容

API利用者にとって重要なエラーレスポンスの情報を自動的にドキュメント化できるようになりました。

- バリデーションルールからメッセージテンプレートを管理するValidationRulesサポートクラスを追加
- FormRequestのルールからエラーメッセージを生成するValidationMessageGeneratorを実装
- 各種HTTPエラーレスポンスのOpenAPIスキーマを生成するErrorResponseGeneratorを実装
- FormRequestAnalyzerにルール・属性・メッセージを同時に取得できるanalyzeWithDetailsメソッドを追加
- OpenApiGeneratorにエラーレスポンス生成機能を統合
- 全ての新機能に対する単体テストと統合テストを追加

## 関連情報

- https://github.com/wadakatu/laravel-prism にて、エラーレスポンスの自動文書化機能の要望に対応
- Laravelの標準的なエラー構造（message と errors フィールド）に準拠
- 認証が必要なルートでは401/403エラーも自動的に含まれる