### PR TITLE
Bugfix: spectrum:watchコマンドでキャッシュ状態を可視化し、削除問題を解決

### DIFF
--- a/config/spectrum.php
+++ b/config/spectrum.php
@@ -160,7 +160,7 @@ return [
         | documentation generation.
         |
         */
-        'enabled' => env('PRISM_CACHE_ENABLED', true),
+        'enabled' => env('SPECTRUM_CACHE_ENABLED', true),
 
         /*
         |--------------------------------------------------------------------------
@@ -180,7 +180,7 @@ return [
         | Time to live for cache files in seconds. Set to null for no expiration.
         |
         */
-        'ttl' => env('PRISM_CACHE_TTL', null),
+        'ttl' => env('SPECTRUM_CACHE_TTL', null),
 
         /*
         |--------------------------------------------------------------------------
@@ -271,7 +271,7 @@ return [
         |--------------------------------------------------------------------------
         */
         'lumen' => [
-            'enabled' => env('PRISM_LUMEN_MODE', false),
+            'enabled' => env('SPECTRUM_LUMEN_MODE', false),
             'default_middleware' => ['api'], // Lumenのデフォルトミドルウェア
         ],
     ],

--- a/src/Cache/DocumentationCache.php
+++ b/src/Cache/DocumentationCache.php
@@ -231,10 +231,28 @@ class DocumentationCache
      */
     public function forget(string $key): bool
     {
+        // キャッシュが無効な場合は何もしない
+        if (!$this->enabled) {
+            return false;
+        }
+        
         $cacheFile = $this->getCachePath($key);
 
         if (File::exists($cacheFile)) {
-            return File::delete($cacheFile);
+            $result = File::delete($cacheFile);
+            
+            // デバッグ用のログ出力（開発環境のみ）
+            if (app()->environment('local') && config('app.debug')) {
+                $status = $result ? 'deleted' : 'failed to delete';
+                \Log::debug("DocumentationCache::forget({$key}) - File: {$cacheFile} - Status: {$status}");
+            }
+            
+            return $result;
+        }
+        
+        // デバッグ用のログ出力（開発環境のみ）
+        if (app()->environment('local') && config('app.debug')) {
+            \Log::debug("DocumentationCache::forget({$key}) - File not found: {$cacheFile}");
         }
 
         return false;
@@ -289,6 +307,7 @@ class DocumentationCache
         if (! File::isDirectory($this->cacheDir)) {
             return [
                 'enabled' => $this->enabled,
+                'cache_directory' => $this->cacheDir,
                 'total_files' => 0,
                 'total_size' => 0,
                 'total_size_human' => '0 B',
@@ -317,6 +336,7 @@ class DocumentationCache
 
         return [
             'enabled' => $this->enabled,
+            'cache_directory' => $this->cacheDir,
             'total_files' => count($files),
             'total_size' => $totalSize,
             'total_size_human' => $this->humanFilesize($totalSize),
@@ -372,4 +392,40 @@ class DocumentationCache
 
         return array_unique($dependencies);
     }
+    
+    /**
+     * 全てのキャッシュエントリのキーを取得
+     */
+    public function getAllCacheKeys(): array
+    {
+        if (! File::isDirectory($this->cacheDir)) {
+            return [];
+        }
+        
+        $keys = [];
+        $files = File::files($this->cacheDir);
+        
+        foreach ($files as $file) {
+            try {
+                $cacheData = unserialize(File::get($file->getPathname()));
+                $key = $cacheData['metadata']['key'] ?? null;
+                if ($key) {
+                    $keys[] = $key;
+                }
+            } catch (\Exception $e) {
+                // 無視
+            }
+        }
+        
+        return $keys;
+    }
+    
+    /**
+     * キャッシュが有効かどうかを確認
+     */
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
 }

--- a/src/Cache/DocumentationCache.php
+++ b/src/Cache/DocumentationCache.php
@@ -3,6 +3,7 @@
 namespace LaravelSpectrum\Cache;
 
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 
 class DocumentationCache
 {
@@ -232,27 +233,27 @@ class DocumentationCache
     public function forget(string $key): bool
     {
         // キャッシュが無効な場合は何もしない
-        if (!$this->enabled) {
+        if (! $this->enabled) {
             return false;
         }
-        
+
         $cacheFile = $this->getCachePath($key);
 
         if (File::exists($cacheFile)) {
             $result = File::delete($cacheFile);
-            
+
             // デバッグ用のログ出力（開発環境のみ）
             if (app()->environment('local') && config('app.debug')) {
                 $status = $result ? 'deleted' : 'failed to delete';
-                \Log::debug("DocumentationCache::forget({$key}) - File: {$cacheFile} - Status: {$status}");
+                Log::debug("DocumentationCache::forget({$key}) - File: {$cacheFile} - Status: {$status}");
             }
-            
+
             return $result;
         }
-        
+
         // デバッグ用のログ出力（開発環境のみ）
         if (app()->environment('local') && config('app.debug')) {
-            \Log::debug("DocumentationCache::forget({$key}) - File not found: {$cacheFile}");
+            Log::debug("DocumentationCache::forget({$key}) - File not found: {$cacheFile}");
         }
 
         return false;
@@ -392,7 +393,7 @@ class DocumentationCache
 
         return array_unique($dependencies);
     }
-    
+
     /**
      * 全てのキャッシュエントリのキーを取得
      */
@@ -401,10 +402,10 @@ class DocumentationCache
         if (! File::isDirectory($this->cacheDir)) {
             return [];
         }
-        
+
         $keys = [];
         $files = File::files($this->cacheDir);
-        
+
         foreach ($files as $file) {
             try {
                 $cacheData = unserialize(File::get($file->getPathname()));
@@ -416,10 +417,10 @@ class DocumentationCache
                 // 無視
             }
         }
-        
+
         return $keys;
     }
-    
+
     /**
      * キャッシュが有効かどうかを確認
      */
@@ -427,5 +428,4 @@ class DocumentationCache
     {
         return $this->enabled;
     }
-
 }

--- a/src/Console/WatchCommand.php
+++ b/src/Console/WatchCommand.php
@@ -38,7 +38,7 @@ class WatchCommand extends Command
         $port = (int) $this->option('port');
 
         $this->info('🚀 Starting Laravel Spectrum preview server...');
-        
+
         // キャッシュ状態を確認
         $this->checkCacheStatus();
 
@@ -115,7 +115,7 @@ class WatchCommand extends Command
         if (str_contains($path, 'Requests')) {
             $className = $this->getClassNameFromPath($path);
             $cacheKey = "form_request:{$className}";
-            
+
             if ($this->cache->forget($cacheKey)) {
                 $clearedCount++;
                 $this->info("  🧹 Cleared cache for FormRequest: {$className}");
@@ -128,7 +128,7 @@ class WatchCommand extends Command
         elseif (str_contains($path, 'Resources')) {
             $className = $this->getClassNameFromPath($path);
             $cacheKey = "resource:{$className}";
-            
+
             if ($this->cache->forget($cacheKey)) {
                 $clearedCount++;
                 $this->info("  🧹 Cleared cache for Resource: {$className}");
@@ -150,7 +150,7 @@ class WatchCommand extends Command
             if ($this->cache->forget('routes:all')) {
                 $clearedCount++;
                 $this->info('  🧹 Cleared routes cache');
-                
+
                 // 追加のデバッグ情報
                 if ($this->option('verbose')) {
                     $this->checkCacheAfterClear();
@@ -165,7 +165,7 @@ class WatchCommand extends Command
             if ($this->cache->forget('routes:all')) {
                 $clearedCount++;
                 $this->info('  🧹 Cleared routes cache (Controller changed)');
-                
+
                 // 追加のデバッグ情報
                 if ($this->option('verbose')) {
                     $this->checkCacheAfterClear();
@@ -181,16 +181,16 @@ class WatchCommand extends Command
             $this->info("  ✅ Total cleared: {$clearedCount} cache entries");
         }
     }
-    
+
     private function checkCacheAfterClear(): void
     {
         try {
             $reflection = new \ReflectionProperty($this->cache, 'cacheDir');
             $reflection->setAccessible(true);
             $cacheDir = $reflection->getValue($this->cache);
-            
+
             if (is_dir($cacheDir)) {
-                $files = glob($cacheDir . '/*.cache');
+                $files = glob($cacheDir.'/*.cache');
                 $count = count($files);
                 $this->info("  📊 Remaining cache entries: {$count}");
             }
@@ -227,47 +227,48 @@ class WatchCommand extends Command
             exec($command);
         }
     }
-    
+
     private function checkCacheStatus(): void
     {
         $cacheEnabled = config('spectrum.cache.enabled', true);
-        
-        if (!$cacheEnabled) {
+
+        if (! $cacheEnabled) {
             $this->warn('⚠️  Cache is disabled. Enable it in config/spectrum.php for better performance.');
+
             return;
         }
-        
+
         // DocumentationCacheのstatusを確認
         try {
             $reflection = new \ReflectionProperty($this->cache, 'enabled');
             $reflection->setAccessible(true);
             $isEnabled = $reflection->getValue($this->cache);
-            
+
             $reflection = new \ReflectionProperty($this->cache, 'cacheDir');
             $reflection->setAccessible(true);
             $cacheDir = $reflection->getValue($this->cache);
-            
+
             $this->info("📁 Cache directory: {$cacheDir}");
-            $this->info("💾 Cache enabled: " . ($isEnabled ? 'Yes' : 'No'));
-            
+            $this->info('💾 Cache enabled: '.($isEnabled ? 'Yes' : 'No'));
+
             if (is_dir($cacheDir)) {
-                $files = glob($cacheDir . '/*.cache');
+                $files = glob($cacheDir.'/*.cache');
                 $count = count($files);
                 $this->info("📊 Cached entries: {$count}");
-                
+
                 // 全てのキャッシュキーを表示
                 if ($count > 0) {
                     $keys = $this->cache->getAllCacheKeys();
-                    $this->info("📋 Cache keys:");
+                    $this->info('📋 Cache keys:');
                     foreach ($keys as $key) {
                         $this->info("   - {$key}");
                     }
                 }
             } else {
-                $this->info("📊 Cache directory does not exist yet");
+                $this->info('📊 Cache directory does not exist yet');
             }
         } catch (\Exception $e) {
-            $this->error("Failed to check cache status: " . $e->getMessage());
+            $this->error('Failed to check cache status: '.$e->getMessage());
         }
     }
 }

--- a/src/Console/WatchCommand.php
+++ b/src/Console/WatchCommand.php
@@ -13,7 +13,8 @@ class WatchCommand extends Command
     protected $signature = 'spectrum:watch
                             {--port=8080 : Port for the preview server}
                             {--host=127.0.0.1 : Host for the preview server}
-                            {--no-open : Don\'t open browser automatically}';
+                            {--no-open : Don\'t open browser automatically}
+                            {--verbose : Show detailed cache information}';
 
     protected $description = 'Start real-time documentation preview';
 
@@ -37,6 +38,9 @@ class WatchCommand extends Command
         $port = (int) $this->option('port');
 
         $this->info('🚀 Starting Laravel Spectrum preview server...');
+        
+        // キャッシュ状態を確認
+        $this->checkCacheStatus();
 
         // Initial generation (キャッシュ有効)
         $this->call('spectrum:generate', ['--quiet' => true]);
@@ -110,25 +114,34 @@ class WatchCommand extends Command
         // For FormRequests
         if (str_contains($path, 'Requests')) {
             $className = $this->getClassNameFromPath($path);
-            if ($this->cache->forget("form_request:{$className}")) {
+            $cacheKey = "form_request:{$className}";
+            
+            if ($this->cache->forget($cacheKey)) {
                 $clearedCount++;
                 $this->info("  🧹 Cleared cache for FormRequest: {$className}");
+            } else {
+                $this->info("  ℹ️  No cache found for FormRequest: {$className}");
             }
         }
 
         // For Resources
         elseif (str_contains($path, 'Resources')) {
             $className = $this->getClassNameFromPath($path);
-            if ($this->cache->forget("resource:{$className}")) {
+            $cacheKey = "resource:{$className}";
+            
+            if ($this->cache->forget($cacheKey)) {
                 $clearedCount++;
                 $this->info("  🧹 Cleared cache for Resource: {$className}");
+            } else {
+                $this->info("  ℹ️  No cache found for Resource: {$className}");
             }
 
             // Resourceが他のResourceに依存している可能性があるため、
             // このResourceを使用している可能性のある他のResourceのキャッシュもクリア
-            $clearedCount += $this->cache->forgetByPattern('resource:');
-            if ($clearedCount > 1) {
-                $this->info('  🧹 Cleared related Resource caches');
+            $relatedCount = $this->cache->forgetByPattern('resource:');
+            if ($relatedCount > 0) {
+                $clearedCount += $relatedCount;
+                $this->info("  🧹 Cleared {$relatedCount} related Resource caches");
             }
         }
 
@@ -137,6 +150,13 @@ class WatchCommand extends Command
             if ($this->cache->forget('routes:all')) {
                 $clearedCount++;
                 $this->info('  🧹 Cleared routes cache');
+                
+                // 追加のデバッグ情報
+                if ($this->option('verbose')) {
+                    $this->checkCacheAfterClear();
+                }
+            } else {
+                $this->info('  ℹ️  No routes cache found to clear');
             }
         }
 
@@ -145,11 +165,37 @@ class WatchCommand extends Command
             if ($this->cache->forget('routes:all')) {
                 $clearedCount++;
                 $this->info('  🧹 Cleared routes cache (Controller changed)');
+                
+                // 追加のデバッグ情報
+                if ($this->option('verbose')) {
+                    $this->checkCacheAfterClear();
+                }
+            } else {
+                $this->info('  ℹ️  No routes cache found to clear (Controller changed)');
             }
         }
 
         if ($clearedCount === 0) {
-            $this->info('  ℹ️  No cache entries to clear');
+            $this->info('  ℹ️  No cache entries were cleared');
+        } else {
+            $this->info("  ✅ Total cleared: {$clearedCount} cache entries");
+        }
+    }
+    
+    private function checkCacheAfterClear(): void
+    {
+        try {
+            $reflection = new \ReflectionProperty($this->cache, 'cacheDir');
+            $reflection->setAccessible(true);
+            $cacheDir = $reflection->getValue($this->cache);
+            
+            if (is_dir($cacheDir)) {
+                $files = glob($cacheDir . '/*.cache');
+                $count = count($files);
+                $this->info("  📊 Remaining cache entries: {$count}");
+            }
+        } catch (\Exception $e) {
+            // 無視
         }
     }
 
@@ -179,6 +225,49 @@ class WatchCommand extends Command
 
         if ($command) {
             exec($command);
+        }
+    }
+    
+    private function checkCacheStatus(): void
+    {
+        $cacheEnabled = config('spectrum.cache.enabled', true);
+        
+        if (!$cacheEnabled) {
+            $this->warn('⚠️  Cache is disabled. Enable it in config/spectrum.php for better performance.');
+            return;
+        }
+        
+        // DocumentationCacheのstatusを確認
+        try {
+            $reflection = new \ReflectionProperty($this->cache, 'enabled');
+            $reflection->setAccessible(true);
+            $isEnabled = $reflection->getValue($this->cache);
+            
+            $reflection = new \ReflectionProperty($this->cache, 'cacheDir');
+            $reflection->setAccessible(true);
+            $cacheDir = $reflection->getValue($this->cache);
+            
+            $this->info("📁 Cache directory: {$cacheDir}");
+            $this->info("💾 Cache enabled: " . ($isEnabled ? 'Yes' : 'No'));
+            
+            if (is_dir($cacheDir)) {
+                $files = glob($cacheDir . '/*.cache');
+                $count = count($files);
+                $this->info("📊 Cached entries: {$count}");
+                
+                // 全てのキャッシュキーを表示
+                if ($count > 0) {
+                    $keys = $this->cache->getAllCacheKeys();
+                    $this->info("📋 Cache keys:");
+                    foreach ($keys as $key) {
+                        $this->info("   - {$key}");
+                    }
+                }
+            } else {
+                $this->info("📊 Cache directory does not exist yet");
+            }
+        } catch (\Exception $e) {
+            $this->error("Failed to check cache status: " . $e->getMessage());
         }
     }
 }

--- a/tests/Unit/Console/WatchCommandTest.php
+++ b/tests/Unit/Console/WatchCommandTest.php
@@ -55,12 +55,13 @@ class WatchCommandTest extends TestCase
             {
                 // Do nothing
             }
-            
+
             public function option($key = null)
             {
                 if ($key === 'verbose') {
                     return false;
                 }
+
                 return null;
             }
         };
@@ -114,12 +115,13 @@ class WatchCommandTest extends TestCase
             {
                 // Do nothing
             }
-            
+
             public function option($key = null)
             {
                 if ($key === 'verbose') {
                     return false;
                 }
+
                 return null;
             }
         };
@@ -177,12 +179,13 @@ class WatchCommandTest extends TestCase
             {
                 // Do nothing
             }
-            
+
             public function option($key = null)
             {
                 if ($key === 'verbose') {
                     return false;
                 }
+
                 return null;
             }
         };
@@ -234,12 +237,13 @@ class WatchCommandTest extends TestCase
             {
                 // Do nothing
             }
-            
+
             public function option($key = null)
             {
                 if ($key === 'verbose') {
                     return false;
                 }
+
                 return null;
             }
         };

--- a/tests/Unit/Console/WatchCommandTest.php
+++ b/tests/Unit/Console/WatchCommandTest.php
@@ -55,6 +55,14 @@ class WatchCommandTest extends TestCase
             {
                 // Do nothing
             }
+            
+            public function option($key = null)
+            {
+                if ($key === 'verbose') {
+                    return false;
+                }
+                return null;
+            }
         };
 
         // Test FormRequest cache clearing
@@ -105,6 +113,14 @@ class WatchCommandTest extends TestCase
             public function info($string, $verbosity = null)
             {
                 // Do nothing
+            }
+            
+            public function option($key = null)
+            {
+                if ($key === 'verbose') {
+                    return false;
+                }
+                return null;
             }
         };
 
@@ -161,6 +177,14 @@ class WatchCommandTest extends TestCase
             {
                 // Do nothing
             }
+            
+            public function option($key = null)
+            {
+                if ($key === 'verbose') {
+                    return false;
+                }
+                return null;
+            }
         };
 
         // Test routes cache clearing
@@ -209,6 +233,14 @@ class WatchCommandTest extends TestCase
             public function info($string, $verbosity = null)
             {
                 // Do nothing
+            }
+            
+            public function option($key = null)
+            {
+                if ($key === 'verbose') {
+                    return false;
+                }
+                return null;
             }
         };
 

--- a/tests/Unit/DocumentationCacheTest.php
+++ b/tests/Unit/DocumentationCacheTest.php
@@ -271,11 +271,12 @@ class DependencyResource {
     {
         // キャッシュにデータを保存
         $this->cache->remember('routes:all', fn () => ['route1', 'route2']);
-        
+
         // キャッシュが存在することを確認
         $callCount = 0;
         $this->cache->remember('routes:all', function () use (&$callCount) {
             $callCount++;
+
             return ['route3'];
         });
         $this->assertEquals(0, $callCount); // キャッシュから取得
@@ -288,6 +289,7 @@ class DependencyResource {
         $callCount = 0;
         $data = $this->cache->remember('routes:all', function () use (&$callCount) {
             $callCount++;
+
             return ['route3'];
         });
         $this->assertEquals(1, $callCount); // コールバックが実行される
@@ -318,6 +320,7 @@ class DependencyResource {
         $callCount = 0;
         $this->cache->remember('resource:UserResource', function () use (&$callCount) {
             $callCount++;
+
             return ['new_user'];
         });
         $this->assertEquals(1, $callCount);
@@ -326,6 +329,7 @@ class DependencyResource {
         $callCount = 0;
         $this->cache->remember('form_request:UserRequest', function () use (&$callCount) {
             $callCount++;
+
             return ['new_request'];
         });
         $this->assertEquals(0, $callCount); // キャッシュから取得

--- a/tests/Unit/DocumentationCacheTest.php
+++ b/tests/Unit/DocumentationCacheTest.php
@@ -265,4 +265,69 @@ class DependencyResource {
 
         $this->assertEquals(1, $callCount);
     }
+
+    /** @test */
+    public function it_forgets_cache_entries()
+    {
+        // キャッシュにデータを保存
+        $this->cache->remember('routes:all', fn () => ['route1', 'route2']);
+        
+        // キャッシュが存在することを確認
+        $callCount = 0;
+        $this->cache->remember('routes:all', function () use (&$callCount) {
+            $callCount++;
+            return ['route3'];
+        });
+        $this->assertEquals(0, $callCount); // キャッシュから取得
+
+        // キャッシュを削除
+        $result = $this->cache->forget('routes:all');
+        $this->assertTrue($result);
+
+        // キャッシュが削除されたことを確認
+        $callCount = 0;
+        $data = $this->cache->remember('routes:all', function () use (&$callCount) {
+            $callCount++;
+            return ['route3'];
+        });
+        $this->assertEquals(1, $callCount); // コールバックが実行される
+        $this->assertEquals(['route3'], $data);
+    }
+
+    /** @test */
+    public function it_returns_false_when_forgetting_non_existent_cache()
+    {
+        $result = $this->cache->forget('non_existent_key');
+        $this->assertFalse($result);
+    }
+
+    /** @test */
+    public function it_forgets_cache_by_pattern()
+    {
+        // 複数のリソースキャッシュを作成
+        $this->cache->remember('resource:UserResource', fn () => ['user']);
+        $this->cache->remember('resource:PostResource', fn () => ['post']);
+        $this->cache->remember('resource:CommentResource', fn () => ['comment']);
+        $this->cache->remember('form_request:UserRequest', fn () => ['request']);
+
+        // パターンマッチでresource:*を削除
+        $count = $this->cache->forgetByPattern('resource:');
+        $this->assertEquals(3, $count);
+
+        // リソースキャッシュが削除されたことを確認
+        $callCount = 0;
+        $this->cache->remember('resource:UserResource', function () use (&$callCount) {
+            $callCount++;
+            return ['new_user'];
+        });
+        $this->assertEquals(1, $callCount);
+
+        // フォームリクエストキャッシュは残っていることを確認
+        $callCount = 0;
+        $this->cache->remember('form_request:UserRequest', function () use (&$callCount) {
+            $callCount++;
+            return ['new_request'];
+        });
+        $this->assertEquals(0, $callCount); // キャッシュから取得
+    }
 }


### PR DESCRIPTION
# 概要

`php artisan spectrum:watch` 実行時にキャッシュの削除ログは表示されるが、実際にはキャッシュが削除されていない問題を修正しました。キャッシュの状態を可視化し、デバッグしやすくしました。

## 変更内容

spectrum:watchコマンドのキャッシュ処理を改善し、状態の可視化とデバッグ機能を追加

- 環境変数名をPRISM_*からSPECTRUM_*に統一
- DocumentationCacheにデバッグログ機能を追加（開発環境のみ）
- 全キャッシュキーを取得する`getAllCacheKeys()`メソッドを追加
- キャッシュ有効状態を確認する`isEnabled()`メソッドを追加
- WatchCommandに`--verbose`オプションを追加し、詳細なキャッシュ情報を表示
- 起動時にキャッシュの状態（有効/無効、ディレクトリ、エントリ数）を表示
- キャッシュ削除時に成功/失敗を明確に区別して表示
- キャッシュ削除後の残りファイル数を表示
- DocumentationCacheTestに新機能のテストを追加

## 関連情報

- spectrum:watchコマンドでキャッシュが適切に削除されない問題を解決
- `php artisan spectrum:watch --verbose`で詳細なキャッシュ情報を確認可能