### PR TITLE
Bugfix: spectrum:watchコマンドの--verboseオプション重複エラーを修正

### DIFF
--- a/src/Console/WatchCommand.php
+++ b/src/Console/WatchCommand.php
@@ -13,8 +13,7 @@ class WatchCommand extends Command
     protected $signature = 'spectrum:watch
                             {--port=8080 : Port for the preview server}
                             {--host=127.0.0.1 : Host for the preview server}
-                            {--no-open : Don\'t open browser automatically}
-                            {--verbose : Show detailed cache information}';
+                            {--no-open : Don\'t open browser automatically}';
 
     protected $description = 'Start real-time documentation preview';
 
@@ -152,7 +151,7 @@ class WatchCommand extends Command
                 $this->info('  🧹 Cleared routes cache');
 
                 // 追加のデバッグ情報
-                if ($this->option('verbose')) {
+                if ($this->output->isVerbose()) {
                     $this->checkCacheAfterClear();
                 }
             } else {
@@ -167,7 +166,7 @@ class WatchCommand extends Command
                 $this->info('  🧹 Cleared routes cache (Controller changed)');
 
                 // 追加のデバッグ情報
-                if ($this->option('verbose')) {
+                if ($this->output->isVerbose()) {
                     $this->checkCacheAfterClear();
                 }
             } else {
@@ -256,8 +255,8 @@ class WatchCommand extends Command
                 $count = count($files);
                 $this->info("📊 Cached entries: {$count}");
 
-                // 全てのキャッシュキーを表示
-                if ($count > 0) {
+                // 全てのキャッシュキーを表示（verboseモード時のみ）
+                if ($count > 0 && $this->output->isVerbose()) {
                     $keys = $this->cache->getAllCacheKeys();
                     $this->info('📋 Cache keys:');
                     foreach ($keys as $key) {

--- a/tests/Unit/Console/WatchCommandTest.php
+++ b/tests/Unit/Console/WatchCommandTest.php
@@ -56,13 +56,15 @@ class WatchCommandTest extends TestCase
                 // Do nothing
             }
 
-            public function option($key = null)
+            public function __construct($fileWatcher, $server, $cache)
             {
-                if ($key === 'verbose') {
-                    return false;
-                }
-
-                return null;
+                parent::__construct($fileWatcher, $server, $cache);
+                $this->output = new class {
+                    public function isVerbose()
+                    {
+                        return false;
+                    }
+                };
             }
         };
 
@@ -116,13 +118,15 @@ class WatchCommandTest extends TestCase
                 // Do nothing
             }
 
-            public function option($key = null)
+            public function __construct($fileWatcher, $server, $cache)
             {
-                if ($key === 'verbose') {
-                    return false;
-                }
-
-                return null;
+                parent::__construct($fileWatcher, $server, $cache);
+                $this->output = new class {
+                    public function isVerbose()
+                    {
+                        return false;
+                    }
+                };
             }
         };
 
@@ -180,13 +184,15 @@ class WatchCommandTest extends TestCase
                 // Do nothing
             }
 
-            public function option($key = null)
+            public function __construct($fileWatcher, $server, $cache)
             {
-                if ($key === 'verbose') {
-                    return false;
-                }
-
-                return null;
+                parent::__construct($fileWatcher, $server, $cache);
+                $this->output = new class {
+                    public function isVerbose()
+                    {
+                        return false;
+                    }
+                };
             }
         };
 
@@ -238,13 +244,15 @@ class WatchCommandTest extends TestCase
                 // Do nothing
             }
 
-            public function option($key = null)
+            public function __construct($fileWatcher, $server, $cache)
             {
-                if ($key === 'verbose') {
-                    return false;
-                }
-
-                return null;
+                parent::__construct($fileWatcher, $server, $cache);
+                $this->output = new class {
+                    public function isVerbose()
+                    {
+                        return false;
+                    }
+                };
             }
         };
 

--- a/tests/Unit/Console/WatchCommandTest.php
+++ b/tests/Unit/Console/WatchCommandTest.php
@@ -59,7 +59,8 @@ class WatchCommandTest extends TestCase
             public function __construct($fileWatcher, $server, $cache)
             {
                 parent::__construct($fileWatcher, $server, $cache);
-                $this->output = new class {
+                $this->output = new class
+                {
                     public function isVerbose()
                     {
                         return false;
@@ -121,7 +122,8 @@ class WatchCommandTest extends TestCase
             public function __construct($fileWatcher, $server, $cache)
             {
                 parent::__construct($fileWatcher, $server, $cache);
-                $this->output = new class {
+                $this->output = new class
+                {
                     public function isVerbose()
                     {
                         return false;
@@ -187,7 +189,8 @@ class WatchCommandTest extends TestCase
             public function __construct($fileWatcher, $server, $cache)
             {
                 parent::__construct($fileWatcher, $server, $cache);
-                $this->output = new class {
+                $this->output = new class
+                {
                     public function isVerbose()
                     {
                         return false;
@@ -247,7 +250,8 @@ class WatchCommandTest extends TestCase
             public function __construct($fileWatcher, $server, $cache)
             {
                 parent::__construct($fileWatcher, $server, $cache);
-                $this->output = new class {
+                $this->output = new class
+                {
                     public function isVerbose()
                     {
                         return false;


### PR DESCRIPTION
# 概要

`php artisan spectrum:watch`実行時に「An option named "verbose" already exists」というエラーが発生する問題を修正しました。

## 変更内容

LaravelのCommandクラスで既に定義されている--verboseオプションとの重複を解消

- WatchCommandから重複する`--verbose`オプションの定義を削除
- `$this->option('verbose')`を`$this->output->isVerbose()`に変更して正しくverboseモードを確認
- テストでモックを更新し、outputプロパティとisVerbose()メソッドを適切にモック

## 関連情報

- LaravelのCommandクラスには既に`--verbose`オプションが定義されているため、独自に定義すると重複エラーが発生
- 修正後は`-v`または`--verbose`オプションで詳細なキャッシュ情報を表示可能