### PR TITLE
Document: Lumen 12.xサポートをREADMEに追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ php artisan prism:watch
 ## 🔧 Requirements
 
 - **PHP** 8.1 or higher
-- **Laravel** 10.x, 11.x, or 12.x / **Lumen** 10.x, 11.x
+- **Laravel** 10.x, 11.x, or 12.x / **Lumen** 10.x, 11.x, 12.x
 - **Composer** 2.0 or higher
 
 ## 📦 Installation


### PR DESCRIPTION
# 概要

READMEの要件セクションにLumen 12.xサポートを追加しました。

## 変更内容

要件セクションのLumenバージョン記載を更新：

- Lumen 10.x, 11.x → Lumen 10.x, 11.x, 12.x

## 関連情報

- Laravel PrismはLumen 12.xにも対応しているため、ドキュメントを更新