### PR TITLE
Bugfix: spectrum:watchコマンドのWorkerMan起動エラーを修正

### DIFF
--- a/src/Console/WatchCommand.php
+++ b/src/Console/WatchCommand.php
@@ -41,6 +41,10 @@ class WatchCommand extends Command
         // Initial generation
         $this->call('spectrum:generate', ['--quiet' => true]);
 
+        // Set WorkerMan to daemon mode for development
+        global $argv;
+        $argv = ['spectrum:watch', 'start'];
+
         // Open browser
         if (! $this->option('no-open')) {
             $this->openBrowser("http://{$host}:{$port}");


### PR DESCRIPTION
# 概要

`php artisan spectrum:watch`実行時にWorkerManの起動引数が正しく設定されていない問題を修正しました。

## 変更内容

WorkerManの起動時に必要な`$argv`グローバル変数を適切に設定することで、spectrum:watchコマンドが正常に動作するように修正しました。

- WatchCommandのhandleメソッドで`$argv`グローバル変数に`['spectrum:watch', 'start']`を設定
- これによりWorkerManが正しいモードで起動されるようになりました

## 関連情報

- spectrum:watchコマンド実行時に表示されていたWorkerManのヘルプメッセージが解消されます