### PR TITLE
New Feature: ファイル変更時の自動ブラウザリロード機能

### DIFF
--- a/resources/views/live-preview.blade.php
+++ b/resources/views/live-preview.blade.php
@@ -98,20 +98,24 @@
         };
         
         ws.onmessage = (event) => {
+            console.log('WebSocket message received:', event.data);
             const data = JSON.parse(event.data);
+            
+            console.log('Parsed data:', data);
             
             if (data.event === 'documentation-updated') {
                 console.log('Documentation updated:', data.path);
+                console.log('Will reload page in 500ms...');
                 
                 // Show notification
                 notification.classList.add('show');
-                setTimeout(() => {
-                    notification.classList.remove('show');
-                }, 3000);
+                notification.textContent = '🔄 Reloading page...';
                 
-                // Reload Swagger UI
+                // Auto reload page
                 setTimeout(() => {
-                    ui.specActions.download();
+                    console.log('Reloading page now...');
+                    // Force reload with cache bypass
+                    window.location.href = window.location.href + '?t=' + new Date().getTime();
                 }, 500);
             }
         };

--- a/src/Services/LiveReloadServer.php
+++ b/src/Services/LiveReloadServer.php
@@ -140,9 +140,10 @@ class LiveReloadServer
             if ($this->httpWorker) {
                 $address = $this->httpWorker->getSocketName();
                 if (preg_match('/:(\\d+)$/', $address, $matches)) {
-                    $wsPort = (int)$matches[1] + 1;
+                    $wsPort = (int) $matches[1] + 1;
                 }
             }
+
             return view('spectrum::live-preview', ['wsPort' => $wsPort])->render();
         }
 

--- a/src/Services/LiveReloadServer.php
+++ b/src/Services/LiveReloadServer.php
@@ -135,7 +135,15 @@ class LiveReloadServer
     {
         // Check if we're in a Laravel app with view support
         if (function_exists('view') && view()->exists('spectrum::live-preview')) {
-            return view('spectrum::live-preview', ['wsPort' => 8081])->render();
+            // Extract port from the HTTP worker address
+            $wsPort = 8081; // Default
+            if ($this->httpWorker) {
+                $address = $this->httpWorker->getSocketName();
+                if (preg_match('/:(\\d+)$/', $address, $matches)) {
+                    $wsPort = (int)$matches[1] + 1;
+                }
+            }
+            return view('spectrum::live-preview', ['wsPort' => $wsPort])->render();
         }
 
         // Fallback HTML for testing
@@ -246,36 +254,15 @@ class LiveReloadServer
                     notification.classList.remove('show');
                 }, 3000);
                 
-                // ルートファイルが変更された場合は強制リロード
-                if (data.forceReload || (data.path && data.path.includes('routes'))) {
-                    console.log('Route file changed, forcing page reload...');
-                    console.log('Changed file:', data.path);
-                    console.log('Timestamp:', data.timestamp);
-                    notification.textContent = '🔄 Reloading page...';
-                    setTimeout(() => {
-                        // 強制的にキャッシュを無視してリロード
-                        window.location.href = window.location.href + '?t=' + new Date().getTime();
-                    }, 500);
-                } else {
-                    // その他のファイルの場合はSwagger UIのみ更新
-                    setTimeout(() => {
-                        // ブラウザキャッシュを回避するため、タイムスタンプを追加
-                        const timestamp = new Date().getTime();
-                        
-                        // Fetch APIでキャッシュを無効化して取得
-                        fetch(`/openapi.json?t=${timestamp}`, { cache: 'no-cache' })
-                            .then(response => response.json())
-                            .then(spec => {
-                                // Swagger UIを新しいspecで更新
-                                ui.specActions.updateLoadingStatus('loading');
-                                ui.specActions.updateSpec(JSON.stringify(spec));
-                                ui.specActions.updateLoadingStatus('success');
-                            })
-                            .catch(error => {
-                                console.error('Failed to reload spec:', error);
-                            });
-                    }, 500);
-                }
+                // 全てのファイル変更時に自動リロード
+                console.log('File changed:', data.path);
+                console.log('Timestamp:', data.timestamp);
+                notification.textContent = '🔄 Reloading page...';
+                
+                setTimeout(() => {
+                    // 強制的にキャッシュを無視してリロード
+                    window.location.href = window.location.href + '?t=' + new Date().getTime();
+                }, 500);
             }
         };
         


### PR DESCRIPTION
# 概要

`spectrum:watch`コマンドでファイル変更を検知した際に、ブラウザを自動的にリロードする機能を追加しました。

## 変更内容

開発効率を向上させるため、ファイル変更時にブラウザを自動的にリロードする機能を実装しました。

- WebSocket通信でファイル変更イベントを受信時に自動的にページをリロード
- キャッシュバスティングのためタイムスタンプ付きでリロード
- デバッグ用のコンソールログを追加
- WebSocketポート番号を動的に取得するよう改善

### 変更ファイル
- `resources/views/live-preview.blade.php` - 自動リロード機能とデバッグログの追加
- `src/Services/LiveReloadServer.php` - WebSocketポートの動的取得

## 関連情報

- 以前は手動でブラウザをリロードする必要があったが、この変更により自動化される
- #52 の修正により子プロセスでのドキュメント生成が可能になったことで、この機能が実現可能に