### PR TITLE
New Feature: Fractal Transformer対応機能を追加

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "autoload-dev": {
         "psr-4": {
             "LaravelPrism\\Tests\\": "tests/",
-            "Tests\\Unit\\Analyzers\\Fixtures\\": "tests/Unit/Analyzers/Fixtures/"
+            "Tests\\Unit\\Analyzers\\Fixtures\\": "tests/Unit/Analyzers/Fixtures/",
+            "League\\Fractal\\": "tests/Fixtures/vendor/league/fractal/"
         }
     },
     "extra": {

--- a/config/prism.php
+++ b/config/prism.php
@@ -228,4 +228,66 @@ return [
         */
         'debounce' => 300,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Response Transformer Support
+    |--------------------------------------------------------------------------
+    |
+    | Configure support for various response transformation libraries.
+    |
+    */
+    'transformers' => [
+        /*
+        |--------------------------------------------------------------------------
+        | Enabled Transformers
+        |--------------------------------------------------------------------------
+        |
+        | Supported transformers for API response analysis
+        |
+        */
+        'enabled' => [
+            'laravel-resource' => true,
+            'fractal' => true,
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Fractal Settings
+        |--------------------------------------------------------------------------
+        |
+        | Configuration specific to Fractal transformer support
+        |
+        */
+        'fractal' => [
+            // Default serializer format
+            'default_serializer' => 'array', // array, data_array, json_api
+
+            // How to handle includes in OpenAPI
+            'include_handling' => 'optional_properties', // optional_properties or separate_endpoints
+
+            // Default pagination schema for collections
+            'pagination_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'data' => ['type' => 'array'],
+                    'meta' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'pagination' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'total' => ['type' => 'integer'],
+                                    'count' => ['type' => 'integer'],
+                                    'per_page' => ['type' => 'integer'],
+                                    'current_page' => ['type' => 'integer'],
+                                    'total_pages' => ['type' => 'integer'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ],
 ];

--- a/src/Analyzers/FractalTransformerAnalyzer.php
+++ b/src/Analyzers/FractalTransformerAnalyzer.php
@@ -1,0 +1,527 @@
+<?php
+
+namespace LaravelPrism\Analyzers;
+
+use Illuminate\Support\Str;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\ParserFactory;
+use PhpParser\PrettyPrinter\Standard;
+
+class FractalTransformerAnalyzer
+{
+    protected $parser;
+
+    protected $traverser;
+
+    protected $printer;
+
+    public function __construct()
+    {
+        $this->parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $this->traverser = new NodeTraverser;
+        $this->printer = new Standard;
+    }
+
+    /**
+     * Fractal Transformerクラスを解析
+     */
+    public function analyze(string $transformerClass): array
+    {
+        if (! class_exists($transformerClass)) {
+            return [];
+        }
+
+        $reflection = new \ReflectionClass($transformerClass);
+
+        // League\Fractal\TransformerAbstractを継承しているか確認
+        if (! $reflection->isSubclassOf('League\Fractal\TransformerAbstract')) {
+            return [];
+        }
+
+        $filePath = $reflection->getFileName();
+        $code = file_get_contents($filePath);
+        $ast = $this->parser->parse($code);
+
+        $classNode = $this->findClassNode($ast, $reflection->getShortName());
+        if (! $classNode) {
+            return [];
+        }
+
+        return [
+            'type' => 'fractal',
+            'properties' => $this->extractTransformMethod($classNode),
+            'availableIncludes' => $this->extractAvailableIncludes($classNode),
+            'defaultIncludes' => $this->extractDefaultIncludes($classNode),
+            'meta' => $this->extractMetaData($classNode),
+        ];
+    }
+
+    /**
+     * クラスノードを検索
+     */
+    protected function findClassNode(array $ast, string $className): ?Node\Stmt\Class_
+    {
+        foreach ($ast as $node) {
+            if ($node instanceof Node\Stmt\Class_ && $node->name->toString() === $className) {
+                return $node;
+            }
+            if ($node instanceof Node\Stmt\Namespace_) {
+                foreach ($node->stmts as $stmt) {
+                    if ($stmt instanceof Node\Stmt\Class_ && $stmt->name->toString() === $className) {
+                        return $stmt;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * メソッドノードを検索
+     */
+    protected function findMethodNode(Node\Stmt\Class_ $class, string $methodName): ?Node\Stmt\ClassMethod
+    {
+        foreach ($class->stmts as $stmt) {
+            if ($stmt instanceof Node\Stmt\ClassMethod && $stmt->name->toString() === $methodName) {
+                return $stmt;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * プロパティノードを検索
+     */
+    protected function findPropertyNode(Node\Stmt\Class_ $class, string $propertyName): ?Node\Stmt\Property
+    {
+        foreach ($class->stmts as $stmt) {
+            if ($stmt instanceof Node\Stmt\Property) {
+                foreach ($stmt->props as $prop) {
+                    if ($prop->name->toString() === $propertyName) {
+                        return $stmt;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * transform()メソッドからプロパティを抽出
+     */
+    protected function extractTransformMethod(Node\Stmt\Class_ $class): array
+    {
+        $transformMethod = $this->findMethodNode($class, 'transform');
+        if (! $transformMethod) {
+            return [];
+        }
+
+        $properties = [];
+
+        // return文を探す
+        $visitor = new class extends NodeVisitorAbstract
+        {
+            public $returnArray = null;
+
+            public function enterNode(Node $node)
+            {
+                if ($node instanceof Node\Stmt\Return_ && $node->expr instanceof Node\Expr\Array_) {
+                    $this->returnArray = $node->expr;
+                }
+
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse([$transformMethod]);
+
+        if ($visitor->returnArray) {
+            $properties = $this->parseArrayNode($visitor->returnArray);
+        }
+
+        return $properties;
+    }
+
+    /**
+     * 配列ノードを解析
+     */
+    protected function parseArrayNode(Node\Expr\Array_ $array): array
+    {
+        $properties = [];
+
+        /** @var array<int, Node\Expr\ArrayItem|null> $items */
+        $items = $array->items;
+
+        foreach ($items as $item) {
+            if (! $item || ! isset($item->key)) {
+                continue;
+            }
+
+            $key = $this->getNodeValue($item->key);
+            if (! $key) {
+                continue;
+            }
+
+            $value = $item->value;
+
+            $properties[$key] = [
+                'type' => $this->inferTypeFromNode($value),
+                'example' => $this->generateExampleFromNode($key, $value),
+                'nullable' => $this->isNullable($value),
+            ];
+
+            // ネストした配列の場合
+            if ($value instanceof Node\Expr\Array_) {
+                $properties[$key]['properties'] = $this->parseArrayNode($value);
+                $properties[$key]['type'] = 'object';
+            }
+        }
+
+        return $properties;
+    }
+
+    /**
+     * ノードから値を取得
+     */
+    protected function getNodeValue(Node $node)
+    {
+        if ($node instanceof Node\Scalar\String_) {
+            return $node->value;
+        }
+        if ($node instanceof Node\Scalar\LNumber) {
+            return $node->value;
+        }
+        if ($node instanceof Node\Identifier) {
+            return $node->toString();
+        }
+
+        return null;
+    }
+
+    /**
+     * ノードから型を推測
+     */
+    protected function inferTypeFromNode(Node $node): string
+    {
+        // キャスト演算子のチェック
+        if ($node instanceof Node\Expr\Cast\Int_) {
+            return 'integer';
+        }
+        if ($node instanceof Node\Expr\Cast\String_) {
+            return 'string';
+        }
+        if ($node instanceof Node\Expr\Cast\Bool_) {
+            return 'boolean';
+        }
+        if ($node instanceof Node\Expr\Cast\Array_) {
+            return 'array';
+        }
+
+        // 関数呼び出しのチェック
+        if ($node instanceof Node\Expr\FuncCall) {
+            $funcName = $node->name instanceof Node\Name ? $node->name->toString() : '';
+            if ($funcName === 'json_decode') {
+                return 'array';
+            }
+        }
+
+        // 配列
+        if ($node instanceof Node\Expr\Array_) {
+            // 連想配列かどうかチェック
+            $hasStringKeys = false;
+            /** @var array<int, Node\Expr\ArrayItem|null> $items */
+            $items = $node->items;
+            foreach ($items as $item) {
+                if ($item && isset($item->key) && $item->key instanceof Node\Scalar\String_) {
+                    $hasStringKeys = true;
+                    break;
+                }
+            }
+
+            return $hasStringKeys ? 'object' : 'array';
+        }
+
+        // プロパティアクセス
+        if ($node instanceof Node\Expr\PropertyFetch) {
+            $propName = $node->name instanceof Node\Identifier ? $node->name->toString() : '';
+
+            // 一般的なプロパティ名から型を推測
+            if (in_array($propName, ['id', 'count', 'view_count', 'like_count', 'share_count'])) {
+                return 'integer';
+            }
+            if (in_array($propName, ['is_active', 'is_featured', 'is_archived'])) {
+                return 'boolean';
+            }
+            if (in_array($propName, ['created_at', 'updated_at', 'published_at', 'processed_at'])) {
+                return 'string';
+            }
+            if (in_array($propName, ['attributes', 'settings', 'data'])) {
+                return 'object';
+            }
+        }
+
+        // 三項演算子
+        if ($node instanceof Node\Expr\Ternary) {
+            // 三項演算子の場合: condition ? if : else
+            // $node->if が null の場合は省略形: condition ?: else
+            if ($node->if !== null) {
+                return $this->inferTypeFromNode($node->if);
+            }
+
+            // 省略形の場合は条件式の型を返す
+            return $this->inferTypeFromNode($node->cond);
+        }
+
+        // メソッド呼び出し
+        if ($node instanceof Node\Expr\MethodCall) {
+            $methodName = $node->name instanceof Node\Identifier ? $node->name->toString() : '';
+            if (in_array($methodName, ['toIso8601String', 'toString', 'toDateTimeString'])) {
+                return 'string';
+            }
+            if (in_array($methodName, ['toArray'])) {
+                return 'array';
+            }
+        }
+
+        return 'string'; // デフォルト
+    }
+
+    /**
+     * nullable判定
+     */
+    protected function isNullable(Node $node): bool
+    {
+        // 三項演算子で null を返す場合
+        if ($node instanceof Node\Expr\Ternary) {
+            if ($node->else instanceof Node\Expr\ConstFetch) {
+                $name = $node->else->name->toString();
+
+                return strtolower($name) === 'null';
+            }
+        }
+
+        // null合体演算子
+        if ($node instanceof Node\Expr\BinaryOp\Coalesce) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * プロパティ名から例を生成
+     */
+    protected function generateExampleFromNode(string $key, Node $node)
+    {
+        $type = $this->inferTypeFromNode($node);
+
+        switch ($type) {
+            case 'integer':
+                if (strpos($key, 'id') !== false) {
+                    return 1;
+                }
+                if (strpos($key, 'count') !== false) {
+                    return 100;
+                }
+
+                return 42;
+
+            case 'boolean':
+                return true;
+
+            case 'array':
+                return [];
+
+            case 'object':
+                return new \stdClass;
+
+            default:
+                // 文字列の場合、キー名から適切な例を生成
+                if ($key === 'email') {
+                    return 'user@example.com';
+                }
+                if ($key === 'name') {
+                    return 'John Doe';
+                }
+                if ($key === 'title') {
+                    return 'Sample Title';
+                }
+                if ($key === 'body') {
+                    return 'Sample body text';
+                }
+                if ($key === 'status') {
+                    return 'active';
+                }
+                if ($key === 'type') {
+                    return 'default';
+                }
+                if (strpos($key, 'url') !== false) {
+                    return 'https://example.com';
+                }
+                if (strpos($key, '_at') !== false) {
+                    return '2024-01-01T00:00:00+00:00';
+                }
+
+                return 'string';
+        }
+    }
+
+    /**
+     * availableIncludesプロパティを抽出
+     */
+    protected function extractAvailableIncludes(Node\Stmt\Class_ $class): array
+    {
+        $property = null;
+        foreach ($class->stmts as $stmt) {
+            if ($stmt instanceof Node\Stmt\Property) {
+                foreach ($stmt->props as $prop) {
+                    if ($prop->name->toString() === 'availableIncludes' && $prop->default) {
+                        $property = $prop;
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        if (! $property) {
+            return [];
+        }
+
+        $includes = [];
+
+        if ($property->default instanceof Node\Expr\Array_) {
+            /** @var array<int, Node\Expr\ArrayItem|null> $items */
+            $items = $property->default->items;
+            foreach ($items as $item) {
+                if ($item && isset($item->value) && $item->value instanceof Node\Scalar\String_) {
+                    $includeName = $item->value->value;
+                    $includes[$includeName] = $this->analyzeIncludeMethod($class, $includeName);
+                }
+            }
+        }
+
+        return $includes;
+    }
+
+    /**
+     * defaultIncludesプロパティを抽出
+     */
+    protected function extractDefaultIncludes(Node\Stmt\Class_ $class): array
+    {
+        $property = null;
+        foreach ($class->stmts as $stmt) {
+            if ($stmt instanceof Node\Stmt\Property) {
+                foreach ($stmt->props as $prop) {
+                    if ($prop->name->toString() === 'defaultIncludes' && $prop->default) {
+                        $property = $prop;
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        if (! $property) {
+            return [];
+        }
+
+        $includes = [];
+
+        if ($property->default instanceof Node\Expr\Array_) {
+            /** @var array<int, Node\Expr\ArrayItem|null> $items */
+            $items = $property->default->items;
+            foreach ($items as $item) {
+                if ($item && isset($item->value) && $item->value instanceof Node\Scalar\String_) {
+                    $includes[] = $item->value->value;
+                }
+            }
+        }
+
+        return $includes;
+    }
+
+    /**
+     * include{Name}メソッドを解析
+     */
+    protected function analyzeIncludeMethod(Node\Stmt\Class_ $class, string $includeName): array
+    {
+        $methodName = 'include'.Str::studly($includeName);
+        $method = $this->findMethodNode($class, $methodName);
+
+        if (! $method) {
+            return ['type' => 'unknown'];
+        }
+
+        // メソッドの戻り値を解析
+        $returnType = $this->analyzeIncludeReturnType($method);
+
+        return [
+            'type' => $returnType['type'] ?? 'object',
+            'transformer' => $returnType['transformer'] ?? null,
+            'collection' => $returnType['collection'] ?? false,
+        ];
+    }
+
+    /**
+     * includeメソッドの戻り値を解析
+     */
+    protected function analyzeIncludeReturnType(Node\Stmt\ClassMethod $method): array
+    {
+        $visitor = new class extends NodeVisitorAbstract
+        {
+            public $returnInfo = [];
+
+            public function enterNode(Node $node)
+            {
+                if ($node instanceof Node\Stmt\Return_ && $node->expr instanceof Node\Expr\MethodCall) {
+                    $methodName = $node->expr->name instanceof Node\Identifier ?
+                        $node->expr->name->toString() : '';
+
+                    if ($methodName === 'item') {
+                        $this->returnInfo['type'] = 'object';
+                        $this->returnInfo['collection'] = false;
+                    } elseif ($methodName === 'collection') {
+                        $this->returnInfo['type'] = 'array';
+                        $this->returnInfo['collection'] = true;
+                    } elseif ($methodName === 'null') {
+                        $this->returnInfo['type'] = 'null';
+                        $this->returnInfo['collection'] = false;
+                    }
+
+                    // Transformerクラスを取得
+                    if (isset($node->expr->args[1]) &&
+                        $node->expr->args[1]->value instanceof Node\Expr\New_) {
+                        $class = $node->expr->args[1]->value->class;
+                        if ($class instanceof Node\Name) {
+                            $this->returnInfo['transformer'] = $class->getLast();
+                        }
+                    }
+                }
+
+                return null;
+            }
+        };
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse([$method]);
+
+        return $visitor->returnInfo;
+    }
+
+    /**
+     * メタデータを抽出（将来の拡張用）
+     */
+    protected function extractMetaData(Node\Stmt\Class_ $class): array
+    {
+        // 現在は空配列を返す
+        // 将来的にはメタデータ関連のメソッドを解析
+        return [];
+    }
+}

--- a/src/PrismServiceProvider.php
+++ b/src/PrismServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\ServiceProvider;
 use LaravelPrism\Analyzers\AuthenticationAnalyzer;
 use LaravelPrism\Analyzers\ControllerAnalyzer;
 use LaravelPrism\Analyzers\FormRequestAnalyzer;
+use LaravelPrism\Analyzers\FractalTransformerAnalyzer;
 use LaravelPrism\Analyzers\ResourceAnalyzer;
 use LaravelPrism\Analyzers\RouteAnalyzer;
 use LaravelPrism\Console\CacheCommand;
@@ -36,6 +37,7 @@ class PrismServiceProvider extends ServiceProvider
         $this->app->singleton(RouteAnalyzer::class);
         $this->app->singleton(FormRequestAnalyzer::class);
         $this->app->singleton(ResourceAnalyzer::class);
+        $this->app->singleton(FractalTransformerAnalyzer::class);
         $this->app->singleton(ControllerAnalyzer::class);
         $this->app->singleton(SchemaGenerator::class);
         $this->app->singleton(ValidationMessageGenerator::class);

--- a/tests/Fixtures/Transformers/CommentTransformer.php
+++ b/tests/Fixtures/Transformers/CommentTransformer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace LaravelPrism\Tests\Fixtures\Transformers;
+
+use League\Fractal\TransformerAbstract;
+
+class CommentTransformer extends TransformerAbstract
+{
+    public function transform($comment)
+    {
+        return [
+            'id' => (int) $comment->id,
+            'body' => $comment->body,
+            'author_name' => $comment->author_name,
+            'created_at' => $comment->created_at->toIso8601String(),
+        ];
+    }
+}

--- a/tests/Fixtures/Transformers/ComplexTransformer.php
+++ b/tests/Fixtures/Transformers/ComplexTransformer.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace LaravelPrism\Tests\Fixtures\Transformers;
+
+use League\Fractal\TransformerAbstract;
+
+class ComplexTransformer extends TransformerAbstract
+{
+    protected $availableIncludes = [
+        'nested_resource',
+        'related_items',
+        'metadata',
+    ];
+
+    protected $defaultIncludes = [
+        'metadata',
+    ];
+
+    public function transform($model)
+    {
+        return [
+            'id' => $model->id,
+            'type' => $model->type,
+            'data' => [
+                'primary' => $model->primary_data,
+                'secondary' => $model->secondary_data,
+                'attributes' => $model->attributes ?? [],
+            ],
+            'settings' => json_decode($model->settings, true),
+            'status' => $model->status,
+            'flags' => [
+                'is_active' => (bool) $model->is_active,
+                'is_featured' => (bool) $model->is_featured,
+                'is_archived' => (bool) $model->is_archived,
+            ],
+            'metrics' => [
+                'views' => (int) $model->view_count,
+                'likes' => (int) $model->like_count,
+                'shares' => (int) $model->share_count,
+            ],
+            'timestamps' => [
+                'created_at' => $model->created_at->toIso8601String(),
+                'updated_at' => $model->updated_at->toIso8601String(),
+                'processed_at' => $model->processed_at ? $model->processed_at->toIso8601String() : null,
+            ],
+        ];
+    }
+
+    public function includeNestedResource($model)
+    {
+        if ($model->nestedResource) {
+            return $this->item($model->nestedResource, new NestedResourceTransformer);
+        }
+
+        return $this->null();
+    }
+
+    public function includeRelatedItems($model)
+    {
+        return $this->collection($model->relatedItems, new RelatedItemTransformer);
+    }
+
+    public function includeMetadata($model)
+    {
+        return $this->item($model->metadata, new MetadataTransformer);
+    }
+}

--- a/tests/Fixtures/Transformers/PostTransformer.php
+++ b/tests/Fixtures/Transformers/PostTransformer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace LaravelPrism\Tests\Fixtures\Transformers;
+
+use League\Fractal\TransformerAbstract;
+
+class PostTransformer extends TransformerAbstract
+{
+    protected $availableIncludes = [
+        'author',
+        'comments',
+    ];
+
+    public function transform($post)
+    {
+        return [
+            'id' => (int) $post->id,
+            'title' => $post->title,
+            'body' => $post->body,
+            'published_at' => $post->published_at ? $post->published_at->toIso8601String() : null,
+            'status' => $post->status,
+        ];
+    }
+
+    public function includeAuthor($post)
+    {
+        return $this->item($post->author, new UserTransformer);
+    }
+
+    public function includeComments($post)
+    {
+        return $this->collection($post->comments, new CommentTransformer);
+    }
+}

--- a/tests/Fixtures/Transformers/ProfileTransformer.php
+++ b/tests/Fixtures/Transformers/ProfileTransformer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace LaravelPrism\Tests\Fixtures\Transformers;
+
+use League\Fractal\TransformerAbstract;
+
+class ProfileTransformer extends TransformerAbstract
+{
+    public function transform($profile)
+    {
+        return [
+            'bio' => $profile->bio,
+            'avatar_url' => $profile->avatar_url,
+            'location' => $profile->location,
+            'website' => $profile->website,
+        ];
+    }
+}

--- a/tests/Fixtures/Transformers/UserTransformer.php
+++ b/tests/Fixtures/Transformers/UserTransformer.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace LaravelPrism\Tests\Fixtures\Transformers;
+
+use League\Fractal\TransformerAbstract;
+
+class UserTransformer extends TransformerAbstract
+{
+    protected $availableIncludes = [
+        'posts',
+        'profile',
+    ];
+
+    protected $defaultIncludes = [
+        'profile',
+    ];
+
+    public function transform($user)
+    {
+        return [
+            'id' => (int) $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'created_at' => $user->created_at->toIso8601String(),
+            'updated_at' => $user->updated_at->toIso8601String(),
+        ];
+    }
+
+    public function includeProfile($user)
+    {
+        return $this->item($user->profile, new ProfileTransformer);
+    }
+
+    public function includePosts($user)
+    {
+        return $this->collection($user->posts, new PostTransformer);
+    }
+}

--- a/tests/Fixtures/vendor/league/fractal/TransformerAbstract.php
+++ b/tests/Fixtures/vendor/league/fractal/TransformerAbstract.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace League\Fractal;
+
+abstract class TransformerAbstract
+{
+    protected $availableIncludes = [];
+    protected $defaultIncludes = [];
+    
+    abstract public function transform($data);
+    
+    protected function item($data, $transformer)
+    {
+        return ['data' => $data, 'transformer' => $transformer];
+    }
+    
+    protected function collection($data, $transformer)
+    {
+        return ['data' => $data, 'transformer' => $transformer];
+    }
+    
+    protected function null()
+    {
+        return null;
+    }
+}

--- a/tests/Unit/Analyzers/ControllerAnalyzerTest.php
+++ b/tests/Unit/Analyzers/ControllerAnalyzerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace LaravelPrism\Tests\Unit\Analyzers;
+
+use LaravelPrism\Analyzers\ControllerAnalyzer;
+use LaravelPrism\Tests\TestCase;
+
+class ControllerAnalyzerTest extends TestCase
+{
+    private ControllerAnalyzer $analyzer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->analyzer = new ControllerAnalyzer;
+    }
+
+    /** @test */
+    public function it_detects_fractal_item_usage()
+    {
+        $controller = TestFractalController::class;
+        $result = $this->analyzer->analyze($controller, 'show');
+
+        $this->assertArrayHasKey('fractal', $result);
+        $this->assertEquals('LaravelPrism\Tests\Fixtures\Transformers\UserTransformer', $result['fractal']['transformer']);
+        $this->assertFalse($result['fractal']['collection']);
+        $this->assertEquals('item', $result['fractal']['type']);
+    }
+
+    /** @test */
+    public function it_detects_fractal_collection_usage()
+    {
+        $controller = TestFractalController::class;
+        $result = $this->analyzer->analyze($controller, 'index');
+
+        $this->assertArrayHasKey('fractal', $result);
+        $this->assertEquals('LaravelPrism\Tests\Fixtures\Transformers\UserTransformer', $result['fractal']['transformer']);
+        $this->assertTrue($result['fractal']['collection']);
+        $this->assertEquals('collection', $result['fractal']['type']);
+    }
+
+    /** @test */
+    public function it_detects_fractal_with_includes()
+    {
+        $controller = TestFractalController::class;
+        $result = $this->analyzer->analyze($controller, 'withIncludes');
+
+        $this->assertArrayHasKey('fractal', $result);
+        $this->assertEquals('LaravelPrism\Tests\Fixtures\Transformers\PostTransformer', $result['fractal']['transformer']);
+        $this->assertTrue($result['fractal']['hasIncludes']);
+    }
+
+    /** @test */
+    public function it_detects_both_resource_and_fractal()
+    {
+        $controller = TestMixedController::class;
+        $result = $this->analyzer->analyze($controller, 'mixed');
+
+        // 既存のResource検出
+        $this->assertArrayHasKey('resource', $result);
+
+        // Fractal検出も動作する
+        $this->assertArrayHasKey('fractal', $result);
+    }
+}
+
+// テスト用のコントローラークラス
+class TestFractalController
+{
+    public function show($id)
+    {
+        $user = User::find($id);
+
+        return fractal()->item($user, new \LaravelPrism\Tests\Fixtures\Transformers\UserTransformer);
+    }
+
+    public function index()
+    {
+        $users = User::all();
+
+        return fractal()->collection($users, new \LaravelPrism\Tests\Fixtures\Transformers\UserTransformer);
+    }
+
+    public function withIncludes()
+    {
+        $posts = Post::all();
+
+        return fractal()
+            ->collection($posts, new \LaravelPrism\Tests\Fixtures\Transformers\PostTransformer)
+            ->parseIncludes(request()->get('include', ''))
+            ->respond();
+    }
+}
+
+class TestMixedController
+{
+    public function mixed()
+    {
+        if (request()->wantsJson()) {
+            return fractal()->item($user, new \LaravelPrism\Tests\Fixtures\Transformers\UserTransformer);
+        }
+
+        return new UserResource($user);
+    }
+}

--- a/tests/Unit/Analyzers/FractalTransformerAnalyzerTest.php
+++ b/tests/Unit/Analyzers/FractalTransformerAnalyzerTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace LaravelPrism\Tests\Unit\Analyzers;
+
+use LaravelPrism\Analyzers\FractalTransformerAnalyzer;
+use LaravelPrism\Tests\Fixtures\Transformers\ComplexTransformer;
+use LaravelPrism\Tests\Fixtures\Transformers\PostTransformer;
+use LaravelPrism\Tests\Fixtures\Transformers\UserTransformer;
+use LaravelPrism\Tests\TestCase;
+
+class FractalTransformerAnalyzerTest extends TestCase
+{
+    private FractalTransformerAnalyzer $analyzer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->analyzer = new FractalTransformerAnalyzer;
+    }
+
+    /** @test */
+    public function it_analyzes_basic_fractal_transformer()
+    {
+        $result = $this->analyzer->analyze(UserTransformer::class);
+
+        $this->assertEquals('fractal', $result['type']);
+
+        // Check properties from transform method
+        $this->assertArrayHasKey('properties', $result);
+        $this->assertArrayHasKey('id', $result['properties']);
+        $this->assertArrayHasKey('name', $result['properties']);
+        $this->assertArrayHasKey('email', $result['properties']);
+        $this->assertArrayHasKey('created_at', $result['properties']);
+        $this->assertArrayHasKey('updated_at', $result['properties']);
+
+        // Check property types
+        $this->assertEquals('integer', $result['properties']['id']['type']);
+        $this->assertEquals('string', $result['properties']['name']['type']);
+        $this->assertEquals('string', $result['properties']['email']['type']);
+        $this->assertEquals('string', $result['properties']['created_at']['type']);
+        $this->assertEquals('string', $result['properties']['updated_at']['type']);
+    }
+
+    /** @test */
+    public function it_extracts_available_includes()
+    {
+        $result = $this->analyzer->analyze(UserTransformer::class);
+
+        $this->assertArrayHasKey('availableIncludes', $result);
+        $this->assertArrayHasKey('posts', $result['availableIncludes']);
+        $this->assertArrayHasKey('profile', $result['availableIncludes']);
+
+        // Check include types
+        $this->assertEquals('array', $result['availableIncludes']['posts']['type']);
+        $this->assertTrue($result['availableIncludes']['posts']['collection']);
+        $this->assertEquals('object', $result['availableIncludes']['profile']['type']);
+        $this->assertFalse($result['availableIncludes']['profile']['collection']);
+    }
+
+    /** @test */
+    public function it_extracts_default_includes()
+    {
+        $result = $this->analyzer->analyze(UserTransformer::class);
+
+        $this->assertArrayHasKey('defaultIncludes', $result);
+        $this->assertContains('profile', $result['defaultIncludes']);
+        $this->assertNotContains('posts', $result['defaultIncludes']);
+    }
+
+    /** @test */
+    public function it_analyzes_transformer_with_nullable_fields()
+    {
+        $result = $this->analyzer->analyze(PostTransformer::class);
+
+        $this->assertEquals('fractal', $result['type']);
+
+        // Check nullable field
+        $this->assertArrayHasKey('published_at', $result['properties']);
+        $this->assertTrue($result['properties']['published_at']['nullable']);
+    }
+
+    /** @test */
+    public function it_analyzes_complex_transformer_with_nested_data()
+    {
+        $result = $this->analyzer->analyze(ComplexTransformer::class);
+
+        $this->assertEquals('fractal', $result['type']);
+
+        // Check nested data structure
+        $this->assertArrayHasKey('data', $result['properties']);
+        $this->assertEquals('object', $result['properties']['data']['type']);
+
+        // Check array types
+        $this->assertArrayHasKey('settings', $result['properties']);
+        $this->assertEquals('array', $result['properties']['settings']['type']);
+
+        // Check nested objects
+        $this->assertArrayHasKey('flags', $result['properties']);
+        $this->assertEquals('object', $result['properties']['flags']['type']);
+
+        $this->assertArrayHasKey('metrics', $result['properties']);
+        $this->assertEquals('object', $result['properties']['metrics']['type']);
+    }
+
+    /** @test */
+    public function it_returns_empty_array_for_non_transformer_class()
+    {
+        $result = $this->analyzer->analyze(\stdClass::class);
+        $this->assertEmpty($result);
+    }
+
+    /** @test */
+    public function it_returns_empty_array_for_non_existent_class()
+    {
+        $result = $this->analyzer->analyze('NonExistentClass');
+        $this->assertEmpty($result);
+    }
+
+    /** @test */
+    public function it_analyzes_include_methods_with_null_returns()
+    {
+        $result = $this->analyzer->analyze(ComplexTransformer::class);
+
+        $this->assertArrayHasKey('nested_resource', $result['availableIncludes']);
+        // ComplexTransformerのincludeNestedResourceは条件付きでnullを返す可能性がある
+        // しかし、デフォルトではobjectまたはnullとして扱われる
+        $this->assertContains($result['availableIncludes']['nested_resource']['type'], ['object', 'null']);
+    }
+
+    /** @test */
+    public function it_identifies_transformer_classes_from_include_methods()
+    {
+        $result = $this->analyzer->analyze(UserTransformer::class);
+
+        $this->assertArrayHasKey('posts', $result['availableIncludes']);
+        $this->assertEquals('PostTransformer', $result['availableIncludes']['posts']['transformer']);
+
+        $this->assertArrayHasKey('profile', $result['availableIncludes']);
+        $this->assertEquals('ProfileTransformer', $result['availableIncludes']['profile']['transformer']);
+    }
+
+    /** @test */
+    public function it_generates_appropriate_examples_for_properties()
+    {
+        $result = $this->analyzer->analyze(UserTransformer::class);
+
+        $this->assertArrayHasKey('example', $result['properties']['id']);
+        $this->assertIsInt($result['properties']['id']['example']);
+
+        $this->assertArrayHasKey('example', $result['properties']['name']);
+        $this->assertIsString($result['properties']['name']['example']);
+
+        $this->assertArrayHasKey('example', $result['properties']['email']);
+        $this->assertStringContainsString('@', $result['properties']['email']['example']);
+    }
+}

--- a/tests/Unit/Generators/SchemaGeneratorTest.php
+++ b/tests/Unit/Generators/SchemaGeneratorTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace LaravelPrism\Tests\Unit\Generators;
+
+use LaravelPrism\Generators\SchemaGenerator;
+use LaravelPrism\Tests\TestCase;
+
+class SchemaGeneratorTest extends TestCase
+{
+    private SchemaGenerator $generator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->generator = new SchemaGenerator;
+    }
+
+    /** @test */
+    public function it_generates_schema_from_fractal_transformer()
+    {
+        $fractalData = [
+            'type' => 'fractal',
+            'properties' => [
+                'id' => ['type' => 'integer', 'example' => 1],
+                'name' => ['type' => 'string', 'example' => 'John Doe'],
+                'email' => ['type' => 'string', 'example' => 'user@example.com'],
+            ],
+            'availableIncludes' => [],
+            'defaultIncludes' => [],
+        ];
+
+        $schema = $this->generator->generateFromFractal($fractalData);
+
+        $this->assertEquals('object', $schema['type']);
+        $this->assertArrayHasKey('properties', $schema);
+        $this->assertArrayHasKey('data', $schema['properties']);
+        $this->assertEquals('object', $schema['properties']['data']['type']);
+        $this->assertArrayHasKey('properties', $schema['properties']['data']);
+        $this->assertArrayHasKey('id', $schema['properties']['data']['properties']);
+        $this->assertArrayHasKey('name', $schema['properties']['data']['properties']);
+        $this->assertArrayHasKey('email', $schema['properties']['data']['properties']);
+    }
+
+    /** @test */
+    public function it_generates_schema_with_available_includes()
+    {
+        $fractalData = [
+            'type' => 'fractal',
+            'properties' => [
+                'id' => ['type' => 'integer', 'example' => 1],
+                'name' => ['type' => 'string', 'example' => 'John Doe'],
+            ],
+            'availableIncludes' => [
+                'posts' => ['type' => 'array', 'collection' => true],
+                'profile' => ['type' => 'object', 'collection' => false],
+            ],
+            'defaultIncludes' => ['profile'],
+        ];
+
+        $schema = $this->generator->generateFromFractal($fractalData);
+
+        // Check includes are added as optional properties
+        $this->assertArrayHasKey('posts', $schema['properties']['data']['properties']);
+        $this->assertArrayHasKey('profile', $schema['properties']['data']['properties']);
+
+        // Check types
+        $this->assertEquals('array', $schema['properties']['data']['properties']['posts']['type']);
+        $this->assertEquals('object', $schema['properties']['data']['properties']['profile']['type']);
+
+        // Check descriptions mention they are includes
+        $this->assertStringContainsString('Optional include', $schema['properties']['data']['properties']['posts']['description']);
+        $this->assertStringContainsString('Default include', $schema['properties']['data']['properties']['profile']['description']);
+    }
+
+    /** @test */
+    public function it_generates_collection_schema_for_fractal()
+    {
+        $fractalData = [
+            'type' => 'fractal',
+            'properties' => [
+                'id' => ['type' => 'integer', 'example' => 1],
+                'name' => ['type' => 'string', 'example' => 'John Doe'],
+            ],
+            'availableIncludes' => [],
+            'defaultIncludes' => [],
+        ];
+
+        $schema = $this->generator->generateFromFractal($fractalData, true);
+
+        $this->assertEquals('object', $schema['type']);
+        $this->assertArrayHasKey('data', $schema['properties']);
+        $this->assertEquals('array', $schema['properties']['data']['type']);
+        $this->assertArrayHasKey('items', $schema['properties']['data']);
+        $this->assertEquals('object', $schema['properties']['data']['items']['type']);
+    }
+
+    /** @test */
+    public function it_adds_pagination_metadata_for_collections()
+    {
+        $fractalData = [
+            'type' => 'fractal',
+            'properties' => [
+                'id' => ['type' => 'integer', 'example' => 1],
+            ],
+            'availableIncludes' => [],
+            'defaultIncludes' => [],
+        ];
+
+        $schema = $this->generator->generateFromFractal($fractalData, true, true);
+
+        $this->assertArrayHasKey('meta', $schema['properties']);
+        $this->assertArrayHasKey('pagination', $schema['properties']['meta']['properties']);
+
+        $pagination = $schema['properties']['meta']['properties']['pagination'];
+        $this->assertArrayHasKey('total', $pagination['properties']);
+        $this->assertArrayHasKey('count', $pagination['properties']);
+        $this->assertArrayHasKey('per_page', $pagination['properties']);
+        $this->assertArrayHasKey('current_page', $pagination['properties']);
+        $this->assertArrayHasKey('total_pages', $pagination['properties']);
+    }
+
+    /** @test */
+    public function it_handles_nested_properties_in_fractal()
+    {
+        $fractalData = [
+            'type' => 'fractal',
+            'properties' => [
+                'id' => ['type' => 'integer', 'example' => 1],
+                'data' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'primary' => ['type' => 'string', 'example' => 'primary data'],
+                        'secondary' => ['type' => 'string', 'example' => 'secondary data'],
+                    ],
+                ],
+                'flags' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'is_active' => ['type' => 'boolean', 'example' => true],
+                        'is_featured' => ['type' => 'boolean', 'example' => false],
+                    ],
+                ],
+            ],
+            'availableIncludes' => [],
+            'defaultIncludes' => [],
+        ];
+
+        $schema = $this->generator->generateFromFractal($fractalData);
+
+        $dataProperties = $schema['properties']['data']['properties'];
+
+        // Check nested object
+        $this->assertArrayHasKey('data', $dataProperties);
+        $this->assertEquals('object', $dataProperties['data']['type']);
+        $this->assertArrayHasKey('properties', $dataProperties['data']);
+        $this->assertArrayHasKey('primary', $dataProperties['data']['properties']);
+
+        // Check flags object
+        $this->assertArrayHasKey('flags', $dataProperties);
+        $this->assertEquals('object', $dataProperties['flags']['type']);
+        $this->assertArrayHasKey('is_active', $dataProperties['flags']['properties']);
+    }
+}


### PR DESCRIPTION
# 概要

Laravel PrismにFractal Transformer（https://fractal.thephpleague.com/）の解析機能を追加し、Fractalを使用したAPIエンドポイントのドキュメント自動生成を可能にします。

## 変更内容

Fractal Transformerの完全サポートを実装しました。

### 主な機能追加
- **FractalTransformerAnalyzer**: Fractal Transformerクラスを解析し、プロパティ、includes、defaultIncludesを抽出
- **ControllerAnalyzer拡張**: `fractal()`ヘルパーの使用を検出し、使用されているTransformerを特定
- **SchemaGenerator拡張**: FractalのデータをOpenAPIスキーマに変換（ページネーション対応含む）
- **設定ファイル**: Fractal固有の設定（シリアライザー、include処理方法など）を追加

### 実装の特徴
- AST（抽象構文木）解析による確実なTransformer構造の抽出
- `availableIncludes`と`defaultIncludes`の自動検出
- `include{Name}()`メソッドの解析と関連Transformerの特定
- ネストしたデータ構造とnullableフィールドの対応
- Laravel ResourceとFractalの共存サポート

### テスト
- 包括的なユニットテストを実装
- 様々なTransformerパターン（基本、includes付き、複雑な構造）をカバー
- PHPStanレベル5での静的解析をパス
- Laravel Pintによるコードフォーマット適用済み

## 関連情報

- Fractal公式ドキュメント: https://fractal.thephpleague.com/
- この実装により、Laravel ResourceとFractalの両方を使用するプロジェクトでAPIドキュメントの自動生成が可能になります