### PR TITLE
Bugfix: バナー更新ワークフローで任意のバージョン番号に対応

### DIFF
--- a/.github/workflows/update-banner.yml
+++ b/.github/workflows/update-banner.yml
@@ -41,7 +41,7 @@ jobs:
         git checkout -b $BRANCH_NAME
         
         # Update banner version
-        sed -i '/id="version"/s/v1\.0\.0/${{ steps.get_version.outputs.VERSION }}/g' assets/banner.svg
+        sed -i '/id="version"/s/v[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-zA-Z0-9]\+\)\?/${{ steps.get_version.outputs.VERSION }}/g' assets/banner.svg
         
         # Commit and push
         git add assets/banner.svg


### PR DESCRIPTION
# 概要

バナー更新ワークフローの`sed`コマンドが`v1.0.0`という固定値しか置換できない問題を修正しました。

## 変更内容

GitHub Actionsのバナー更新ワークフローを改善しました。

- `sed`コマンドの正規表現を修正し、任意のバージョン番号形式に対応
  - 対応形式: `v1.0.0`, `v10.2.3`, `v1.0.0-alpha`, `v2.1.0-beta1` など
  - セマンティックバージョニングに準拠した形式をサポート

## 関連情報

update-banner.ymlの44行目で指摘された問題の修正対応です。