### PR TITLE
Bugfix: OpenAPI 3.0仕様に準拠したパラメータ定義の修正

### DIFF
--- a/src/Analyzers/RouteAnalyzer.php
+++ b/src/Analyzers/RouteAnalyzer.php
@@ -101,7 +101,9 @@ class RouteAnalyzer
                 'name' => $name,
                 'required' => ! $isOptional,
                 'in' => 'path',
-                'type' => 'string', // デフォルト、後で型推論で上書き可能
+                'schema' => [
+                    'type' => 'string', // デフォルト、後で型推論で上書き可能
+                ],
             ];
         }
 


### PR DESCRIPTION
# 概要

RouteAnalyzerで生成されるパスパラメータの構造をOpenAPI 3.0仕様に準拠するよう修正しました。

## 変更内容

OpenAPI 3.0では、パラメータのtype属性はschemaオブジェクト内に配置する必要があります。

- RouteAnalyzerのextractRouteParametersメソッドで、type属性を直接設定していた箇所を修正
- type属性をschemaオブジェクト内に移動し、正しいOpenAPI 3.0形式に準拠

変更前:
```json
"parameters": [
    {
        "name": "post",
        "required": true,
        "in": "path",
        "type": "string"
    }
]
```

変更後:
```json
"parameters": [
    {
        "name": "post", 
        "required": true,
        "in": "path",
        "schema": {
            "type": "string"
        }
    }
]
```

## 関連情報

- OpenAPI 3.0仕様に準拠した正しいパラメータ定義形式への修正