### PR TITLE
Bugfix: watchモードでルートファイル変更が反映されない問題を修正

### DIFF
--- a/src/Console/WatchCommand.php
+++ b/src/Console/WatchCommand.php
@@ -88,7 +88,7 @@ class WatchCommand extends Command
             $allKeys = $this->cache->getAllCacheKeys();
             $hasRoutesCache = in_array('routes:all', $allKeys);
             $this->info('  📊 Routes cache still exists: '.($hasRoutesCache ? 'Yes ⚠️' : 'No ✅'));
-            
+
             if ($hasRoutesCache) {
                 $this->warn('  ⚠️  Routes cache was not properly cleared!');
             }
@@ -97,7 +97,7 @@ class WatchCommand extends Command
         // Regenerate (キャッシュ有効で差分更新)
         $startTime = microtime(true);
         $this->info('  🔄 Regenerating documentation...');
-        
+
         // 強制的にキャッシュを無効化するオプションを追加
         if (str_contains($path, 'routes')) {
             $this->info('  💨 Forcing route cache refresh...');
@@ -105,7 +105,7 @@ class WatchCommand extends Command
             $this->cache->clear();
             $this->info('  🧹 All caches cleared for route changes');
         }
-        
+
         $exitCode = $this->call('spectrum:generate');
         $duration = round(microtime(true) - $startTime, 2);
 

--- a/src/Services/LiveReloadServer.php
+++ b/src/Services/LiveReloadServer.php
@@ -61,13 +61,13 @@ class LiveReloadServer
                     if (file_exists($jsonPath)) {
                         // ファイルシステムキャッシュをクリア
                         clearstatcache(true, $jsonPath);
-                        
+
                         // 最新のファイル内容を読み込む
                         $json = file_get_contents($jsonPath);
                         $lastModified = filemtime($jsonPath);
-                        
+
                         // デバッグ情報
-                        error_log("LiveReloadServer: Serving {$jsonPath} (modified: ".date('Y-m-d H:i:s', $lastModified).", size: ".strlen($json)." bytes)");
+                        error_log("LiveReloadServer: Serving {$jsonPath} (modified: ".date('Y-m-d H:i:s', $lastModified).', size: '.strlen($json).' bytes)');
                         break;
                     }
                 }
@@ -81,7 +81,7 @@ class LiveReloadServer
                     'Expires' => '0',
                     'X-Content-Type-Options' => 'nosniff',
                 ];
-                
+
                 // ETagとLast-Modifiedヘッダーを追加
                 if ($lastModified > 0) {
                     $etag = md5($json);

--- a/tests/Unit/Console/WatchCommandTest.php
+++ b/tests/Unit/Console/WatchCommandTest.php
@@ -211,6 +211,11 @@ class WatchCommandTest extends TestCase
                 // Do nothing
             }
 
+            public function warn($string, $verbosity = null)
+            {
+                // Do nothing
+            }
+
             public function __construct($fileWatcher, $server, $cache)
             {
                 parent::__construct($fileWatcher, $server, $cache);
@@ -234,6 +239,14 @@ class WatchCommandTest extends TestCase
             ->once()
             ->with('routes:all')
             ->andReturn(true);
+
+        // Mock getAllCacheKeys method for cache verification
+        $cache->shouldReceive('getAllCacheKeys')
+            ->andReturn([]);
+
+        // Mock clear method for forced cache clearing
+        $cache->shouldReceive('clear')
+            ->once();
 
         $server->shouldReceive('notifyClients')
             ->once()


### PR DESCRIPTION
# 概要

watchモードでルートファイルを更新してもlocalhostに戻った際に変更が反映されない問題を修正しました。

## 変更内容

ルートファイル変更時のキャッシュ処理を強化し、確実に最新の内容が反映されるようにしました。

### WatchCommandの改善
- ルートファイル変更時の詳細なデバッグ情報を追加
- キャッシュクリア後の確認処理を実装  
- ルートファイル変更時は全キャッシュをクリアして確実な更新を保証

### LiveReloadServerの改善
- HTTPレスポンスにキャッシュ制御ヘッダーを追加
  - `Cache-Control: no-cache, no-store, must-revalidate`
  - `Pragma: no-cache`
  - `Expires: 0`
- ETagとLast-Modifiedヘッダーを実装
- ファイルシステムキャッシュのクリア処理を追加
- デバッグ用のログ出力（ファイルパス、サイズ、更新時刻、ハッシュ値）

## テスト方法
1. `php artisan spectrum:watch` を実行
2. ルートファイルを編集
3. ブラウザでlocalhost:8080にアクセスして変更が反映されることを確認

## 関連情報

- ルートファイル変更時にキャッシュが適切にクリアされていない問題に対応
- ブラウザとサーバー両方のキャッシュ問題を解決