### PR TITLE
New Feature: FormRequestの条件分岐を含む動的ルール解析機能

### DIFF
--- a/src/Analyzers/AST/Visitors/AnonymousClassFindingVisitor.php
+++ b/src/Analyzers/AST/Visitors/AnonymousClassFindingVisitor.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LaravelPrism\Analyzers\AST\Visitors;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+class AnonymousClassFindingVisitor extends NodeVisitorAbstract
+{
+    private ?Node\Stmt\Class_ $classNode = null;
+
+    public function enterNode(Node $node)
+    {
+        // Look for anonymous class nodes in various contexts
+        if ($node instanceof Node\Expr\New_ &&
+            $node->class instanceof Node\Stmt\Class_) {
+            $this->classNode = $node->class;
+
+            return NodeTraverser::STOP_TRAVERSAL;
+        }
+
+        return null;
+    }
+
+    public function getClassNode(): ?Node\Stmt\Class_
+    {
+        return $this->classNode;
+    }
+}

--- a/src/Analyzers/AST/Visitors/ConditionalRulesExtractorVisitor.php
+++ b/src/Analyzers/AST/Visitors/ConditionalRulesExtractorVisitor.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace LaravelPrism\Analyzers\AST\Visitors;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\PrettyPrinter;
+
+class ConditionalRulesExtractorVisitor extends NodeVisitorAbstract
+{
+    private array $ruleSets = [];
+
+    private array $currentPath = [];
+
+    private PrettyPrinter\Standard $printer;
+
+    private bool $foundReturn = false;
+
+    public function __construct(PrettyPrinter\Standard $printer)
+    {
+        $this->printer = $printer;
+    }
+
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof Node\Stmt\If_) {
+            $this->processIfStatement($node);
+
+            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+        }
+
+        if ($node instanceof Node\Stmt\Return_ && $node->expr instanceof Node\Expr\Array_) {
+            $this->addRuleSet($node->expr);
+            $this->foundReturn = true;
+        }
+
+        return null;
+    }
+
+    private function processIfStatement(Node\Stmt\If_ $ifNode): void
+    {
+        // Analyze condition
+        $condition = $this->analyzeCondition($ifNode->cond);
+
+        // Process if block
+        $this->currentPath[] = $condition;
+        $this->traverseStatements($ifNode->stmts);
+        array_pop($this->currentPath);
+
+        // Process elseif blocks
+        foreach ($ifNode->elseifs as $elseif) {
+            $elseifCondition = $this->analyzeCondition($elseif->cond);
+            $this->currentPath[] = $elseifCondition;
+            $this->traverseStatements($elseif->stmts);
+            array_pop($this->currentPath);
+        }
+
+        // Process else block
+        if ($ifNode->else !== null) {
+            $negatedConditions = [];
+
+            // Negate the main if condition
+            $negatedConditions[] = $this->negateCondition($condition);
+
+            // Also negate all elseif conditions
+            foreach ($ifNode->elseifs as $elseif) {
+                $elseifCondition = $this->analyzeCondition($elseif->cond);
+                $negatedConditions[] = $this->negateCondition($elseifCondition);
+            }
+
+            // For else block, we need to ensure none of the previous conditions matched
+            $this->currentPath[] = [
+                'type' => 'else',
+                'negated_conditions' => $negatedConditions,
+                'expression' => 'else',
+            ];
+
+            $this->traverseStatements($ifNode->else->stmts);
+            array_pop($this->currentPath);
+        }
+    }
+
+    private function analyzeCondition(Node\Expr $condition): array
+    {
+        // $this->isMethod('POST') pattern
+        if ($condition instanceof Node\Expr\MethodCall &&
+            $condition->var instanceof Node\Expr\Variable &&
+            $condition->var->name === 'this' &&
+            $condition->name instanceof Node\Identifier &&
+            $condition->name->toString() === 'isMethod') {
+
+            $method = $this->extractStringArgument($condition->args[0] ?? null);
+
+            return [
+                'type' => 'http_method',
+                'method' => $method,
+                'expression' => $this->printer->prettyPrintExpr($condition),
+            ];
+        }
+
+        // $this->user()->isAdmin() pattern
+        if ($condition instanceof Node\Expr\MethodCall &&
+            $condition->var instanceof Node\Expr\MethodCall &&
+            $condition->var->var instanceof Node\Expr\Variable &&
+            $condition->var->var->name === 'this') {
+
+            return [
+                'type' => 'user_method',
+                'chain' => $this->printer->prettyPrintExpr($condition),
+                'expression' => $this->printer->prettyPrintExpr($condition),
+            ];
+        }
+
+        // request()->isMethod('POST') pattern
+        if ($condition instanceof Node\Expr\MethodCall &&
+            $condition->var instanceof Node\Expr\FuncCall &&
+            $condition->var->name instanceof Node\Name &&
+            $condition->var->name->toString() === 'request' &&
+            $condition->name instanceof Node\Identifier &&
+            $condition->name->toString() === 'isMethod') {
+
+            $method = $this->extractStringArgument($condition->args[0] ?? null);
+
+            return [
+                'type' => 'http_method',
+                'method' => $method,
+                'expression' => $this->printer->prettyPrintExpr($condition),
+            ];
+        }
+
+        // Other conditions
+        return [
+            'type' => 'custom',
+            'expression' => $this->printer->prettyPrintExpr($condition),
+        ];
+    }
+
+    private function extractStringArgument(?Node\Arg $arg): ?string
+    {
+        if (! $arg || ! $arg->value instanceof Node\Scalar\String_) {
+            return null;
+        }
+
+        return $arg->value->value;
+    }
+
+    private function negateCondition(array $condition): array
+    {
+        $negated = $condition;
+        $negated['negated'] = true;
+
+        if ($condition['type'] === 'http_method') {
+            $negated['description'] = 'NOT '.($condition['method'] ?? 'unknown');
+        }
+
+        return $negated;
+    }
+
+    private function traverseStatements(array $statements): void
+    {
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($this);
+        $traverser->traverse($statements);
+    }
+
+    private function addRuleSet(Node\Expr\Array_ $rules): void
+    {
+        // Only add rule set if we're inside a conditional path or if no conditions exist
+        $this->ruleSets[] = [
+            'conditions' => $this->currentPath,
+            'rules' => $this->extractArrayRules($rules),
+            'probability' => $this->calculateProbability(),
+        ];
+    }
+
+    private function extractArrayRules(Node\Expr\Array_ $array): array
+    {
+        $rules = [];
+
+        foreach ($array->items as $item) {
+            if (! isset($item->key)) {
+                continue;
+            }
+
+            $key = $this->evaluateKey($item->key);
+            $value = $this->evaluateValue($item->value);
+
+            if ($key !== null && $value !== null) {
+                $rules[$key] = $value;
+            }
+        }
+
+        return $rules;
+    }
+
+    private function evaluateKey(Node $expr): ?string
+    {
+        if ($expr instanceof Node\Scalar\String_) {
+            return $expr->value;
+        }
+
+        if ($expr instanceof Node\Scalar\LNumber) {
+            return (string) $expr->value;
+        }
+
+        // Handle other expressions
+        if ($expr instanceof Node\Expr) {
+            return $this->printer->prettyPrintExpr($expr);
+        }
+
+        return null;
+    }
+
+    private function evaluateValue(Node $expr)
+    {
+        if ($expr instanceof Node\Scalar\String_) {
+            return $expr->value;
+        }
+
+        if ($expr instanceof Node\Expr\Array_) {
+            $result = [];
+            foreach ($expr->items as $item) {
+                $value = $this->evaluateValue($item->value);
+                if ($value !== null) {
+                    $result[] = $value;
+                }
+            }
+
+            return $result;
+        }
+
+        // Handle concatenation (e.g., 'required|string')
+        if ($expr instanceof Node\Expr\BinaryOp\Concat) {
+            $left = $this->evaluateValue($expr->left);
+            $right = $this->evaluateValue($expr->right);
+
+            if (is_string($left) && is_string($right)) {
+                return $left.$right;
+            }
+        }
+
+        // Handle static calls (e.g., Rule::unique())
+        if ($expr instanceof Node\Expr\StaticCall) {
+            return $this->printer->prettyPrintExpr($expr);
+        }
+
+        // Handle other expressions
+        if ($expr instanceof Node\Expr) {
+            return $this->printer->prettyPrintExpr($expr);
+        }
+
+        return '';
+    }
+
+    private function calculateProbability(): float
+    {
+        // Simple probability calculation based on condition depth
+        return 1.0 / pow(2, count($this->currentPath));
+    }
+
+    public function getRuleSets(): array
+    {
+        // If no conditional rules were found, return empty structure
+        if (empty($this->ruleSets)) {
+            return [
+                'rules_sets' => [],
+                'merged_rules' => [],
+            ];
+        }
+
+        return [
+            'rules_sets' => $this->ruleSets,
+            'merged_rules' => $this->mergeAllRules(),
+        ];
+    }
+
+    private function mergeAllRules(): array
+    {
+        $merged = [];
+
+        foreach ($this->ruleSets as $set) {
+            foreach ($set['rules'] as $field => $rules) {
+                if (! isset($merged[$field])) {
+                    $merged[$field] = [];
+                }
+
+                if (is_string($rules)) {
+                    $rules = explode('|', $rules);
+                }
+
+                if (is_array($rules)) {
+                    $merged[$field] = array_unique(array_merge($merged[$field], $rules));
+                }
+            }
+        }
+
+        return $merged;
+    }
+
+    /**
+     * Check if conditional rules were found
+     */
+    public function hasConditionalRules(): bool
+    {
+        return $this->foundReturn && ! empty($this->currentPath);
+    }
+}

--- a/src/Generators/SchemaGenerator.php
+++ b/src/Generators/SchemaGenerator.php
@@ -55,4 +55,116 @@ class SchemaGenerator
             'properties' => $properties,
         ];
     }
+
+    /**
+     * Generate schema from conditional parameters
+     */
+    public function generateFromConditionalParameters(array $parameters): array
+    {
+        // Group parameters by HTTP method
+        $groupedByMethod = $this->groupParametersByHttpMethod($parameters);
+
+        if (count($groupedByMethod) <= 1) {
+            // No conditions or single condition - generate regular schema
+            return $this->generateFromParameters($parameters);
+        }
+
+        // Generate oneOf schema
+        $schemas = [];
+
+        foreach ($groupedByMethod as $method => $params) {
+            $schema = $this->generateFromParameters($params);
+            $schema['title'] = "{$method} Request";
+            $schemas[] = $schema;
+        }
+
+        return [
+            'oneOf' => $schemas,
+        ];
+    }
+
+    /**
+     * Group parameters by HTTP method from conditional rules
+     */
+    private function groupParametersByHttpMethod(array $parameters): array
+    {
+        $grouped = [];
+        $hasConditions = false;
+
+        foreach ($parameters as $param) {
+            if (! isset($param['conditional_rules']) || empty($param['conditional_rules'])) {
+                continue;
+            }
+
+            $hasConditions = true;
+
+            foreach ($param['conditional_rules'] as $condRule) {
+                $method = $this->extractHttpMethodFromConditions($condRule['conditions']);
+
+                if (! $method) {
+                    $method = 'DEFAULT';
+                }
+
+                if (! isset($grouped[$method])) {
+                    $grouped[$method] = [];
+                }
+
+                // Check if this parameter already exists for this method
+                $exists = false;
+                foreach ($grouped[$method] as $existingParam) {
+                    if ($existingParam['name'] === $param['name']) {
+                        $exists = true;
+                        break;
+                    }
+                }
+
+                if (! $exists) {
+                    $grouped[$method][] = [
+                        'name' => $param['name'],
+                        'type' => $param['type'],
+                        'required' => $this->isRequired($condRule['rules']),
+                        'description' => $param['description'],
+                        'example' => $param['example'] ?? null,
+                        'validation' => $condRule['rules'],
+                    ];
+                }
+            }
+        }
+
+        // If no conditions were found, return parameters as single group
+        if (! $hasConditions) {
+            return ['all' => $parameters];
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * Extract HTTP method from conditions array
+     */
+    private function extractHttpMethodFromConditions(array $conditions): ?string
+    {
+        foreach ($conditions as $condition) {
+            if (isset($condition['type']) && $condition['type'] === 'http_method' && isset($condition['method'])) {
+                return $condition['method'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if rules include required validation
+     */
+    private function isRequired(array $rules): bool
+    {
+        foreach ($rules as $rule) {
+            $ruleName = is_string($rule) ? explode(':', $rule)[0] : '';
+            if (in_array($ruleName, ['required', 'required_if', 'required_unless', 'required_with', 'required_without'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/tests/Unit/Analyzers/AST/ConditionalRulesTest.php
+++ b/tests/Unit/Analyzers/AST/ConditionalRulesTest.php
@@ -1,0 +1,401 @@
+<?php
+
+namespace Tests\Unit\Analyzers\AST;
+
+use Illuminate\Foundation\Http\FormRequest;
+use LaravelPrism\Analyzers\FormRequestAnalyzer;
+use LaravelPrism\Support\TypeInference;
+use LaravelPrism\Tests\TestCase;
+
+class ConditionalRulesTest extends TestCase
+{
+    private FormRequestAnalyzer $analyzer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->analyzer = new FormRequestAnalyzer(new TypeInference);
+    }
+
+    /** @test */
+    public function it_analyzes_http_method_conditions()
+    {
+        $requestClass = new class extends FormRequest
+        {
+            public function rules(): array
+            {
+                if ($this->isMethod('POST')) {
+                    return [
+                        'email' => 'required|email|unique:users',
+                        'password' => 'required|min:8|confirmed',
+                    ];
+                }
+
+                return [
+                    'email' => 'sometimes|email',
+                    'password' => 'sometimes|min:8',
+                ];
+            }
+        };
+
+        $result = $this->analyzer->analyzeWithConditionalRules(get_class($requestClass));
+
+        // Check that conditional rules were detected
+        $this->assertArrayHasKey('conditional_rules', $result);
+        $this->assertArrayHasKey('rules_sets', $result['conditional_rules']);
+        $this->assertArrayHasKey('merged_rules', $result['conditional_rules']);
+
+        // Check rule sets
+        $ruleSets = $result['conditional_rules']['rules_sets'];
+        $this->assertCount(2, $ruleSets);
+
+        // POST rules
+        $postRules = $ruleSets[0];
+        $this->assertNotEmpty($postRules['conditions']);
+        $this->assertEquals('http_method', $postRules['conditions'][0]['type']);
+        $this->assertEquals('POST', $postRules['conditions'][0]['method']);
+        $this->assertArrayHasKey('email', $postRules['rules']);
+        $this->assertArrayHasKey('password', $postRules['rules']);
+        $this->assertStringContainsString('required', $postRules['rules']['email']);
+        $this->assertStringContainsString('unique:users', $postRules['rules']['email']);
+
+        // Non-POST rules (else block has empty conditions as it's the default)
+        $otherRules = $ruleSets[1];
+        $this->assertEmpty($otherRules['conditions']);
+        $this->assertArrayHasKey('email', $otherRules['rules']);
+        $this->assertStringContainsString('sometimes', $otherRules['rules']['email']);
+
+        // Check merged rules
+        $mergedRules = $result['conditional_rules']['merged_rules'];
+        $this->assertArrayHasKey('email', $mergedRules);
+        $this->assertArrayHasKey('password', $mergedRules);
+        $this->assertContains('required', $mergedRules['email']);
+        $this->assertContains('sometimes', $mergedRules['email']);
+        $this->assertContains('unique:users', $mergedRules['email']);
+    }
+
+    /** @test */
+    public function it_analyzes_nested_conditions()
+    {
+        $requestClass = new class extends FormRequest
+        {
+            public function rules(): array
+            {
+                if ($this->isMethod('POST')) {
+                    if ($this->user()->isAdmin()) {
+                        return [
+                            'title' => 'required|string',
+                            'published_at' => 'required|date',
+                        ];
+                    }
+
+                    return [
+                        'title' => 'required|string',
+                    ];
+                }
+
+                return [
+                    'title' => 'sometimes|string',
+                ];
+            }
+        };
+
+        $result = $this->analyzer->analyzeWithConditionalRules(get_class($requestClass));
+
+        $ruleSets = $result['conditional_rules']['rules_sets'];
+        $this->assertCount(3, $ruleSets);
+
+        // Find the admin rule set (has published_at field)
+        $adminRuleSet = null;
+        foreach ($ruleSets as $ruleSet) {
+            if (isset($ruleSet['rules']['published_at'])) {
+                $adminRuleSet = $ruleSet;
+                break;
+            }
+        }
+
+        $this->assertNotNull($adminRuleSet);
+        $this->assertCount(2, $adminRuleSet['conditions']);
+        $this->assertEquals('http_method', $adminRuleSet['conditions'][0]['type']);
+        $this->assertEquals('user_method', $adminRuleSet['conditions'][1]['type']);
+    }
+
+    /** @test */
+    public function it_handles_early_returns()
+    {
+        $requestClass = new class extends FormRequest
+        {
+            public function rules(): array
+            {
+                if ($this->isMethod('DELETE')) {
+                    return [];
+                }
+
+                if ($this->isMethod('POST')) {
+                    return [
+                        'name' => 'required|string',
+                        'email' => 'required|email',
+                    ];
+                }
+
+                return [
+                    'name' => 'sometimes|string',
+                    'email' => 'sometimes|email',
+                ];
+            }
+        };
+
+        $result = $this->analyzer->analyzeWithConditionalRules(get_class($requestClass));
+
+        $ruleSets = $result['conditional_rules']['rules_sets'];
+        $this->assertCount(3, $ruleSets);
+
+        // Check DELETE returns empty rules
+        $deleteRules = null;
+        foreach ($ruleSets as $ruleSet) {
+            if (! empty($ruleSet['conditions']) &&
+                $ruleSet['conditions'][0]['type'] === 'http_method' &&
+                $ruleSet['conditions'][0]['method'] === 'DELETE') {
+                $deleteRules = $ruleSet;
+                break;
+            }
+        }
+
+        $this->assertNotNull($deleteRules);
+        $this->assertEmpty($deleteRules['rules']);
+    }
+
+    /** @test */
+    public function it_handles_elseif_conditions()
+    {
+        $requestClass = new class extends FormRequest
+        {
+            public function rules(): array
+            {
+                if ($this->isMethod('POST')) {
+                    return ['status' => 'required|in:draft,published'];
+                } elseif ($this->isMethod('PUT')) {
+                    return ['status' => 'required|in:draft,published,archived'];
+                } else {
+                    return ['status' => 'sometimes|string'];
+                }
+            }
+        };
+
+        $result = $this->analyzer->analyzeWithConditionalRules(get_class($requestClass));
+
+        $ruleSets = $result['conditional_rules']['rules_sets'];
+        $this->assertCount(3, $ruleSets);
+
+        // Find PUT rules
+        $putRules = null;
+        foreach ($ruleSets as $ruleSet) {
+            if (! empty($ruleSet['conditions']) &&
+                $ruleSet['conditions'][0]['type'] === 'http_method' &&
+                $ruleSet['conditions'][0]['method'] === 'PUT') {
+                $putRules = $ruleSet;
+                break;
+            }
+        }
+
+        $this->assertNotNull($putRules);
+        $this->assertStringContainsString('archived', $putRules['rules']['status']);
+    }
+
+    /** @test */
+    public function it_handles_request_helper_conditions()
+    {
+        $requestClass = new class extends FormRequest
+        {
+            public function rules(): array
+            {
+                if (request()->isMethod('POST')) {
+                    return [
+                        'name' => 'required|string',
+                    ];
+                }
+
+                return [
+                    'name' => 'sometimes|string',
+                ];
+            }
+        };
+
+        $result = $this->analyzer->analyzeWithConditionalRules(get_class($requestClass));
+
+        $ruleSets = $result['conditional_rules']['rules_sets'];
+        $this->assertCount(2, $ruleSets);
+
+        // Check that request()->isMethod() is recognized
+        $postRules = $ruleSets[0];
+        $this->assertEquals('http_method', $postRules['conditions'][0]['type']);
+        $this->assertEquals('POST', $postRules['conditions'][0]['method']);
+    }
+
+    /** @test */
+    public function it_handles_array_validation_rules()
+    {
+        $requestClass = new class extends FormRequest
+        {
+            public function rules(): array
+            {
+                if ($this->isMethod('POST')) {
+                    return [
+                        'tags' => ['required', 'array'],
+                        'tags.*' => ['string', 'max:50'],
+                    ];
+                }
+
+                return [
+                    'tags' => ['sometimes', 'array'],
+                    'tags.*' => ['string'],
+                ];
+            }
+        };
+
+        $result = $this->analyzer->analyzeWithConditionalRules(get_class($requestClass));
+
+        $ruleSets = $result['conditional_rules']['rules_sets'];
+        $postRules = $ruleSets[0];
+
+        $this->assertIsArray($postRules['rules']['tags']);
+        $this->assertContains('required', $postRules['rules']['tags']);
+        $this->assertContains('array', $postRules['rules']['tags']);
+
+        $this->assertIsArray($postRules['rules']['tags.*']);
+        $this->assertContains('max:50', $postRules['rules']['tags.*']);
+    }
+
+    /** @test */
+    public function it_generates_parameters_from_conditional_rules()
+    {
+        $requestClass = new class extends FormRequest
+        {
+            public function rules(): array
+            {
+                if ($this->isMethod('POST')) {
+                    return [
+                        'email' => 'required|email|unique:users',
+                        'password' => 'required|min:8',
+                    ];
+                }
+
+                return [
+                    'email' => 'sometimes|email',
+                ];
+            }
+        };
+
+        $result = $this->analyzer->analyzeWithConditionalRules(get_class($requestClass));
+        $parameters = $result['parameters'];
+
+        // Find email parameter
+        $emailParam = null;
+        foreach ($parameters as $param) {
+            if ($param['name'] === 'email') {
+                $emailParam = $param;
+                break;
+            }
+        }
+
+        $this->assertNotNull($emailParam);
+        $this->assertArrayHasKey('conditional_rules', $emailParam);
+        $this->assertCount(2, $emailParam['conditional_rules']);
+
+        // Check that required is true (since it's required in at least one condition)
+        $this->assertTrue($emailParam['required']);
+    }
+
+    /** @test */
+    public function it_falls_back_to_regular_extraction_when_no_conditions()
+    {
+        $requestClass = new class extends FormRequest
+        {
+            public function rules(): array
+            {
+                return [
+                    'name' => 'required|string',
+                    'email' => 'required|email',
+                ];
+            }
+        };
+
+        $result = $this->analyzer->analyzeWithConditionalRules(get_class($requestClass));
+
+        // Should still work and return parameters
+        $this->assertArrayHasKey('parameters', $result);
+        $this->assertCount(2, $result['parameters']);
+
+        // Should have one rule set with empty conditions (no if statements)
+        $this->assertArrayHasKey('conditional_rules', $result);
+        $this->assertCount(1, $result['conditional_rules']['rules_sets']);
+        $this->assertEmpty($result['conditional_rules']['rules_sets'][0]['conditions']);
+    }
+
+    /** @test */
+    public function it_handles_complex_conditions()
+    {
+        $requestClass = new class extends FormRequest
+        {
+            public function rules(): array
+            {
+                if ($this->user() && $this->user()->isPremium()) {
+                    return [
+                        'advanced_feature' => 'required|string',
+                    ];
+                }
+
+                return [
+                    'basic_feature' => 'required|string',
+                ];
+            }
+        };
+
+        $result = $this->analyzer->analyzeWithConditionalRules(get_class($requestClass));
+
+        $ruleSets = $result['conditional_rules']['rules_sets'];
+        $this->assertCount(2, $ruleSets);
+
+        // Check custom condition type
+        $premiumRules = $ruleSets[0];
+        $this->assertEquals('custom', $premiumRules['conditions'][0]['type']);
+        $this->assertStringContainsString('isPremium', $premiumRules['conditions'][0]['expression']);
+    }
+
+    /** @test */
+    public function it_calculates_probability_correctly()
+    {
+        $requestClass = new class extends FormRequest
+        {
+            public function rules(): array
+            {
+                if ($this->isMethod('POST')) {
+                    if ($this->user()->isAdmin()) {
+                        return ['role' => 'required|in:admin,moderator'];
+                    }
+
+                    return ['role' => 'required|in:user'];
+                }
+
+                return [];
+            }
+        };
+
+        $result = $this->analyzer->analyzeWithConditionalRules(get_class($requestClass));
+
+        $ruleSets = $result['conditional_rules']['rules_sets'];
+
+        // Find nested condition rule set
+        $nestedRules = null;
+        foreach ($ruleSets as $ruleSet) {
+            if (count($ruleSet['conditions']) === 2) {
+                $nestedRules = $ruleSet;
+                break;
+            }
+        }
+
+        $this->assertNotNull($nestedRules);
+        // Probability should be 1/4 for 2 nested conditions
+        $this->assertEquals(0.25, $nestedRules['probability']);
+    }
+}

--- a/tests/Unit/Generators/ConditionalSchemaGeneratorTest.php
+++ b/tests/Unit/Generators/ConditionalSchemaGeneratorTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Tests\Unit\Generators;
+
+use LaravelPrism\Generators\SchemaGenerator;
+use LaravelPrism\Tests\TestCase;
+
+class ConditionalSchemaGeneratorTest extends TestCase
+{
+    private SchemaGenerator $generator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->generator = new SchemaGenerator;
+    }
+
+    /** @test */
+    public function it_generates_oneof_schema_for_conditional_parameters()
+    {
+        $parameters = [
+            [
+                'name' => 'email',
+                'type' => 'string',
+                'required' => true,
+                'description' => 'Email address',
+                'example' => 'user@example.com',
+                'conditional_rules' => [
+                    [
+                        'conditions' => [
+                            ['type' => 'http_method', 'method' => 'POST'],
+                        ],
+                        'rules' => ['required', 'email', 'unique:users'],
+                    ],
+                    [
+                        'conditions' => [
+                            ['type' => 'else', 'negated_conditions' => []],
+                        ],
+                        'rules' => ['sometimes', 'email'],
+                    ],
+                ],
+            ],
+            [
+                'name' => 'password',
+                'type' => 'string',
+                'required' => true,
+                'description' => 'Password',
+                'conditional_rules' => [
+                    [
+                        'conditions' => [
+                            ['type' => 'http_method', 'method' => 'POST'],
+                        ],
+                        'rules' => ['required', 'min:8'],
+                    ],
+                ],
+            ],
+        ];
+
+        $schema = $this->generator->generateFromConditionalParameters($parameters);
+
+        // Should generate oneOf schema
+        $this->assertArrayHasKey('oneOf', $schema);
+        $this->assertCount(2, $schema['oneOf']);
+
+        // Find POST schema
+        $postSchema = null;
+        foreach ($schema['oneOf'] as $s) {
+            if ($s['title'] === 'POST Request') {
+                $postSchema = $s;
+                break;
+            }
+        }
+
+        $this->assertNotNull($postSchema);
+        $this->assertEquals('object', $postSchema['type']);
+        $this->assertArrayHasKey('properties', $postSchema);
+        $this->assertArrayHasKey('email', $postSchema['properties']);
+        $this->assertArrayHasKey('password', $postSchema['properties']);
+        $this->assertContains('email', $postSchema['required']);
+        $this->assertContains('password', $postSchema['required']);
+    }
+
+    /** @test */
+    public function it_generates_regular_schema_when_no_conditions()
+    {
+        $parameters = [
+            [
+                'name' => 'name',
+                'type' => 'string',
+                'required' => true,
+                'description' => 'Name',
+            ],
+            [
+                'name' => 'email',
+                'type' => 'string',
+                'required' => true,
+                'description' => 'Email',
+            ],
+        ];
+
+        $schema = $this->generator->generateFromConditionalParameters($parameters);
+
+        // Should generate regular schema (no oneOf)
+        $this->assertArrayNotHasKey('oneOf', $schema);
+        $this->assertEquals('object', $schema['type']);
+        $this->assertArrayHasKey('properties', $schema);
+        $this->assertArrayHasKey('name', $schema['properties']);
+        $this->assertArrayHasKey('email', $schema['properties']);
+    }
+
+    /** @test */
+    public function it_handles_non_http_method_conditions()
+    {
+        $parameters = [
+            [
+                'name' => 'admin_field',
+                'type' => 'string',
+                'required' => true,
+                'description' => 'Admin only field',
+                'conditional_rules' => [
+                    [
+                        'conditions' => [
+                            ['type' => 'user_method', 'expression' => '$this->user()->isAdmin()'],
+                        ],
+                        'rules' => ['required', 'string'],
+                    ],
+                ],
+            ],
+        ];
+
+        $schema = $this->generator->generateFromConditionalParameters($parameters);
+
+        // Non-HTTP method conditions should be grouped as DEFAULT
+        $this->assertEquals('object', $schema['type']);
+        $this->assertArrayHasKey('properties', $schema);
+        $this->assertArrayHasKey('admin_field', $schema['properties']);
+    }
+
+    /** @test */
+    public function it_merges_duplicate_fields_correctly()
+    {
+        $parameters = [
+            [
+                'name' => 'status',
+                'type' => 'string',
+                'required' => true,
+                'description' => 'Status field',
+                'conditional_rules' => [
+                    [
+                        'conditions' => [
+                            ['type' => 'http_method', 'method' => 'POST'],
+                        ],
+                        'rules' => ['required', 'in:draft,published'],
+                    ],
+                    [
+                        'conditions' => [
+                            ['type' => 'http_method', 'method' => 'POST'],
+                            ['type' => 'user_method', 'expression' => '$this->user()->isAdmin()'],
+                        ],
+                        'rules' => ['required', 'in:draft,published,archived'],
+                    ],
+                ],
+            ],
+        ];
+
+        $schema = $this->generator->generateFromConditionalParameters($parameters);
+
+        // When all conditions have the same HTTP method, it generates a single schema
+        $this->assertEquals('object', $schema['type']);
+        $this->assertArrayHasKey('properties', $schema);
+        $this->assertArrayHasKey('status', $schema['properties']);
+
+        // Should only have one status field
+        $statusCount = 0;
+        foreach ($schema['properties'] as $name => $prop) {
+            if ($name === 'status') {
+                $statusCount++;
+            }
+        }
+        $this->assertEquals(1, $statusCount, 'Should only have one status field');
+    }
+}


### PR DESCRIPTION
# 概要

FormRequestのrules()メソッドで条件分岐（if文）を使用した動的なバリデーションルール定義を解析し、OpenAPIドキュメントに反映できる機能を実装しました。

## 変更内容

実際のプロジェクトでは、HTTPメソッドや認証状態によってバリデーションルールを動的に変更することがよくあります。この機能により、そのような条件付きルールを正確に抽出し、ドキュメント化できるようになりました。

### 新機能
- **ConditionalRulesExtractorVisitor**: if文による条件分岐を解析し、各条件下でのルールセットを抽出
- **条件付きルール解析**: HTTPメソッド条件、ユーザー権限条件、ネストした条件、elseif文などに対応
- **OpenAPIスキーマ生成**: 条件に応じて異なるスキーマを生成（oneOf形式）
- **匿名クラス対応**: テストで使用される匿名FormRequestクラスの解析をサポート

### 対応する条件パターン
- `$this->isMethod('POST')` - HTTPメソッドによる分岐
- `$this->user()->isAdmin()` - ユーザー権限による分岐
- ネストした条件分岐
- elseif文
- 早期returnパターン

### テスト
- 各種条件パターンに対する包括的なユニットテストを追加
- 既存のテストとの互換性を維持

## 関連情報

- Issue: #7 (仮想的なIssue番号)
- ドキュメント: docs/complicated_condition.md