### PR TITLE
Bugfix: spectrum:watchでキャッシュ削除後も変更が反映されない問題を修正

### DIFF
--- a/config/spectrum.php
+++ b/config/spectrum.php
@@ -170,7 +170,9 @@ return [
         | The directory where cache files will be stored.
         |
         */
-        'directory' => storage_path('app/spectrum/cache'),
+        'directory' => function_exists('storage_path')
+            ? storage_path('app/spectrum/cache')
+            : getcwd().'/storage/spectrum/cache',
 
         /*
         |--------------------------------------------------------------------------

--- a/src/Cache/DocumentationCache.php
+++ b/src/Cache/DocumentationCache.php
@@ -13,7 +13,12 @@ class DocumentationCache
 
     public function __construct()
     {
-        $this->cacheDir = config('spectrum.cache.directory', storage_path('app/spectrum/cache'));
+        // パッケージ開発環境と通常環境の両方に対応
+        $defaultCacheDir = function_exists('storage_path')
+            ? storage_path('app/spectrum/cache')
+            : getcwd().'/storage/spectrum/cache';
+
+        $this->cacheDir = config('spectrum.cache.directory', $defaultCacheDir);
         $this->enabled = config('spectrum.cache.enabled', true);
 
         if ($this->enabled) {

--- a/src/Console/GenerateDocsCommand.php
+++ b/src/Console/GenerateDocsCommand.php
@@ -73,9 +73,22 @@ class GenerateDocsCommand extends Command
 
         // ファイルの保存
         $content = $this->formatOutput($openapi, $this->option('format'));
-        File::put($outputPath, $content);
+        $result = File::put($outputPath, $content);
+
+        if ($result === false) {
+            $this->error("❌ Failed to write documentation to: {$outputPath}");
+
+            return 1;
+        }
 
         $this->info("✅ Documentation generated: {$outputPath}");
+
+        // デバッグ情報
+        if (! $this->option('quiet')) {
+            $fileSize = File::size($outputPath);
+            $this->info('   📁 File size: '.number_format($fileSize).' bytes');
+            $this->info('   📍 Absolute path: '.realpath($outputPath));
+        }
 
         $endTime = microtime(true);
         $duration = round($endTime - $startTime, 2);
@@ -95,7 +108,16 @@ class GenerateDocsCommand extends Command
     {
         $format = $this->option('format');
 
-        return storage_path("app/spectrum/openapi.{$format}");
+        // パッケージ開発環境かどうかを判定
+        if (function_exists('storage_path')) {
+            return storage_path("app/spectrum/openapi.{$format}");
+        }
+
+        // パッケージ開発環境の場合は、現在のディレクトリに生成
+        $outputDir = getcwd().'/storage/spectrum';
+        File::ensureDirectoryExists($outputDir);
+
+        return $outputDir."/openapi.{$format}";
     }
 
     protected function formatOutput(array $openapi, string $format): string

--- a/tests/Unit/Console/WatchCommandTest.php
+++ b/tests/Unit/Console/WatchCommandTest.php
@@ -55,6 +55,11 @@ class WatchCommandTest extends TestCase
             {
                 // Do nothing
             }
+            
+            public function error($string, $verbosity = null)
+            {
+                // Do nothing
+            }
 
             public function __construct($fileWatcher, $server, $cache)
             {
@@ -64,6 +69,11 @@ class WatchCommandTest extends TestCase
                     public function isVerbose()
                     {
                         return false;
+                    }
+                    
+                    public function writeln($messages, $options = 0)
+                    {
+                        // Do nothing
                     }
                 };
             }
@@ -90,7 +100,7 @@ class WatchCommandTest extends TestCase
         $method->invoke($command, base_path('app/Http/Requests/TestRequest.php'), 'modified');
 
         $this->assertTrue($command->callInvoked);
-        $this->assertEquals(['--quiet' => true], $command->callArguments);
+        $this->assertEquals([], $command->callArguments);
     }
 
     public function test_handle_file_change_clears_cache_and_regenerates_for_resources(): void
@@ -118,6 +128,11 @@ class WatchCommandTest extends TestCase
             {
                 // Do nothing
             }
+            
+            public function error($string, $verbosity = null)
+            {
+                // Do nothing
+            }
 
             public function __construct($fileWatcher, $server, $cache)
             {
@@ -127,6 +142,11 @@ class WatchCommandTest extends TestCase
                     public function isVerbose()
                     {
                         return false;
+                    }
+                    
+                    public function writeln($messages, $options = 0)
+                    {
+                        // Do nothing
                     }
                 };
             }
@@ -157,7 +177,7 @@ class WatchCommandTest extends TestCase
         $method->invoke($command, base_path('app/Http/Resources/UserResource.php'), 'modified');
 
         $this->assertTrue($command->callInvoked);
-        $this->assertEquals(['--quiet' => true], $command->callArguments);
+        $this->assertEquals([], $command->callArguments);
     }
 
     public function test_handle_file_change_clears_cache_and_regenerates_for_routes(): void
@@ -185,6 +205,11 @@ class WatchCommandTest extends TestCase
             {
                 // Do nothing
             }
+            
+            public function error($string, $verbosity = null)
+            {
+                // Do nothing
+            }
 
             public function __construct($fileWatcher, $server, $cache)
             {
@@ -194,6 +219,11 @@ class WatchCommandTest extends TestCase
                     public function isVerbose()
                     {
                         return false;
+                    }
+                    
+                    public function writeln($messages, $options = 0)
+                    {
+                        // Do nothing
                     }
                 };
             }
@@ -218,7 +248,7 @@ class WatchCommandTest extends TestCase
         $method->invoke($command, base_path('routes/api.php'), 'modified');
 
         $this->assertTrue($command->callInvoked);
-        $this->assertEquals(['--quiet' => true], $command->callArguments);
+        $this->assertEquals([], $command->callArguments);
     }
 
     public function test_handle_file_change_clears_cache_for_controllers(): void
@@ -246,6 +276,11 @@ class WatchCommandTest extends TestCase
             {
                 // Do nothing
             }
+            
+            public function error($string, $verbosity = null)
+            {
+                // Do nothing
+            }
 
             public function __construct($fileWatcher, $server, $cache)
             {
@@ -255,6 +290,11 @@ class WatchCommandTest extends TestCase
                     public function isVerbose()
                     {
                         return false;
+                    }
+                    
+                    public function writeln($messages, $options = 0)
+                    {
+                        // Do nothing
                     }
                 };
             }
@@ -279,7 +319,7 @@ class WatchCommandTest extends TestCase
         $method->invoke($command, base_path('app/Http/Controllers/UserController.php'), 'modified');
 
         $this->assertTrue($command->callInvoked);
-        $this->assertEquals(['--quiet' => true], $command->callArguments);
+        $this->assertEquals([], $command->callArguments);
     }
 
     public function test_get_class_name_from_path(): void

--- a/tests/Unit/Console/WatchCommandTest.php
+++ b/tests/Unit/Console/WatchCommandTest.php
@@ -55,7 +55,7 @@ class WatchCommandTest extends TestCase
             {
                 // Do nothing
             }
-            
+
             public function error($string, $verbosity = null)
             {
                 // Do nothing
@@ -70,7 +70,7 @@ class WatchCommandTest extends TestCase
                     {
                         return false;
                     }
-                    
+
                     public function writeln($messages, $options = 0)
                     {
                         // Do nothing
@@ -128,7 +128,7 @@ class WatchCommandTest extends TestCase
             {
                 // Do nothing
             }
-            
+
             public function error($string, $verbosity = null)
             {
                 // Do nothing
@@ -143,7 +143,7 @@ class WatchCommandTest extends TestCase
                     {
                         return false;
                     }
-                    
+
                     public function writeln($messages, $options = 0)
                     {
                         // Do nothing
@@ -205,7 +205,7 @@ class WatchCommandTest extends TestCase
             {
                 // Do nothing
             }
-            
+
             public function error($string, $verbosity = null)
             {
                 // Do nothing
@@ -220,7 +220,7 @@ class WatchCommandTest extends TestCase
                     {
                         return false;
                     }
-                    
+
                     public function writeln($messages, $options = 0)
                     {
                         // Do nothing
@@ -276,7 +276,7 @@ class WatchCommandTest extends TestCase
             {
                 // Do nothing
             }
-            
+
             public function error($string, $verbosity = null)
             {
                 // Do nothing
@@ -291,7 +291,7 @@ class WatchCommandTest extends TestCase
                     {
                         return false;
                     }
-                    
+
                     public function writeln($messages, $options = 0)
                     {
                         // Do nothing


### PR DESCRIPTION
# 概要

`php artisan spectrum:watch`実行時に、キャッシュは削除されているのにlocalhost側に変更が反映されない問題を修正しました。パッケージ開発環境での`storage_path()`関数の互換性問題とデバッグ機能を追加しました。

## 変更内容

パッケージ開発環境での互換性対応とデバッグ機能の強化

- **storage_path()関数の互換性対応**
  - DocumentationCache、GenerateDocsCommand、LiveReloadServer、config/spectrum.phpで`function_exists('storage_path')`によるチェックを追加
  - パッケージ開発環境では`getcwd() . '/storage/spectrum'`を使用

- **デバッグ機能の追加**
  - GenerateDocsCommand: ファイル書き込みエラーチェック、ファイルサイズと絶対パスの表示
  - WatchCommand: 生成されたファイルの存在確認、ファイルパスとサイズの表示
  - `--quiet`オプションを削除して詳細な情報を表示

- **ブラウザキャッシュ対策の強化**
  - LiveReloadServer: Fetch APIで`cache: 'no-cache'`を使用
  - Swagger UIのspecを直接更新する方式に変更

## 関連情報

- キャッシュ削除後もlocalhost側に変更が反映されない問題を解決
- パッケージ開発環境でのファイルパス解決問題に対応
- デバッグ情報により問題の原因を特定しやすくなりました