### PR TITLE
New Feature: ファイルアップロード自動検出とmultipart/form-data生成機能

### DIFF
--- a/demo-app/laravel-app/app/Http/Controllers/FileUploadController.php
+++ b/demo-app/laravel-app/app/Http/Controllers/FileUploadController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\FileUploadDemoRequest;
+use Illuminate\Http\JsonResponse;
+
+class FileUploadController extends Controller
+{
+    /**
+     * Handle user profile upload
+     *
+     * This endpoint handles file uploads for user profiles including avatar, resume and certificates
+     */
+    public function upload(FileUploadDemoRequest $request): JsonResponse
+    {
+        // Handle file uploads
+        $data = $request->validated();
+
+        // Process files (in real app, you would save these)
+        $response = [
+            'message' => 'Files uploaded successfully',
+            'data' => [
+                'name' => $data['name'],
+                'email' => $data['email'],
+                'avatar_uploaded' => $request->hasFile('avatar'),
+                'resume_uploaded' => $request->hasFile('resume'),
+                'certificates_count' => count($request->file('certificates') ?? []),
+            ],
+        ];
+
+        return response()->json($response, 201);
+    }
+
+    /**
+     * Upload multiple images
+     *
+     * This endpoint handles multiple image uploads with inline validation
+     */
+    public function uploadImages()
+    {
+        $validated = request()->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'images' => 'required|array|min:1|max:10',
+            'images.*' => 'required|image|mimes:jpeg,png,gif|max:5120|dimensions:min_width=100,min_height=100',
+            'thumbnail' => 'required|image|max:1024|dimensions:ratio=16/9',
+        ]);
+
+        return response()->json([
+            'message' => 'Images uploaded successfully',
+            'data' => [
+                'title' => $validated['title'],
+                'images_count' => count($validated['images']),
+                'thumbnail_uploaded' => request()->hasFile('thumbnail'),
+            ],
+        ], 201);
+    }
+}

--- a/demo-app/laravel-app/app/Http/Requests/FileUploadDemoRequest.php
+++ b/demo-app/laravel-app/app/Http/Requests/FileUploadDemoRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class FileUploadDemoRequest extends FormRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email',
+            'avatar' => 'required|image|mimes:jpeg,png|max:2048',
+            'resume' => 'required|file|mimes:pdf,doc,docx|max:10240',
+            'certificates' => 'array|max:5',
+            'certificates.*' => 'file|mimes:pdf|max:5120',
+            'bio' => 'nullable|string|max:1000',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'name' => 'Full Name',
+            'email' => 'Email Address',
+            'avatar' => 'Profile Picture',
+            'resume' => 'Resume Document',
+            'certificates' => 'Professional Certificates',
+            'certificates.*' => 'Certificate',
+            'bio' => 'Biography',
+        ];
+    }
+}

--- a/demo-app/laravel-app/routes/api.php
+++ b/demo-app/laravel-app/routes/api.php
@@ -34,3 +34,11 @@ Route::prefix('products')->group(function () {
     Route::get('/filter', [ProductController::class, 'filter']);
 });
 Route::get('/match-test', [\App\Http\Controllers\TestMatchController::class, 'matchTest']);
+
+// File upload routes - File upload detection test
+use App\Http\Controllers\FileUploadController;
+
+Route::prefix('uploads')->group(function () {
+    Route::post('/profile', [FileUploadController::class, 'upload']);
+    Route::post('/images', [FileUploadController::class, 'uploadImages']);
+});

--- a/src/Analyzers/FileUploadAnalyzer.php
+++ b/src/Analyzers/FileUploadAnalyzer.php
@@ -9,7 +9,7 @@ use Illuminate\Validation\Rules\File;
 class FileUploadAnalyzer
 {
     private const FILE_RULES = ['file', 'image', 'mimes', 'mimetypes'];
-    
+
     private const IMAGE_MIME_TYPES = [
         'image/jpeg',
         'image/png',
@@ -18,7 +18,7 @@ class FileUploadAnalyzer
         'image/svg+xml',
         'image/webp',
     ];
-    
+
     private const MIME_TYPE_MAPPING = [
         'jpg' => 'image/jpeg',
         'jpeg' => 'image/jpeg',
@@ -47,7 +47,7 @@ class FileUploadAnalyzer
     ];
 
     /**
-     * @param array<string, mixed> $rules
+     * @param  array<string, mixed>  $rules
      * @return array<string, array<string, mixed>>
      */
     public function analyzeRules(array $rules): array
@@ -56,7 +56,7 @@ class FileUploadAnalyzer
 
         foreach ($rules as $field => $fieldRules) {
             $analysis = $this->analyzeFieldRules($field, $fieldRules);
-            
+
             if ($analysis !== null) {
                 $fileFields[$field] = $analysis;
             }
@@ -66,12 +66,12 @@ class FileUploadAnalyzer
     }
 
     /**
-     * @param array<string, mixed> $fileRules
+     * @param  array<string, mixed>  $fileRules
      * @return array<string>
      */
     public function inferMimeTypes(array $fileRules): array
     {
-        if (isset($fileRules['mime_types']) && !empty($fileRules['mime_types'])) {
+        if (isset($fileRules['mime_types']) && ! empty($fileRules['mime_types'])) {
             return $fileRules['mime_types'];
         }
 
@@ -79,9 +79,9 @@ class FileUploadAnalyzer
             return self::IMAGE_MIME_TYPES;
         }
 
-        if (isset($fileRules['mimes']) && !empty($fileRules['mimes'])) {
+        if (isset($fileRules['mimes']) && ! empty($fileRules['mimes'])) {
             return array_map(
-                fn($ext) => self::MIME_TYPE_MAPPING[$ext] ?? 'application/octet-stream',
+                fn ($ext) => self::MIME_TYPE_MAPPING[$ext] ?? 'application/octet-stream',
                 $fileRules['mimes']
             );
         }
@@ -95,15 +95,13 @@ class FileUploadAnalyzer
     }
 
     /**
-     * @param string $field
-     * @param mixed $fieldRules
      * @return array<string, mixed>|null
      */
     private function analyzeFieldRules(string $field, mixed $fieldRules): ?array
     {
         $rulesArray = $this->normalizeRules($fieldRules);
-        
-        if (!$this->hasFileRule($rulesArray)) {
+
+        if (! $this->hasFileRule($rulesArray)) {
             return null;
         }
 
@@ -122,7 +120,7 @@ class FileUploadAnalyzer
             $this->processRule($rule, $analysis);
         }
 
-        if (!empty($analysis['mimes'])) {
+        if (! empty($analysis['mimes'])) {
             $analysis['mime_types'] = $this->inferMimeTypes($analysis);
         } elseif ($analysis['is_image'] && empty($analysis['mime_types'])) {
             $analysis['mime_types'] = self::IMAGE_MIME_TYPES;
@@ -132,7 +130,6 @@ class FileUploadAnalyzer
     }
 
     /**
-     * @param mixed $rules
      * @return array<mixed>
      */
     private function normalizeRules(mixed $rules): array
@@ -149,7 +146,7 @@ class FileUploadAnalyzer
     }
 
     /**
-     * @param array<mixed> $rules
+     * @param  array<mixed>  $rules
      */
     private function hasFileRule(array $rules): bool
     {
@@ -166,6 +163,7 @@ class FileUploadAnalyzer
     {
         if (is_string($rule)) {
             $ruleName = explode(':', $rule)[0];
+
             return in_array($ruleName, self::FILE_RULES, true);
         }
 
@@ -177,8 +175,7 @@ class FileUploadAnalyzer
     }
 
     /**
-     * @param mixed $rule
-     * @param array<string, mixed> $analysis
+     * @param  array<string, mixed>  $analysis
      */
     private function processRule(mixed $rule, array &$analysis): void
     {
@@ -190,7 +187,7 @@ class FileUploadAnalyzer
     }
 
     /**
-     * @param array<string, mixed> $analysis
+     * @param  array<string, mixed>  $analysis
      */
     private function processStringRule(string $rule, array &$analysis): void
     {
@@ -223,20 +220,19 @@ class FileUploadAnalyzer
     }
 
     /**
-     * @param File $rule
-     * @param array<string, mixed> $analysis
+     * @param  array<string, mixed>  $analysis
      */
     private function processFileRuleObject(File $rule, array &$analysis): void
     {
         $reflection = new \ReflectionClass($rule);
-        
+
         try {
             $property = $reflection->getProperty('allowedMimetypes');
             $property->setAccessible(true);
             $mimetypes = $property->getValue($rule);
-            if (!empty($mimetypes)) {
+            if (! empty($mimetypes)) {
                 // If these look like file extensions rather than MIME types
-                if (isset($mimetypes[0]) && !str_contains($mimetypes[0], '/')) {
+                if (isset($mimetypes[0]) && ! str_contains($mimetypes[0], '/')) {
                     $analysis['mimes'] = $mimetypes;
                 } else {
                     $analysis['mime_types'] = $mimetypes;
@@ -245,18 +241,18 @@ class FileUploadAnalyzer
         } catch (\ReflectionException $e) {
             // Property not found
         }
-        
+
         try {
             $property = $reflection->getProperty('allowedExtensions');
             $property->setAccessible(true);
             $extensions = $property->getValue($rule);
-            if (!empty($extensions)) {
+            if (! empty($extensions)) {
                 $analysis['mimes'] = $extensions;
             }
         } catch (\ReflectionException $e) {
             // Property not found
         }
-        
+
         try {
             $property = $reflection->getProperty('minimumFileSize');
             $property->setAccessible(true);
@@ -267,7 +263,7 @@ class FileUploadAnalyzer
         } catch (\ReflectionException $e) {
             // Property not found
         }
-        
+
         try {
             $property = $reflection->getProperty('maximumFileSize');
             $property->setAccessible(true);
@@ -287,13 +283,13 @@ class FileUploadAnalyzer
     {
         $dimensions = [];
         $pairs = explode(',', $parameters);
-        
+
         foreach ($pairs as $pair) {
             $parts = explode('=', $pair, 2);
             if (count($parts) === 2) {
                 $key = trim($parts[0]);
                 $value = trim($parts[1]);
-                
+
                 if ($key === 'ratio') {
                     $dimensions[$key] = $value;
                 } else {
@@ -301,7 +297,7 @@ class FileUploadAnalyzer
                 }
             }
         }
-        
+
         return $dimensions;
     }
 }

--- a/src/Analyzers/FileUploadAnalyzer.php
+++ b/src/Analyzers/FileUploadAnalyzer.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Analyzers;
+
+use Illuminate\Validation\Rules\File;
+
+class FileUploadAnalyzer
+{
+    private const FILE_RULES = ['file', 'image', 'mimes', 'mimetypes'];
+    
+    private const IMAGE_MIME_TYPES = [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/bmp',
+        'image/svg+xml',
+        'image/webp',
+    ];
+    
+    private const MIME_TYPE_MAPPING = [
+        'jpg' => 'image/jpeg',
+        'jpeg' => 'image/jpeg',
+        'png' => 'image/png',
+        'gif' => 'image/gif',
+        'bmp' => 'image/bmp',
+        'svg' => 'image/svg+xml',
+        'webp' => 'image/webp',
+        'pdf' => 'application/pdf',
+        'doc' => 'application/msword',
+        'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'xls' => 'application/vnd.ms-excel',
+        'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'ppt' => 'application/vnd.ms-powerpoint',
+        'pptx' => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        'csv' => 'text/csv',
+        'txt' => 'text/plain',
+        'zip' => 'application/zip',
+        'rar' => 'application/x-rar-compressed',
+        'mp4' => 'video/mp4',
+        'avi' => 'video/x-msvideo',
+        'mp3' => 'audio/mpeg',
+        'wav' => 'audio/wav',
+        'json' => 'application/json',
+        'xml' => 'application/xml',
+    ];
+
+    /**
+     * @param array<string, mixed> $rules
+     * @return array<string, array<string, mixed>>
+     */
+    public function analyzeRules(array $rules): array
+    {
+        $fileFields = [];
+
+        foreach ($rules as $field => $fieldRules) {
+            $analysis = $this->analyzeFieldRules($field, $fieldRules);
+            
+            if ($analysis !== null) {
+                $fileFields[$field] = $analysis;
+            }
+        }
+
+        return $fileFields;
+    }
+
+    /**
+     * @param array<string, mixed> $fileRules
+     * @return array<string>
+     */
+    public function inferMimeTypes(array $fileRules): array
+    {
+        if (isset($fileRules['mime_types']) && !empty($fileRules['mime_types'])) {
+            return $fileRules['mime_types'];
+        }
+
+        if (isset($fileRules['is_image']) && $fileRules['is_image']) {
+            return self::IMAGE_MIME_TYPES;
+        }
+
+        if (isset($fileRules['mimes']) && !empty($fileRules['mimes'])) {
+            return array_map(
+                fn($ext) => self::MIME_TYPE_MAPPING[$ext] ?? 'application/octet-stream',
+                $fileRules['mimes']
+            );
+        }
+
+        return [];
+    }
+
+    public function isMultipleFiles(string $field): bool
+    {
+        return str_contains($field, '.*');
+    }
+
+    /**
+     * @param string $field
+     * @param mixed $fieldRules
+     * @return array<string, mixed>|null
+     */
+    private function analyzeFieldRules(string $field, mixed $fieldRules): ?array
+    {
+        $rulesArray = $this->normalizeRules($fieldRules);
+        
+        if (!$this->hasFileRule($rulesArray)) {
+            return null;
+        }
+
+        $analysis = [
+            'type' => 'file',
+            'is_image' => false,
+            'mimes' => [],
+            'mime_types' => [],
+            'max_size' => null,
+            'min_size' => null,
+            'dimensions' => [],
+            'multiple' => $this->isMultipleFiles($field),
+        ];
+
+        foreach ($rulesArray as $rule) {
+            $this->processRule($rule, $analysis);
+        }
+
+        if (!empty($analysis['mimes'])) {
+            $analysis['mime_types'] = $this->inferMimeTypes($analysis);
+        } elseif ($analysis['is_image'] && empty($analysis['mime_types'])) {
+            $analysis['mime_types'] = self::IMAGE_MIME_TYPES;
+        }
+
+        return $analysis;
+    }
+
+    /**
+     * @param mixed $rules
+     * @return array<mixed>
+     */
+    private function normalizeRules(mixed $rules): array
+    {
+        if (is_string($rules)) {
+            return explode('|', $rules);
+        }
+
+        if (is_array($rules)) {
+            return $rules;
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<mixed> $rules
+     */
+    private function hasFileRule(array $rules): bool
+    {
+        foreach ($rules as $rule) {
+            if ($this->isFileRule($rule)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isFileRule(mixed $rule): bool
+    {
+        if (is_string($rule)) {
+            $ruleName = explode(':', $rule)[0];
+            return in_array($ruleName, self::FILE_RULES, true);
+        }
+
+        if ($rule instanceof File) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param mixed $rule
+     * @param array<string, mixed> $analysis
+     */
+    private function processRule(mixed $rule, array &$analysis): void
+    {
+        if (is_string($rule)) {
+            $this->processStringRule($rule, $analysis);
+        } elseif ($rule instanceof File) {
+            $this->processFileRuleObject($rule, $analysis);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $analysis
+     */
+    private function processStringRule(string $rule, array &$analysis): void
+    {
+        $parts = explode(':', $rule, 2);
+        $ruleName = $parts[0];
+        $parameters = $parts[1] ?? '';
+
+        switch ($ruleName) {
+            case 'file':
+                break;
+            case 'image':
+                $analysis['is_image'] = true;
+                break;
+            case 'mimes':
+                $analysis['mimes'] = explode(',', $parameters);
+                break;
+            case 'mimetypes':
+                $analysis['mime_types'] = explode(',', $parameters);
+                break;
+            case 'max':
+                $analysis['max_size'] = (int) $parameters * 1024; // KB to bytes
+                break;
+            case 'min':
+                $analysis['min_size'] = (int) $parameters * 1024; // KB to bytes
+                break;
+            case 'dimensions':
+                $analysis['dimensions'] = $this->parseDimensions($parameters);
+                break;
+        }
+    }
+
+    /**
+     * @param File $rule
+     * @param array<string, mixed> $analysis
+     */
+    private function processFileRuleObject(File $rule, array &$analysis): void
+    {
+        $reflection = new \ReflectionClass($rule);
+        
+        try {
+            $property = $reflection->getProperty('allowedMimetypes');
+            $property->setAccessible(true);
+            $mimetypes = $property->getValue($rule);
+            if (!empty($mimetypes)) {
+                // If these look like file extensions rather than MIME types
+                if (isset($mimetypes[0]) && !str_contains($mimetypes[0], '/')) {
+                    $analysis['mimes'] = $mimetypes;
+                } else {
+                    $analysis['mime_types'] = $mimetypes;
+                }
+            }
+        } catch (\ReflectionException $e) {
+            // Property not found
+        }
+        
+        try {
+            $property = $reflection->getProperty('allowedExtensions');
+            $property->setAccessible(true);
+            $extensions = $property->getValue($rule);
+            if (!empty($extensions)) {
+                $analysis['mimes'] = $extensions;
+            }
+        } catch (\ReflectionException $e) {
+            // Property not found
+        }
+        
+        try {
+            $property = $reflection->getProperty('minimumFileSize');
+            $property->setAccessible(true);
+            $minSize = $property->getValue($rule);
+            if ($minSize !== null) {
+                $analysis['min_size'] = $minSize * 1024; // KB to bytes
+            }
+        } catch (\ReflectionException $e) {
+            // Property not found
+        }
+        
+        try {
+            $property = $reflection->getProperty('maximumFileSize');
+            $property->setAccessible(true);
+            $maxSize = $property->getValue($rule);
+            if ($maxSize !== null) {
+                $analysis['max_size'] = $maxSize * 1024; // KB to bytes
+            }
+        } catch (\ReflectionException $e) {
+            // Property not found
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parseDimensions(string $parameters): array
+    {
+        $dimensions = [];
+        $pairs = explode(',', $parameters);
+        
+        foreach ($pairs as $pair) {
+            $parts = explode('=', $pair, 2);
+            if (count($parts) === 2) {
+                $key = trim($parts[0]);
+                $value = trim($parts[1]);
+                
+                if ($key === 'ratio') {
+                    $dimensions[$key] = $value;
+                } else {
+                    $dimensions[$key] = (int) $value;
+                }
+            }
+        }
+        
+        return $dimensions;
+    }
+}

--- a/src/Analyzers/FormRequestAnalyzer.php
+++ b/src/Analyzers/FormRequestAnalyzer.php
@@ -27,7 +27,9 @@ class FormRequestAnalyzer
 
     protected EnumAnalyzer $enumAnalyzer;
 
-    public function __construct(TypeInference $typeInference, DocumentationCache $cache, ?EnumAnalyzer $enumAnalyzer = null)
+    protected FileUploadAnalyzer $fileUploadAnalyzer;
+
+    public function __construct(TypeInference $typeInference, DocumentationCache $cache, ?EnumAnalyzer $enumAnalyzer = null, ?FileUploadAnalyzer $fileUploadAnalyzer = null)
     {
         $this->typeInference = $typeInference;
         $this->cache = $cache;
@@ -35,6 +37,7 @@ class FormRequestAnalyzer
         $this->traverser = new NodeTraverser;
         $this->printer = new PrettyPrinter\Standard;
         $this->enumAnalyzer = $enumAnalyzer ?? new EnumAnalyzer;
+        $this->fileUploadAnalyzer = $fileUploadAnalyzer ?? new FileUploadAnalyzer;
     }
 
     /**
@@ -343,6 +346,9 @@ class FormRequestAnalyzer
     protected function generateParameters(array $rules, array $attributes = [], ?string $namespace = null, array $useStatements = []): array
     {
         $parameters = [];
+        
+        // Analyze file upload fields
+        $fileFields = $this->fileUploadAnalyzer->analyzeRules($rules);
 
         foreach ($rules as $field => $rule) {
             // 特殊なフィールド（_noticeなど）はスキップ
@@ -351,6 +357,24 @@ class FormRequestAnalyzer
             }
 
             $ruleArray = is_array($rule) ? $rule : explode('|', $rule);
+
+            // Check if this is a file upload field
+            if (isset($fileFields[$field])) {
+                $fileInfo = $fileFields[$field];
+                $parameter = [
+                    'name' => $field,
+                    'in' => 'body',
+                    'required' => $this->isRequired($ruleArray),
+                    'type' => 'file',
+                    'format' => 'binary',
+                    'file_info' => $fileInfo,
+                    'description' => $this->generateFileDescriptionWithAttribute($field, $fileInfo, $attributes[$field] ?? null),
+                    'validation' => $ruleArray,
+                ];
+                
+                $parameters[] = $parameter;
+                continue;
+            }
 
             // Check for enum rules
             $enumInfo = null;
@@ -440,6 +464,109 @@ class FormRequestAnalyzer
         }
 
         return $description;
+    }
+
+    /**
+     * ファイルフィールドの説明を生成
+     */
+    protected function generateFileDescription(string $field, array $fileInfo): string
+    {
+        $description = Str::title(str_replace(['_', '-'], ' ', $field));
+        
+        $parts = [];
+        
+        if (!empty($fileInfo['mimes'])) {
+            $parts[] = 'Allowed types: ' . implode(', ', $fileInfo['mimes']);
+        }
+        
+        if (isset($fileInfo['max_size'])) {
+            $maxSize = $this->formatFileSize($fileInfo['max_size']);
+            $parts[] = "Max size: {$maxSize}";
+        }
+        
+        if (isset($fileInfo['min_size'])) {
+            $minSize = $this->formatFileSize($fileInfo['min_size']);
+            $parts[] = "Min size: {$minSize}";
+        }
+        
+        if (!empty($fileInfo['dimensions'])) {
+            if (isset($fileInfo['dimensions']['min_width']) && isset($fileInfo['dimensions']['min_height'])) {
+                $parts[] = "Min dimensions: {$fileInfo['dimensions']['min_width']}x{$fileInfo['dimensions']['min_height']}";
+            }
+            if (isset($fileInfo['dimensions']['max_width']) && isset($fileInfo['dimensions']['max_height'])) {
+                $parts[] = "Max dimensions: {$fileInfo['dimensions']['max_width']}x{$fileInfo['dimensions']['max_height']}";
+            }
+            if (isset($fileInfo['dimensions']['ratio'])) {
+                $parts[] = "Aspect ratio: {$fileInfo['dimensions']['ratio']}";
+            }
+        }
+        
+        if (!empty($parts)) {
+            $description .= ' (' . implode('. ', $parts) . ')';
+        }
+        
+        return $description;
+    }
+    
+    /**
+     * ファイルフィールドの説明を生成（属性名付き）
+     */
+    protected function generateFileDescriptionWithAttribute(string $field, array $fileInfo, ?string $attribute = null): string
+    {
+        $fieldName = $attribute ?? Str::title(str_replace(['_', '-'], ' ', $field));
+        
+        $parts = [];
+        
+        if (!empty($fileInfo['mimes'])) {
+            $parts[] = 'Allowed types: ' . implode(', ', $fileInfo['mimes']);
+        }
+        
+        if (isset($fileInfo['max_size'])) {
+            $maxSize = $this->formatFileSize($fileInfo['max_size']);
+            $parts[] = "Max size: {$maxSize}";
+        }
+        
+        if (isset($fileInfo['min_size'])) {
+            $minSize = $this->formatFileSize($fileInfo['min_size']);
+            $parts[] = "Min size: {$minSize}";
+        }
+        
+        if (!empty($fileInfo['dimensions'])) {
+            if (isset($fileInfo['dimensions']['min_width']) && isset($fileInfo['dimensions']['min_height'])) {
+                $parts[] = "Min dimensions: {$fileInfo['dimensions']['min_width']}x{$fileInfo['dimensions']['min_height']}";
+            }
+            if (isset($fileInfo['dimensions']['max_width']) && isset($fileInfo['dimensions']['max_height'])) {
+                $parts[] = "Max dimensions: {$fileInfo['dimensions']['max_width']}x{$fileInfo['dimensions']['max_height']}";
+            }
+            if (isset($fileInfo['dimensions']['ratio'])) {
+                $parts[] = "Aspect ratio: {$fileInfo['dimensions']['ratio']}";
+            }
+        }
+        
+        return $fieldName . (!empty($parts) ? ' (' . implode('. ', $parts) . ')' : '');
+    }
+    
+    /**
+     * Format file size to human readable format
+     */
+    protected function formatFileSize(int $bytes): string
+    {
+        if ($bytes >= 1073741824) {
+            $size = $bytes / 1073741824;
+            return $size == (int) $size ? sprintf('%dGB', (int) $size) : sprintf('%.1fGB', $size);
+        }
+        
+        if ($bytes >= 1048576) {
+            $size = $bytes / 1048576;
+            return $size == (int) $size ? sprintf('%dMB', (int) $size) : sprintf('%.1fMB', $size);
+        }
+        
+        if ($bytes >= 1024) {
+            $size = $bytes / 1024;
+            return $size == (int) $size ? sprintf('%dKB', (int) $size) : sprintf('%.1fKB', $size);
+        }
+        
+        return sprintf('%dB', $bytes);
     }
 
     /**

--- a/src/Analyzers/FormRequestAnalyzer.php
+++ b/src/Analyzers/FormRequestAnalyzer.php
@@ -346,7 +346,7 @@ class FormRequestAnalyzer
     protected function generateParameters(array $rules, array $attributes = [], ?string $namespace = null, array $useStatements = []): array
     {
         $parameters = [];
-        
+
         // Analyze file upload fields
         $fileFields = $this->fileUploadAnalyzer->analyzeRules($rules);
 
@@ -371,8 +371,9 @@ class FormRequestAnalyzer
                     'description' => $this->generateFileDescriptionWithAttribute($field, $fileInfo, $attributes[$field] ?? null),
                     'validation' => $ruleArray,
                 ];
-                
+
                 $parameters[] = $parameter;
+
                 continue;
             }
 
@@ -472,24 +473,24 @@ class FormRequestAnalyzer
     protected function generateFileDescription(string $field, array $fileInfo): string
     {
         $description = Str::title(str_replace(['_', '-'], ' ', $field));
-        
+
         $parts = [];
-        
-        if (!empty($fileInfo['mimes'])) {
-            $parts[] = 'Allowed types: ' . implode(', ', $fileInfo['mimes']);
+
+        if (! empty($fileInfo['mimes'])) {
+            $parts[] = 'Allowed types: '.implode(', ', $fileInfo['mimes']);
         }
-        
+
         if (isset($fileInfo['max_size'])) {
             $maxSize = $this->formatFileSize($fileInfo['max_size']);
             $parts[] = "Max size: {$maxSize}";
         }
-        
+
         if (isset($fileInfo['min_size'])) {
             $minSize = $this->formatFileSize($fileInfo['min_size']);
             $parts[] = "Min size: {$minSize}";
         }
-        
-        if (!empty($fileInfo['dimensions'])) {
+
+        if (! empty($fileInfo['dimensions'])) {
             if (isset($fileInfo['dimensions']['min_width']) && isset($fileInfo['dimensions']['min_height'])) {
                 $parts[] = "Min dimensions: {$fileInfo['dimensions']['min_width']}x{$fileInfo['dimensions']['min_height']}";
             }
@@ -500,38 +501,38 @@ class FormRequestAnalyzer
                 $parts[] = "Aspect ratio: {$fileInfo['dimensions']['ratio']}";
             }
         }
-        
-        if (!empty($parts)) {
-            $description .= ' (' . implode('. ', $parts) . ')';
+
+        if (! empty($parts)) {
+            $description .= ' ('.implode('. ', $parts).')';
         }
-        
+
         return $description;
     }
-    
+
     /**
      * ファイルフィールドの説明を生成（属性名付き）
      */
     protected function generateFileDescriptionWithAttribute(string $field, array $fileInfo, ?string $attribute = null): string
     {
         $fieldName = $attribute ?? Str::title(str_replace(['_', '-'], ' ', $field));
-        
+
         $parts = [];
-        
-        if (!empty($fileInfo['mimes'])) {
-            $parts[] = 'Allowed types: ' . implode(', ', $fileInfo['mimes']);
+
+        if (! empty($fileInfo['mimes'])) {
+            $parts[] = 'Allowed types: '.implode(', ', $fileInfo['mimes']);
         }
-        
+
         if (isset($fileInfo['max_size'])) {
             $maxSize = $this->formatFileSize($fileInfo['max_size']);
             $parts[] = "Max size: {$maxSize}";
         }
-        
+
         if (isset($fileInfo['min_size'])) {
             $minSize = $this->formatFileSize($fileInfo['min_size']);
             $parts[] = "Min size: {$minSize}";
         }
-        
-        if (!empty($fileInfo['dimensions'])) {
+
+        if (! empty($fileInfo['dimensions'])) {
             if (isset($fileInfo['dimensions']['min_width']) && isset($fileInfo['dimensions']['min_height'])) {
                 $parts[] = "Min dimensions: {$fileInfo['dimensions']['min_width']}x{$fileInfo['dimensions']['min_height']}";
             }
@@ -542,10 +543,10 @@ class FormRequestAnalyzer
                 $parts[] = "Aspect ratio: {$fileInfo['dimensions']['ratio']}";
             }
         }
-        
-        return $fieldName . (!empty($parts) ? ' (' . implode('. ', $parts) . ')' : '');
+
+        return $fieldName.(! empty($parts) ? ' ('.implode('. ', $parts).')' : '');
     }
-    
+
     /**
      * Format file size to human readable format
      */
@@ -553,19 +554,22 @@ class FormRequestAnalyzer
     {
         if ($bytes >= 1073741824) {
             $size = $bytes / 1073741824;
+
             return $size == (int) $size ? sprintf('%dGB', (int) $size) : sprintf('%.1fGB', $size);
         }
-        
+
         if ($bytes >= 1048576) {
             $size = $bytes / 1048576;
+
             return $size == (int) $size ? sprintf('%dMB', (int) $size) : sprintf('%.1fMB', $size);
         }
-        
+
         if ($bytes >= 1024) {
             $size = $bytes / 1024;
+
             return $size == (int) $size ? sprintf('%dKB', (int) $size) : sprintf('%.1fKB', $size);
         }
-        
+
         return sprintf('%dB', $bytes);
     }
 

--- a/src/Analyzers/InlineValidationAnalyzer.php
+++ b/src/Analyzers/InlineValidationAnalyzer.php
@@ -12,7 +12,7 @@ class InlineValidationAnalyzer
     protected TypeInference $typeInference;
 
     protected EnumAnalyzer $enumAnalyzer;
-    
+
     protected FileUploadAnalyzer $fileUploadAnalyzer;
 
     public function __construct(TypeInference $typeInference, ?EnumAnalyzer $enumAnalyzer = null, ?FileUploadAnalyzer $fileUploadAnalyzer = null)
@@ -248,7 +248,7 @@ class InlineValidationAnalyzer
     public function generateParameters(array $validation, ?string $namespace = null, array $useStatements = []): array
     {
         $parameters = [];
-        
+
         // Analyze file upload fields
         $fileFields = $this->fileUploadAnalyzer->analyzeRules($validation['rules']);
 
@@ -257,7 +257,7 @@ class InlineValidationAnalyzer
             if (isset($fileFields[$field])) {
                 $fileInfo = $fileFields[$field];
                 $rulesList = is_array($rules) ? $rules : explode('|', $rules);
-                
+
                 $parameter = [
                     'name' => $field,
                     'type' => 'file',
@@ -267,11 +267,12 @@ class InlineValidationAnalyzer
                     'rules' => $rules,
                     'description' => $this->generateFileDescription($field, $fileInfo, $validation['attributes'] ?? []),
                 ];
-                
+
                 $parameters[] = $parameter;
+
                 continue;
             }
-            
+
             // Check if this is a concatenated string expression
             $isConcatenated = is_string($rules) && preg_match('/[\'"].*\|.*[\'"].*\..*::class/', $rules);
 
@@ -415,7 +416,7 @@ class InlineValidationAnalyzer
 
         return $fieldName.(! empty($descriptions) ? ' - '.implode(', ', $descriptions) : '');
     }
-    
+
     /**
      * ファイルフィールドの説明を生成
      */
@@ -423,24 +424,24 @@ class InlineValidationAnalyzer
     {
         // カスタム属性名があれば使用
         $fieldName = $attributes[$field] ?? str_replace('_', ' ', ucfirst($field));
-        
+
         $parts = [];
-        
-        if (!empty($fileInfo['mimes'])) {
-            $parts[] = 'Allowed types: ' . implode(', ', $fileInfo['mimes']);
+
+        if (! empty($fileInfo['mimes'])) {
+            $parts[] = 'Allowed types: '.implode(', ', $fileInfo['mimes']);
         }
-        
+
         if (isset($fileInfo['max_size'])) {
             $maxSize = $this->formatFileSize($fileInfo['max_size']);
             $parts[] = "Max size: {$maxSize}";
         }
-        
+
         if (isset($fileInfo['min_size'])) {
             $minSize = $this->formatFileSize($fileInfo['min_size']);
             $parts[] = "Min size: {$minSize}";
         }
-        
-        if (!empty($fileInfo['dimensions'])) {
+
+        if (! empty($fileInfo['dimensions'])) {
             if (isset($fileInfo['dimensions']['min_width']) && isset($fileInfo['dimensions']['min_height'])) {
                 $parts[] = "Min dimensions: {$fileInfo['dimensions']['min_width']}x{$fileInfo['dimensions']['min_height']}";
             }
@@ -451,10 +452,10 @@ class InlineValidationAnalyzer
                 $parts[] = "Aspect ratio: {$fileInfo['dimensions']['ratio']}";
             }
         }
-        
-        return $fieldName . (!empty($parts) ? ' - ' . implode('. ', $parts) : '');
+
+        return $fieldName.(! empty($parts) ? ' - '.implode('. ', $parts) : '');
     }
-    
+
     /**
      * Format file size to human readable format
      */
@@ -462,19 +463,22 @@ class InlineValidationAnalyzer
     {
         if ($bytes >= 1073741824) {
             $size = $bytes / 1073741824;
+
             return $size == (int) $size ? sprintf('%dGB', (int) $size) : sprintf('%.1fGB', $size);
         }
-        
+
         if ($bytes >= 1048576) {
             $size = $bytes / 1048576;
+
             return $size == (int) $size ? sprintf('%dMB', (int) $size) : sprintf('%.1fMB', $size);
         }
-        
+
         if ($bytes >= 1024) {
             $size = $bytes / 1024;
+
             return $size == (int) $size ? sprintf('%dKB', (int) $size) : sprintf('%.1fKB', $size);
         }
-        
+
         return sprintf('%dB', $bytes);
     }
 }

--- a/src/Generators/FileUploadSchemaGenerator.php
+++ b/src/Generators/FileUploadSchemaGenerator.php
@@ -7,7 +7,7 @@ namespace LaravelSpectrum\Generators;
 class FileUploadSchemaGenerator
 {
     /**
-     * @param array<string, mixed> $fileField
+     * @param  array<string, mixed>  $fileField
      * @return array<string, mixed>
      */
     public function generate(array $fileField): array
@@ -26,8 +26,8 @@ class FileUploadSchemaGenerator
     }
 
     /**
-     * @param array<string, mixed> $fields
-     * @param array<string, mixed> $fileFields
+     * @param  array<string, mixed>  $fields
+     * @param  array<string, mixed>  $fileFields
      * @return array<string, mixed>
      */
     public function generateMultipartSchema(array $fields, array $fileFields): array
@@ -49,28 +49,28 @@ class FileUploadSchemaGenerator
     }
 
     /**
-     * @param array<string, mixed> $fileField
+     * @param  array<string, mixed>  $fileField
      */
     private function generateDescription(array $fileField): string
     {
         $parts = [];
 
         // Allowed types
-        if (!empty($fileField['mimes'])) {
-            $parts[] = 'Allowed types: ' . implode(', ', $fileField['mimes']);
+        if (! empty($fileField['mimes'])) {
+            $parts[] = 'Allowed types: '.implode(', ', $fileField['mimes']);
         }
 
         // File size constraints
         if (isset($fileField['max_size'])) {
-            $parts[] = 'Max size: ' . $this->formatFileSize($fileField['max_size']);
+            $parts[] = 'Max size: '.$this->formatFileSize($fileField['max_size']);
         }
-        
+
         if (isset($fileField['min_size'])) {
-            $parts[] = 'Min size: ' . $this->formatFileSize($fileField['min_size']);
+            $parts[] = 'Min size: '.$this->formatFileSize($fileField['min_size']);
         }
 
         // Dimension constraints
-        if (!empty($fileField['dimensions'])) {
+        if (! empty($fileField['dimensions'])) {
             $dimensionParts = $this->formatDimensions($fileField['dimensions']);
             $parts = array_merge($parts, $dimensionParts);
         }
@@ -79,7 +79,7 @@ class FileUploadSchemaGenerator
     }
 
     /**
-     * @param array<string, mixed> $dimensions
+     * @param  array<string, mixed>  $dimensions
      * @return array<string>
      */
     private function formatDimensions(array $dimensions): array
@@ -121,25 +121,28 @@ class FileUploadSchemaGenerator
     {
         if ($bytes >= 1073741824) {
             $size = $bytes / 1073741824;
+
             return $size == (int) $size ? sprintf('%dGB', (int) $size) : sprintf('%.1fGB', $size);
         }
-        
+
         if ($bytes >= 1048576) {
             $size = $bytes / 1048576;
+
             return $size == (int) $size ? sprintf('%dMB', (int) $size) : sprintf('%.1fMB', $size);
         }
-        
+
         if ($bytes >= 1024) {
             $size = $bytes / 1024;
+
             return $size == (int) $size ? sprintf('%dKB', (int) $size) : sprintf('%.1fKB', $size);
         }
-        
+
         return sprintf('%dB', $bytes);
     }
 
     /**
-     * @param array<string, mixed> $fields
-     * @param array<string, mixed> $fileFields
+     * @param  array<string, mixed>  $fields
+     * @param  array<string, mixed>  $fileFields
      * @return array<string, mixed>
      */
     private function mergeProperties(array $fields, array $fileFields): array
@@ -151,11 +154,11 @@ class FileUploadSchemaGenerator
             $properties[$name] = [
                 'type' => $field['type'] ?? 'string',
             ];
-            
+
             if (isset($field['maxLength'])) {
                 $properties[$name]['maxLength'] = $field['maxLength'];
             }
-            
+
             // Add other properties as needed
             foreach (['minLength', 'pattern', 'enum', 'format', 'minimum', 'maximum'] as $prop) {
                 if (isset($field[$prop])) {
@@ -173,8 +176,8 @@ class FileUploadSchemaGenerator
     }
 
     /**
-     * @param array<string, mixed> $fields
-     * @param array<string, mixed> $fileFields
+     * @param  array<string, mixed>  $fields
+     * @param  array<string, mixed>  $fileFields
      * @return array<string>
      */
     private function extractRequired(array $fields, array $fileFields): array

--- a/src/Generators/FileUploadSchemaGenerator.php
+++ b/src/Generators/FileUploadSchemaGenerator.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Generators;
+
+class FileUploadSchemaGenerator
+{
+    /**
+     * @param array<string, mixed> $fileField
+     * @return array<string, mixed>
+     */
+    public function generate(array $fileField): array
+    {
+        $schema = [
+            'type' => 'string',
+            'format' => 'binary',
+        ];
+
+        $description = $this->generateDescription($fileField);
+        if ($description !== '') {
+            $schema['description'] = $description;
+        }
+
+        return $schema;
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     * @param array<string, mixed> $fileFields
+     * @return array<string, mixed>
+     */
+    public function generateMultipartSchema(array $fields, array $fileFields): array
+    {
+        $properties = $this->mergeProperties($fields, $fileFields);
+        $required = $this->extractRequired($fields, $fileFields);
+
+        return [
+            'content' => [
+                'multipart/form-data' => [
+                    'schema' => [
+                        'type' => 'object',
+                        'properties' => $properties,
+                        'required' => $required,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $fileField
+     */
+    private function generateDescription(array $fileField): string
+    {
+        $parts = [];
+
+        // Allowed types
+        if (!empty($fileField['mimes'])) {
+            $parts[] = 'Allowed types: ' . implode(', ', $fileField['mimes']);
+        }
+
+        // File size constraints
+        if (isset($fileField['max_size'])) {
+            $parts[] = 'Max size: ' . $this->formatFileSize($fileField['max_size']);
+        }
+        
+        if (isset($fileField['min_size'])) {
+            $parts[] = 'Min size: ' . $this->formatFileSize($fileField['min_size']);
+        }
+
+        // Dimension constraints
+        if (!empty($fileField['dimensions'])) {
+            $dimensionParts = $this->formatDimensions($fileField['dimensions']);
+            $parts = array_merge($parts, $dimensionParts);
+        }
+
+        return implode('. ', $parts);
+    }
+
+    /**
+     * @param array<string, mixed> $dimensions
+     * @return array<string>
+     */
+    private function formatDimensions(array $dimensions): array
+    {
+        $parts = [];
+
+        // Exact dimensions
+        if (isset($dimensions['width']) && isset($dimensions['height'])) {
+            $parts[] = sprintf('Required dimensions: %dx%d', $dimensions['width'], $dimensions['height']);
+        }
+
+        // Min dimensions
+        if (isset($dimensions['min_width']) && isset($dimensions['min_height'])) {
+            $parts[] = sprintf('Min dimensions: %dx%d', $dimensions['min_width'], $dimensions['min_height']);
+        } elseif (isset($dimensions['min_width'])) {
+            $parts[] = sprintf('Min width: %d', $dimensions['min_width']);
+        } elseif (isset($dimensions['min_height'])) {
+            $parts[] = sprintf('Min height: %d', $dimensions['min_height']);
+        }
+
+        // Max dimensions
+        if (isset($dimensions['max_width']) && isset($dimensions['max_height'])) {
+            $parts[] = sprintf('Max dimensions: %dx%d', $dimensions['max_width'], $dimensions['max_height']);
+        } elseif (isset($dimensions['max_width'])) {
+            $parts[] = sprintf('Max width: %d', $dimensions['max_width']);
+        } elseif (isset($dimensions['max_height'])) {
+            $parts[] = sprintf('Max height: %d', $dimensions['max_height']);
+        }
+
+        // Aspect ratio
+        if (isset($dimensions['ratio'])) {
+            $parts[] = sprintf('Aspect ratio: %s', $dimensions['ratio']);
+        }
+
+        return $parts;
+    }
+
+    private function formatFileSize(int $bytes): string
+    {
+        if ($bytes >= 1073741824) {
+            $size = $bytes / 1073741824;
+            return $size == (int) $size ? sprintf('%dGB', (int) $size) : sprintf('%.1fGB', $size);
+        }
+        
+        if ($bytes >= 1048576) {
+            $size = $bytes / 1048576;
+            return $size == (int) $size ? sprintf('%dMB', (int) $size) : sprintf('%.1fMB', $size);
+        }
+        
+        if ($bytes >= 1024) {
+            $size = $bytes / 1024;
+            return $size == (int) $size ? sprintf('%dKB', (int) $size) : sprintf('%.1fKB', $size);
+        }
+        
+        return sprintf('%dB', $bytes);
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     * @param array<string, mixed> $fileFields
+     * @return array<string, mixed>
+     */
+    private function mergeProperties(array $fields, array $fileFields): array
+    {
+        $properties = [];
+
+        // Add regular fields
+        foreach ($fields as $name => $field) {
+            $properties[$name] = [
+                'type' => $field['type'] ?? 'string',
+            ];
+            
+            if (isset($field['maxLength'])) {
+                $properties[$name]['maxLength'] = $field['maxLength'];
+            }
+            
+            // Add other properties as needed
+            foreach (['minLength', 'pattern', 'enum', 'format', 'minimum', 'maximum'] as $prop) {
+                if (isset($field[$prop])) {
+                    $properties[$name][$prop] = $field[$prop];
+                }
+            }
+        }
+
+        // Add file fields
+        foreach ($fileFields as $name => $field) {
+            $properties[$name] = $field;
+        }
+
+        return $properties;
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     * @param array<string, mixed> $fileFields
+     * @return array<string>
+     */
+    private function extractRequired(array $fields, array $fileFields): array
+    {
+        $required = [];
+
+        foreach ($fields as $name => $field) {
+            if (isset($field['required']) && $field['required']) {
+                $required[] = $name;
+            }
+        }
+
+        foreach ($fileFields as $name => $field) {
+            if (isset($field['required']) && $field['required']) {
+                $required[] = $name;
+            }
+        }
+
+        return array_values(array_unique($required));
+    }
+}

--- a/src/Generators/OpenApiGenerator.php
+++ b/src/Generators/OpenApiGenerator.php
@@ -175,6 +175,14 @@ class OpenApiGenerator
         }
 
         $schema = $this->schemaGenerator->generateFromParameters($parameters);
+        
+        // Check if schema is for multipart/form-data (has 'content' key)
+        if (isset($schema['content'])) {
+            return [
+                'required' => true,
+                'content' => $schema['content'],
+            ];
+        }
 
         return [
             'required' => true,

--- a/src/Generators/OpenApiGenerator.php
+++ b/src/Generators/OpenApiGenerator.php
@@ -175,7 +175,7 @@ class OpenApiGenerator
         }
 
         $schema = $this->schemaGenerator->generateFromParameters($parameters);
-        
+
         // Check if schema is for multipart/form-data (has 'content' key)
         if (isset($schema['content'])) {
             return [

--- a/src/Generators/SchemaGenerator.php
+++ b/src/Generators/SchemaGenerator.php
@@ -5,12 +5,12 @@ namespace LaravelSpectrum\Generators;
 class SchemaGenerator
 {
     protected FileUploadSchemaGenerator $fileUploadSchemaGenerator;
-    
+
     public function __construct(?FileUploadSchemaGenerator $fileUploadSchemaGenerator = null)
     {
         $this->fileUploadSchemaGenerator = $fileUploadSchemaGenerator ?? new FileUploadSchemaGenerator;
     }
-    
+
     /**
      * パラメータからスキーマを生成
      */
@@ -20,7 +20,7 @@ class SchemaGenerator
         $hasFileUpload = false;
         $fileFields = [];
         $normalFields = [];
-        
+
         foreach ($parameters as $parameter) {
             if (isset($parameter['type']) && $parameter['type'] === 'file') {
                 $hasFileUpload = true;
@@ -29,12 +29,12 @@ class SchemaGenerator
                 $normalFields[] = $parameter;
             }
         }
-        
+
         // If we have file uploads, we need to generate multipart/form-data schema
         if ($hasFileUpload) {
             return $this->generateMultipartSchema($normalFields, $fileFields);
         }
-        
+
         // Otherwise, generate normal JSON schema
         $properties = [];
         $required = [];
@@ -105,7 +105,7 @@ class SchemaGenerator
 
         return $schema;
     }
-    
+
     /**
      * Generate multipart/form-data schema
      */
@@ -113,18 +113,18 @@ class SchemaGenerator
     {
         $normalFieldsFormatted = [];
         $fileFieldsFormatted = [];
-        
+
         // Format normal fields
         foreach ($normalFields as $field) {
-            if (!isset($field['name'])) {
+            if (! isset($field['name'])) {
                 continue;
             }
-            
+
             $fieldData = [
                 'type' => $field['type'] ?? 'string',
                 'required' => $field['required'] ?? false,
             ];
-            
+
             if (isset($field['description'])) {
                 $fieldData['description'] = $field['description'];
             }
@@ -140,26 +140,26 @@ class SchemaGenerator
                     $fieldData['type'] = $field['enum']['type'];
                 }
             }
-            
+
             $normalFieldsFormatted[$field['name']] = $fieldData;
         }
-        
+
         // Format file fields
         foreach ($fileFields as $field) {
-            if (!isset($field['name'])) {
+            if (! isset($field['name'])) {
                 continue;
             }
-            
+
             $fileFieldData = [
                 'type' => 'string',
                 'format' => 'binary',
                 'required' => $field['required'] ?? false,
             ];
-            
+
             if (isset($field['description'])) {
                 $fileFieldData['description'] = $field['description'];
             }
-            
+
             // Handle array files (multiple uploads)
             if (isset($field['file_info']) && $field['file_info']['multiple']) {
                 $fileFieldsFormatted[$field['name']] = [
@@ -174,7 +174,7 @@ class SchemaGenerator
                 $fileFieldsFormatted[$field['name']] = $fileFieldData;
             }
         }
-        
+
         return $this->fileUploadSchemaGenerator->generateMultipartSchema($normalFieldsFormatted, $fileFieldsFormatted);
     }
 

--- a/src/Support/FileUploadDetector.php
+++ b/src/Support/FileUploadDetector.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Support;
+
+use Illuminate\Validation\Rules\File;
+
+class FileUploadDetector
+{
+    private const FILE_RULES = ['file', 'image', 'mimes', 'mimetypes'];
+    
+    private const MIME_TYPE_MAPPING = [
+        'jpg' => 'image/jpeg',
+        'jpeg' => 'image/jpeg',
+        'png' => 'image/png',
+        'gif' => 'image/gif',
+        'bmp' => 'image/bmp',
+        'svg' => 'image/svg+xml',
+        'webp' => 'image/webp',
+        'pdf' => 'application/pdf',
+        'doc' => 'application/msword',
+        'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'xls' => 'application/vnd.ms-excel',
+        'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'ppt' => 'application/vnd.ms-powerpoint',
+        'pptx' => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        'csv' => 'text/csv',
+        'txt' => 'text/plain',
+        'zip' => 'application/zip',
+        'rar' => 'application/x-rar-compressed',
+        'mp4' => 'video/mp4',
+        'avi' => 'video/x-msvideo',
+        'mp3' => 'audio/mpeg',
+        'wav' => 'audio/wav',
+        'json' => 'application/json',
+        'xml' => 'application/xml',
+    ];
+
+    /**
+     * @param array<string, mixed> $rules
+     * @return array<string, array<mixed>>
+     */
+    public function extractFileRules(array $rules): array
+    {
+        $fileRules = [];
+
+        foreach ($rules as $field => $fieldRules) {
+            if ($this->hasFileRule($fieldRules)) {
+                $fileRules[$field] = $this->normalizeRules($fieldRules);
+            }
+        }
+
+        return $fileRules;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getMimeTypeMapping(): array
+    {
+        return self::MIME_TYPE_MAPPING;
+    }
+
+    /**
+     * @param array<mixed> $rules
+     * @return array<string, int>
+     */
+    public function extractSizeConstraints(array $rules): array
+    {
+        $constraints = [];
+        $normalizedRules = $this->flattenRules($rules);
+
+        foreach ($normalizedRules as $rule) {
+            if (is_string($rule)) {
+                $parts = explode(':', $rule, 2);
+                $ruleName = $parts[0];
+                $value = $parts[1] ?? '';
+
+                if ($ruleName === 'min' && $value !== '') {
+                    $constraints['min'] = (int) $value * 1024; // KB to bytes
+                } elseif ($ruleName === 'max' && $value !== '') {
+                    $constraints['max'] = (int) $value * 1024; // KB to bytes
+                }
+            }
+        }
+
+        return $constraints;
+    }
+
+    /**
+     * @param array<mixed> $rules
+     * @return array<string, mixed>
+     */
+    public function extractDimensionConstraints(array $rules): array
+    {
+        $dimensions = [];
+        $normalizedRules = $this->flattenRules($rules);
+
+        foreach ($normalizedRules as $rule) {
+            if (is_string($rule) && str_starts_with($rule, 'dimensions:')) {
+                $parameters = substr($rule, 11); // Remove 'dimensions:'
+                $pairs = explode(',', $parameters);
+                
+                foreach ($pairs as $pair) {
+                    $parts = explode('=', $pair, 2);
+                    if (count($parts) === 2) {
+                        $key = trim($parts[0]);
+                        $value = trim($parts[1]);
+                        
+                        if ($key === 'ratio') {
+                            $dimensions[$key] = $value;
+                        } else {
+                            $dimensions[$key] = (int) $value;
+                        }
+                    }
+                }
+            }
+        }
+
+        return $dimensions;
+    }
+
+    /**
+     * @param mixed $rules
+     */
+    private function hasFileRule(mixed $rules): bool
+    {
+        $normalizedRules = $this->normalizeRules($rules);
+
+        foreach ($normalizedRules as $rule) {
+            if ($this->isFileRule($rule)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param mixed $rule
+     */
+    private function isFileRule(mixed $rule): bool
+    {
+        if (is_string($rule)) {
+            $ruleName = explode(':', $rule)[0];
+            return in_array($ruleName, self::FILE_RULES, true);
+        }
+
+        if ($rule instanceof File) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param mixed $rules
+     * @return array<mixed>
+     */
+    private function normalizeRules(mixed $rules): array
+    {
+        if (is_string($rules)) {
+            return explode('|', $rules);
+        }
+
+        if (is_array($rules)) {
+            return $rules;
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<mixed> $rules
+     * @return array<mixed>
+     */
+    private function flattenRules(array $rules): array
+    {
+        $flattened = [];
+
+        foreach ($rules as $rule) {
+            if (is_string($rule) && str_contains($rule, '|')) {
+                $flattened = array_merge($flattened, explode('|', $rule));
+            } else {
+                $flattened[] = $rule;
+            }
+        }
+
+        return $flattened;
+    }
+}

--- a/src/Support/FileUploadDetector.php
+++ b/src/Support/FileUploadDetector.php
@@ -9,7 +9,7 @@ use Illuminate\Validation\Rules\File;
 class FileUploadDetector
 {
     private const FILE_RULES = ['file', 'image', 'mimes', 'mimetypes'];
-    
+
     private const MIME_TYPE_MAPPING = [
         'jpg' => 'image/jpeg',
         'jpeg' => 'image/jpeg',
@@ -38,7 +38,7 @@ class FileUploadDetector
     ];
 
     /**
-     * @param array<string, mixed> $rules
+     * @param  array<string, mixed>  $rules
      * @return array<string, array<mixed>>
      */
     public function extractFileRules(array $rules): array
@@ -63,7 +63,7 @@ class FileUploadDetector
     }
 
     /**
-     * @param array<mixed> $rules
+     * @param  array<mixed>  $rules
      * @return array<string, int>
      */
     public function extractSizeConstraints(array $rules): array
@@ -89,7 +89,7 @@ class FileUploadDetector
     }
 
     /**
-     * @param array<mixed> $rules
+     * @param  array<mixed>  $rules
      * @return array<string, mixed>
      */
     public function extractDimensionConstraints(array $rules): array
@@ -101,13 +101,13 @@ class FileUploadDetector
             if (is_string($rule) && str_starts_with($rule, 'dimensions:')) {
                 $parameters = substr($rule, 11); // Remove 'dimensions:'
                 $pairs = explode(',', $parameters);
-                
+
                 foreach ($pairs as $pair) {
                     $parts = explode('=', $pair, 2);
                     if (count($parts) === 2) {
                         $key = trim($parts[0]);
                         $value = trim($parts[1]);
-                        
+
                         if ($key === 'ratio') {
                             $dimensions[$key] = $value;
                         } else {
@@ -121,9 +121,6 @@ class FileUploadDetector
         return $dimensions;
     }
 
-    /**
-     * @param mixed $rules
-     */
     private function hasFileRule(mixed $rules): bool
     {
         $normalizedRules = $this->normalizeRules($rules);
@@ -137,13 +134,11 @@ class FileUploadDetector
         return false;
     }
 
-    /**
-     * @param mixed $rule
-     */
     private function isFileRule(mixed $rule): bool
     {
         if (is_string($rule)) {
             $ruleName = explode(':', $rule)[0];
+
             return in_array($ruleName, self::FILE_RULES, true);
         }
 
@@ -155,7 +150,6 @@ class FileUploadDetector
     }
 
     /**
-     * @param mixed $rules
      * @return array<mixed>
      */
     private function normalizeRules(mixed $rules): array
@@ -172,7 +166,7 @@ class FileUploadDetector
     }
 
     /**
-     * @param array<mixed> $rules
+     * @param  array<mixed>  $rules
      * @return array<mixed>
      */
     private function flattenRules(array $rules): array

--- a/tests/Feature/FileUploadAnalyzerIntegrationTest.php
+++ b/tests/Feature/FileUploadAnalyzerIntegrationTest.php
@@ -7,10 +7,10 @@ namespace LaravelSpectrum\Tests\Feature;
 use LaravelSpectrum\Analyzers\FileUploadAnalyzer;
 use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
 use LaravelSpectrum\Analyzers\InlineValidationAnalyzer;
-use LaravelSpectrum\Generators\SchemaGenerator;
-use LaravelSpectrum\Generators\OpenApiGenerator;
-use LaravelSpectrum\Support\TypeInference;
 use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Generators\OpenApiGenerator;
+use LaravelSpectrum\Generators\SchemaGenerator;
+use LaravelSpectrum\Support\TypeInference;
 use LaravelSpectrum\Tests\Fixtures\FormRequests\FileUploadRequest;
 use LaravelSpectrum\Tests\Fixtures\FormRequests\MultipleFilesRequest;
 use PHPUnit\Framework\TestCase;
@@ -18,31 +18,34 @@ use PHPUnit\Framework\TestCase;
 class FileUploadAnalyzerIntegrationTest extends TestCase
 {
     private FormRequestAnalyzer $formRequestAnalyzer;
+
     private InlineValidationAnalyzer $inlineValidationAnalyzer;
+
     private SchemaGenerator $schemaGenerator;
+
     private OpenApiGenerator $openApiGenerator;
 
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         $cache = $this->createMock(DocumentationCache::class);
-        $cache->method('rememberFormRequest')->willReturnCallback(fn($key, $callback) => $callback());
-        
-        $typeInference = new TypeInference();
-        $fileUploadAnalyzer = new FileUploadAnalyzer();
-        
+        $cache->method('rememberFormRequest')->willReturnCallback(fn ($key, $callback) => $callback());
+
+        $typeInference = new TypeInference;
+        $fileUploadAnalyzer = new FileUploadAnalyzer;
+
         $this->formRequestAnalyzer = new FormRequestAnalyzer($typeInference, $cache, null, $fileUploadAnalyzer);
         $this->inlineValidationAnalyzer = new InlineValidationAnalyzer($typeInference, null, $fileUploadAnalyzer);
-        $this->schemaGenerator = new SchemaGenerator();
-        
+        $this->schemaGenerator = new SchemaGenerator;
+
         $this->openApiGenerator = $this->createMock(OpenApiGenerator::class);
     }
 
-    public function testFileUploadRequestGeneratesMultipartSchema(): void
+    public function test_file_upload_request_generates_multipart_schema(): void
     {
         $parameters = $this->formRequestAnalyzer->analyze(FileUploadRequest::class);
-        
+
         // Check file parameters
         $avatarParam = $this->findParameter($parameters, 'avatar');
         $this->assertNotNull($avatarParam);
@@ -52,23 +55,23 @@ class FileUploadAnalyzerIntegrationTest extends TestCase
         // var_dump($avatarParam);
         $this->assertStringContainsString('Profile Picture', $avatarParam['description']);
         $this->assertStringContainsString('Max size: 2MB', $avatarParam['description']);
-        
+
         $resumeParam = $this->findParameter($parameters, 'resume');
         $this->assertNotNull($resumeParam);
         $this->assertEquals('file', $resumeParam['type']);
         $this->assertStringContainsString('Allowed types: pdf, doc, docx', $resumeParam['description']);
         $this->assertStringContainsString('Max size: 10MB', $resumeParam['description']);
-        
+
         // Generate schema
         $schema = $this->schemaGenerator->generateFromParameters($parameters);
-        
+
         // Check that it generates multipart/form-data
         $this->assertArrayHasKey('content', $schema);
         $this->assertArrayHasKey('multipart/form-data', $schema['content']);
-        
+
         $multipartSchema = $schema['content']['multipart/form-data']['schema'];
         $this->assertEquals('object', $multipartSchema['type']);
-        
+
         // Check properties
         $properties = $multipartSchema['properties'];
         $this->assertArrayHasKey('name', $properties);
@@ -76,13 +79,13 @@ class FileUploadAnalyzerIntegrationTest extends TestCase
         $this->assertArrayHasKey('avatar', $properties);
         $this->assertArrayHasKey('resume', $properties);
         $this->assertArrayHasKey('portfolio', $properties);
-        
+
         // Check file properties
         $this->assertEquals('string', $properties['avatar']['type']);
         $this->assertEquals('binary', $properties['avatar']['format']);
         $this->assertEquals('string', $properties['resume']['type']);
         $this->assertEquals('binary', $properties['resume']['format']);
-        
+
         // Check required fields
         $this->assertContains('name', $multipartSchema['required']);
         $this->assertContains('email', $multipartSchema['required']);
@@ -91,10 +94,10 @@ class FileUploadAnalyzerIntegrationTest extends TestCase
         $this->assertNotContains('portfolio', $multipartSchema['required']);
     }
 
-    public function testMultipleFilesRequestGeneratesArraySchema(): void
+    public function test_multiple_files_request_generates_array_schema(): void
     {
         $parameters = $this->formRequestAnalyzer->analyze(MultipleFilesRequest::class);
-        
+
         // Check array file parameters
         $photosParam = $this->findParameter($parameters, 'photos.*');
         $this->assertNotNull($photosParam);
@@ -103,27 +106,27 @@ class FileUploadAnalyzerIntegrationTest extends TestCase
         $this->assertStringContainsString('Photo', $photosParam['description']);
         $this->assertStringContainsString('Max size: 5MB', $photosParam['description']);
         $this->assertStringContainsString('Min dimensions: 100x100', $photosParam['description']);
-        
+
         // Generate schema
         $schema = $this->schemaGenerator->generateFromParameters($parameters);
-        
+
         $this->assertArrayHasKey('content', $schema);
         $this->assertArrayHasKey('multipart/form-data', $schema['content']);
-        
+
         $properties = $schema['content']['multipart/form-data']['schema']['properties'];
-        
+
         // Check photos array
         $this->assertArrayHasKey('photos.*', $properties);
         $this->assertEquals('array', $properties['photos.*']['type']);
         $this->assertEquals('string', $properties['photos.*']['items']['type']);
         $this->assertEquals('binary', $properties['photos.*']['items']['format']);
-        
+
         // Check documents array
         $this->assertArrayHasKey('documents.*', $properties);
         $this->assertEquals('array', $properties['documents.*']['type']);
     }
 
-    public function testInlineValidationWithFileUpload(): void
+    public function test_inline_validation_with_file_upload(): void
     {
         $validation = [
             'rules' => [
@@ -137,24 +140,24 @@ class FileUploadAnalyzerIntegrationTest extends TestCase
                 'attachment' => 'Additional File',
             ],
         ];
-        
+
         $parameters = $this->inlineValidationAnalyzer->generateParameters($validation);
-        
+
         // Check file parameters
         $thumbnailParam = $this->findParameter($parameters, 'thumbnail');
         $this->assertNotNull($thumbnailParam);
         $this->assertEquals('file', $thumbnailParam['type']);
         $this->assertStringContainsString('Allowed types: jpeg, png', $thumbnailParam['description']);
         $this->assertStringContainsString('Max size: 1MB', $thumbnailParam['description']);
-        
+
         // Generate schema
         $schema = $this->schemaGenerator->generateFromParameters($parameters);
-        
+
         $this->assertArrayHasKey('content', $schema);
         $this->assertArrayHasKey('multipart/form-data', $schema['content']);
     }
 
-    public function testMixedContentWithFilesAndRegularFields(): void
+    public function test_mixed_content_with_files_and_regular_fields(): void
     {
         $validation = [
             'rules' => [
@@ -166,18 +169,18 @@ class FileUploadAnalyzerIntegrationTest extends TestCase
                 'bio' => 'nullable|string|max:1000',
             ],
         ];
-        
+
         $parameters = $this->inlineValidationAnalyzer->generateParameters($validation);
         $schema = $this->schemaGenerator->generateFromParameters($parameters);
-        
+
         $this->assertArrayHasKey('content', $schema);
         $properties = $schema['content']['multipart/form-data']['schema']['properties'];
-        
+
         // Regular fields
         $this->assertEquals('string', $properties['name']['type']);
         $this->assertEquals('integer', $properties['age']['type']);
         $this->assertEquals('string', $properties['bio']['type']);
-        
+
         // File fields
         $this->assertEquals('string', $properties['profile_pic']['type']);
         $this->assertEquals('binary', $properties['profile_pic']['format']);
@@ -192,6 +195,7 @@ class FileUploadAnalyzerIntegrationTest extends TestCase
                 return $param;
             }
         }
+
         return null;
     }
 }

--- a/tests/Feature/FileUploadAnalyzerIntegrationTest.php
+++ b/tests/Feature/FileUploadAnalyzerIntegrationTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Feature;
+
+use LaravelSpectrum\Analyzers\FileUploadAnalyzer;
+use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
+use LaravelSpectrum\Analyzers\InlineValidationAnalyzer;
+use LaravelSpectrum\Generators\SchemaGenerator;
+use LaravelSpectrum\Generators\OpenApiGenerator;
+use LaravelSpectrum\Support\TypeInference;
+use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Tests\Fixtures\FormRequests\FileUploadRequest;
+use LaravelSpectrum\Tests\Fixtures\FormRequests\MultipleFilesRequest;
+use PHPUnit\Framework\TestCase;
+
+class FileUploadAnalyzerIntegrationTest extends TestCase
+{
+    private FormRequestAnalyzer $formRequestAnalyzer;
+    private InlineValidationAnalyzer $inlineValidationAnalyzer;
+    private SchemaGenerator $schemaGenerator;
+    private OpenApiGenerator $openApiGenerator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $cache = $this->createMock(DocumentationCache::class);
+        $cache->method('rememberFormRequest')->willReturnCallback(fn($key, $callback) => $callback());
+        
+        $typeInference = new TypeInference();
+        $fileUploadAnalyzer = new FileUploadAnalyzer();
+        
+        $this->formRequestAnalyzer = new FormRequestAnalyzer($typeInference, $cache, null, $fileUploadAnalyzer);
+        $this->inlineValidationAnalyzer = new InlineValidationAnalyzer($typeInference, null, $fileUploadAnalyzer);
+        $this->schemaGenerator = new SchemaGenerator();
+        
+        $this->openApiGenerator = $this->createMock(OpenApiGenerator::class);
+    }
+
+    public function testFileUploadRequestGeneratesMultipartSchema(): void
+    {
+        $parameters = $this->formRequestAnalyzer->analyze(FileUploadRequest::class);
+        
+        // Check file parameters
+        $avatarParam = $this->findParameter($parameters, 'avatar');
+        $this->assertNotNull($avatarParam);
+        $this->assertEquals('file', $avatarParam['type']);
+        $this->assertEquals('binary', $avatarParam['format']);
+        // Debug: print actual parameter
+        // var_dump($avatarParam);
+        $this->assertStringContainsString('Profile Picture', $avatarParam['description']);
+        $this->assertStringContainsString('Max size: 2MB', $avatarParam['description']);
+        
+        $resumeParam = $this->findParameter($parameters, 'resume');
+        $this->assertNotNull($resumeParam);
+        $this->assertEquals('file', $resumeParam['type']);
+        $this->assertStringContainsString('Allowed types: pdf, doc, docx', $resumeParam['description']);
+        $this->assertStringContainsString('Max size: 10MB', $resumeParam['description']);
+        
+        // Generate schema
+        $schema = $this->schemaGenerator->generateFromParameters($parameters);
+        
+        // Check that it generates multipart/form-data
+        $this->assertArrayHasKey('content', $schema);
+        $this->assertArrayHasKey('multipart/form-data', $schema['content']);
+        
+        $multipartSchema = $schema['content']['multipart/form-data']['schema'];
+        $this->assertEquals('object', $multipartSchema['type']);
+        
+        // Check properties
+        $properties = $multipartSchema['properties'];
+        $this->assertArrayHasKey('name', $properties);
+        $this->assertArrayHasKey('email', $properties);
+        $this->assertArrayHasKey('avatar', $properties);
+        $this->assertArrayHasKey('resume', $properties);
+        $this->assertArrayHasKey('portfolio', $properties);
+        
+        // Check file properties
+        $this->assertEquals('string', $properties['avatar']['type']);
+        $this->assertEquals('binary', $properties['avatar']['format']);
+        $this->assertEquals('string', $properties['resume']['type']);
+        $this->assertEquals('binary', $properties['resume']['format']);
+        
+        // Check required fields
+        $this->assertContains('name', $multipartSchema['required']);
+        $this->assertContains('email', $multipartSchema['required']);
+        $this->assertContains('avatar', $multipartSchema['required']);
+        $this->assertContains('resume', $multipartSchema['required']);
+        $this->assertNotContains('portfolio', $multipartSchema['required']);
+    }
+
+    public function testMultipleFilesRequestGeneratesArraySchema(): void
+    {
+        $parameters = $this->formRequestAnalyzer->analyze(MultipleFilesRequest::class);
+        
+        // Check array file parameters
+        $photosParam = $this->findParameter($parameters, 'photos.*');
+        $this->assertNotNull($photosParam);
+        $this->assertEquals('file', $photosParam['type']);
+        $this->assertTrue($photosParam['file_info']['multiple']);
+        $this->assertStringContainsString('Photo', $photosParam['description']);
+        $this->assertStringContainsString('Max size: 5MB', $photosParam['description']);
+        $this->assertStringContainsString('Min dimensions: 100x100', $photosParam['description']);
+        
+        // Generate schema
+        $schema = $this->schemaGenerator->generateFromParameters($parameters);
+        
+        $this->assertArrayHasKey('content', $schema);
+        $this->assertArrayHasKey('multipart/form-data', $schema['content']);
+        
+        $properties = $schema['content']['multipart/form-data']['schema']['properties'];
+        
+        // Check photos array
+        $this->assertArrayHasKey('photos.*', $properties);
+        $this->assertEquals('array', $properties['photos.*']['type']);
+        $this->assertEquals('string', $properties['photos.*']['items']['type']);
+        $this->assertEquals('binary', $properties['photos.*']['items']['format']);
+        
+        // Check documents array
+        $this->assertArrayHasKey('documents.*', $properties);
+        $this->assertEquals('array', $properties['documents.*']['type']);
+    }
+
+    public function testInlineValidationWithFileUpload(): void
+    {
+        $validation = [
+            'rules' => [
+                'title' => 'required|string|max:255',
+                'thumbnail' => 'required|image|mimes:jpeg,png|max:1024',
+                'attachment' => 'nullable|file|max:5120',
+            ],
+            'attributes' => [
+                'title' => 'Article Title',
+                'thumbnail' => 'Thumbnail Image',
+                'attachment' => 'Additional File',
+            ],
+        ];
+        
+        $parameters = $this->inlineValidationAnalyzer->generateParameters($validation);
+        
+        // Check file parameters
+        $thumbnailParam = $this->findParameter($parameters, 'thumbnail');
+        $this->assertNotNull($thumbnailParam);
+        $this->assertEquals('file', $thumbnailParam['type']);
+        $this->assertStringContainsString('Allowed types: jpeg, png', $thumbnailParam['description']);
+        $this->assertStringContainsString('Max size: 1MB', $thumbnailParam['description']);
+        
+        // Generate schema
+        $schema = $this->schemaGenerator->generateFromParameters($parameters);
+        
+        $this->assertArrayHasKey('content', $schema);
+        $this->assertArrayHasKey('multipart/form-data', $schema['content']);
+    }
+
+    public function testMixedContentWithFilesAndRegularFields(): void
+    {
+        $validation = [
+            'rules' => [
+                'name' => 'required|string',
+                'age' => 'required|integer|min:18',
+                'profile_pic' => 'required|image',
+                'documents' => 'array',
+                'documents.*' => 'file|mimes:pdf',
+                'bio' => 'nullable|string|max:1000',
+            ],
+        ];
+        
+        $parameters = $this->inlineValidationAnalyzer->generateParameters($validation);
+        $schema = $this->schemaGenerator->generateFromParameters($parameters);
+        
+        $this->assertArrayHasKey('content', $schema);
+        $properties = $schema['content']['multipart/form-data']['schema']['properties'];
+        
+        // Regular fields
+        $this->assertEquals('string', $properties['name']['type']);
+        $this->assertEquals('integer', $properties['age']['type']);
+        $this->assertEquals('string', $properties['bio']['type']);
+        
+        // File fields
+        $this->assertEquals('string', $properties['profile_pic']['type']);
+        $this->assertEquals('binary', $properties['profile_pic']['format']);
+        $this->assertEquals('array', $properties['documents.*']['type']);
+        $this->assertEquals('binary', $properties['documents.*']['items']['format']);
+    }
+
+    private function findParameter(array $parameters, string $name): ?array
+    {
+        foreach ($parameters as $param) {
+            if ($param['name'] === $name) {
+                return $param;
+            }
+        }
+        return null;
+    }
+}

--- a/tests/Fixtures/FormRequests/FileUploadRequest.php
+++ b/tests/Fixtures/FormRequests/FileUploadRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LaravelSpectrum\Tests\Fixtures\FormRequests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class FileUploadRequest extends FormRequest
+{
+    public function rules()
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email',
+            'avatar' => 'required|image|max:2048',
+            'resume' => 'required|file|mimes:pdf,doc,docx|max:10240',
+            'portfolio' => 'nullable|url',
+        ];
+    }
+    
+    public function attributes()
+    {
+        return [
+            'name' => 'Full Name',
+            'email' => 'Email Address', 
+            'avatar' => 'Profile Picture',
+            'resume' => 'CV/Resume Document',
+            'portfolio' => 'Portfolio Website',
+        ];
+    }
+}

--- a/tests/Fixtures/FormRequests/FileUploadRequest.php
+++ b/tests/Fixtures/FormRequests/FileUploadRequest.php
@@ -16,12 +16,12 @@ class FileUploadRequest extends FormRequest
             'portfolio' => 'nullable|url',
         ];
     }
-    
+
     public function attributes()
     {
         return [
             'name' => 'Full Name',
-            'email' => 'Email Address', 
+            'email' => 'Email Address',
             'avatar' => 'Profile Picture',
             'resume' => 'CV/Resume Document',
             'portfolio' => 'Portfolio Website',

--- a/tests/Fixtures/FormRequests/MultipleFilesRequest.php
+++ b/tests/Fixtures/FormRequests/MultipleFilesRequest.php
@@ -17,7 +17,7 @@ class MultipleFilesRequest extends FormRequest
             'documents.*' => 'file|mimes:pdf,doc,docx|max:20480',
         ];
     }
-    
+
     public function attributes()
     {
         return [

--- a/tests/Fixtures/FormRequests/MultipleFilesRequest.php
+++ b/tests/Fixtures/FormRequests/MultipleFilesRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace LaravelSpectrum\Tests\Fixtures\FormRequests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class MultipleFilesRequest extends FormRequest
+{
+    public function rules()
+    {
+        return [
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'photos' => 'required|array|max:10',
+            'photos.*' => 'image|max:5120|dimensions:min_width=100,min_height=100',
+            'documents' => 'array',
+            'documents.*' => 'file|mimes:pdf,doc,docx|max:20480',
+        ];
+    }
+    
+    public function attributes()
+    {
+        return [
+            'title' => 'Project Title',
+            'description' => 'Project Description',
+            'photos' => 'Photo Gallery',
+            'photos.*' => 'Photo',
+            'documents' => 'Supporting Documents',
+            'documents.*' => 'Document',
+        ];
+    }
+}

--- a/tests/Unit/Analyzers/FileUploadAnalyzerTest.php
+++ b/tests/Unit/Analyzers/FileUploadAnalyzerTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\Analyzers;
+
+use LaravelSpectrum\Analyzers\FileUploadAnalyzer;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Rules\File;
+
+class FileUploadAnalyzerTest extends TestCase
+{
+    private FileUploadAnalyzer $analyzer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->analyzer = new FileUploadAnalyzer();
+    }
+
+    public function testAnalyzesBasicFileRule(): void
+    {
+        $rules = [
+            'document' => 'required|file|max:2048',
+        ];
+
+        $result = $this->analyzer->analyzeRules($rules);
+
+        $this->assertArrayHasKey('document', $result);
+        $this->assertEquals('file', $result['document']['type']);
+        $this->assertFalse($result['document']['is_image']);
+        $this->assertEquals(2097152, $result['document']['max_size']); // 2048 KB in bytes
+        $this->assertFalse($result['document']['multiple']);
+    }
+
+    public function testAnalyzesImageRule(): void
+    {
+        $rules = [
+            'avatar' => 'required|image|mimes:jpeg,png|max:1024',
+        ];
+
+        $result = $this->analyzer->analyzeRules($rules);
+
+        $this->assertArrayHasKey('avatar', $result);
+        $this->assertEquals('file', $result['avatar']['type']);
+        $this->assertTrue($result['avatar']['is_image']);
+        $this->assertEquals(['jpeg', 'png'], $result['avatar']['mimes']);
+        $this->assertContains('image/jpeg', $result['avatar']['mime_types']);
+        $this->assertContains('image/png', $result['avatar']['mime_types']);
+        $this->assertEquals(1048576, $result['avatar']['max_size']); // 1024 KB in bytes
+    }
+
+    public function testAnalyzesMultipleFiles(): void
+    {
+        $rules = [
+            'photos' => 'required|array',
+            'photos.*' => 'image|max:5120',
+        ];
+
+        $result = $this->analyzer->analyzeRules($rules);
+
+        $this->assertArrayHasKey('photos.*', $result);
+        $this->assertEquals('file', $result['photos.*']['type']);
+        $this->assertTrue($result['photos.*']['is_image']);
+        $this->assertTrue($result['photos.*']['multiple']);
+        $this->assertEquals(5242880, $result['photos.*']['max_size']); // 5120 KB in bytes
+    }
+
+    public function testAnalyzesMimeTypes(): void
+    {
+        $rules = [
+            'video' => 'mimetypes:video/mp4,video/avi',
+        ];
+
+        $result = $this->analyzer->analyzeRules($rules);
+
+        $this->assertArrayHasKey('video', $result);
+        $this->assertEquals(['video/mp4', 'video/avi'], $result['video']['mime_types']);
+    }
+
+    public function testAnalyzesDimensions(): void
+    {
+        $rules = [
+            'profile_pic' => 'image|dimensions:min_width=100,min_height=100,ratio=3/2',
+        ];
+
+        $result = $this->analyzer->analyzeRules($rules);
+
+        $this->assertArrayHasKey('profile_pic', $result);
+        $this->assertEquals([
+            'min_width' => 100,
+            'min_height' => 100,
+            'ratio' => '3/2',
+        ], $result['profile_pic']['dimensions']);
+    }
+
+    public function testAnalyzesMinMaxSize(): void
+    {
+        $rules = [
+            'document' => 'file|min:100|max:10240',
+        ];
+
+        $result = $this->analyzer->analyzeRules($rules);
+
+        $this->assertArrayHasKey('document', $result);
+        $this->assertEquals(102400, $result['document']['min_size']); // 100 KB in bytes
+        $this->assertEquals(10485760, $result['document']['max_size']); // 10240 KB in bytes
+    }
+
+    public function testAnalyzesFileRuleObject(): void
+    {
+        $rules = [
+            'video' => [
+                'required',
+                File::types(['mp4', 'avi'])
+                    ->min(1024)
+                    ->max(50 * 1024),
+            ],
+        ];
+
+        $result = $this->analyzer->analyzeRules($rules);
+
+        $this->assertArrayHasKey('video', $result);
+        $this->assertEquals('file', $result['video']['type']);
+        $this->assertEquals(['mp4', 'avi'], $result['video']['mimes']);
+        $this->assertEquals(1048576, $result['video']['min_size']); // 1024 KB in bytes
+        $this->assertEquals(52428800, $result['video']['max_size']); // 50 * 1024 KB in bytes
+    }
+
+    public function testAnalyzesMixedFields(): void
+    {
+        $rules = [
+            'title' => 'required|string',
+            'description' => 'required|string',
+            'thumbnail' => 'required|image',
+            'document' => 'nullable|file|mimes:pdf',
+        ];
+
+        $result = $this->analyzer->analyzeRules($rules);
+
+        $this->assertCount(2, $result);
+        $this->assertArrayHasKey('thumbnail', $result);
+        $this->assertArrayHasKey('document', $result);
+        $this->assertArrayNotHasKey('title', $result);
+        $this->assertArrayNotHasKey('description', $result);
+    }
+
+    public function testInferMimeTypesForImage(): void
+    {
+        $fileRules = [
+            'type' => 'file',
+            'is_image' => true,
+            'mimes' => [],
+        ];
+
+        $result = $this->analyzer->inferMimeTypes($fileRules);
+
+        $this->assertContains('image/jpeg', $result);
+        $this->assertContains('image/png', $result);
+        $this->assertContains('image/gif', $result);
+        $this->assertContains('image/bmp', $result);
+        $this->assertContains('image/svg+xml', $result);
+        $this->assertContains('image/webp', $result);
+    }
+
+    public function testInferMimeTypesFromExtensions(): void
+    {
+        $fileRules = [
+            'mimes' => ['pdf', 'doc', 'docx'],
+        ];
+
+        $result = $this->analyzer->inferMimeTypes($fileRules);
+
+        $this->assertEquals([
+            'application/pdf',
+            'application/msword',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        ], $result);
+    }
+
+    public function testIsMultipleFiles(): void
+    {
+        $this->assertTrue($this->analyzer->isMultipleFiles('photos.*'));
+        $this->assertTrue($this->analyzer->isMultipleFiles('documents.*'));
+        $this->assertTrue($this->analyzer->isMultipleFiles('files.*.document'));
+        $this->assertFalse($this->analyzer->isMultipleFiles('photo'));
+        $this->assertFalse($this->analyzer->isMultipleFiles('document'));
+    }
+
+    public function testAnalyzesOptionalFiles(): void
+    {
+        $rules = [
+            'profile_image' => 'sometimes|image|mimes:jpeg,png|max:1024',
+            'background_image' => 'nullable|image|dimensions:width=1920,height=1080',
+        ];
+
+        $result = $this->analyzer->analyzeRules($rules);
+
+        $this->assertArrayHasKey('profile_image', $result);
+        $this->assertArrayHasKey('background_image', $result);
+        $this->assertTrue($result['profile_image']['is_image']);
+        $this->assertTrue($result['background_image']['is_image']);
+    }
+
+    public function testAnalyzesComplexArrayStructure(): void
+    {
+        $rules = [
+            'attachments' => 'array|max:5',
+            'attachments.*' => 'file|max:5120',
+            'images' => 'array',
+            'images.*.file' => 'required|image',
+            'images.*.caption' => 'required|string',
+        ];
+
+        $result = $this->analyzer->analyzeRules($rules);
+
+        $this->assertArrayHasKey('attachments.*', $result);
+        $this->assertArrayHasKey('images.*.file', $result);
+        $this->assertArrayNotHasKey('images.*.caption', $result);
+        $this->assertTrue($result['attachments.*']['multiple']);
+        $this->assertTrue($result['images.*.file']['multiple']);
+    }
+}

--- a/tests/Unit/Analyzers/FileUploadAnalyzerTest.php
+++ b/tests/Unit/Analyzers/FileUploadAnalyzerTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace LaravelSpectrum\Tests\Unit\Analyzers;
 
+use Illuminate\Validation\Rules\File;
 use LaravelSpectrum\Analyzers\FileUploadAnalyzer;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Validation\Rules\File;
 
 class FileUploadAnalyzerTest extends TestCase
 {
@@ -15,10 +15,10 @@ class FileUploadAnalyzerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->analyzer = new FileUploadAnalyzer();
+        $this->analyzer = new FileUploadAnalyzer;
     }
 
-    public function testAnalyzesBasicFileRule(): void
+    public function test_analyzes_basic_file_rule(): void
     {
         $rules = [
             'document' => 'required|file|max:2048',
@@ -33,7 +33,7 @@ class FileUploadAnalyzerTest extends TestCase
         $this->assertFalse($result['document']['multiple']);
     }
 
-    public function testAnalyzesImageRule(): void
+    public function test_analyzes_image_rule(): void
     {
         $rules = [
             'avatar' => 'required|image|mimes:jpeg,png|max:1024',
@@ -50,7 +50,7 @@ class FileUploadAnalyzerTest extends TestCase
         $this->assertEquals(1048576, $result['avatar']['max_size']); // 1024 KB in bytes
     }
 
-    public function testAnalyzesMultipleFiles(): void
+    public function test_analyzes_multiple_files(): void
     {
         $rules = [
             'photos' => 'required|array',
@@ -66,7 +66,7 @@ class FileUploadAnalyzerTest extends TestCase
         $this->assertEquals(5242880, $result['photos.*']['max_size']); // 5120 KB in bytes
     }
 
-    public function testAnalyzesMimeTypes(): void
+    public function test_analyzes_mime_types(): void
     {
         $rules = [
             'video' => 'mimetypes:video/mp4,video/avi',
@@ -78,7 +78,7 @@ class FileUploadAnalyzerTest extends TestCase
         $this->assertEquals(['video/mp4', 'video/avi'], $result['video']['mime_types']);
     }
 
-    public function testAnalyzesDimensions(): void
+    public function test_analyzes_dimensions(): void
     {
         $rules = [
             'profile_pic' => 'image|dimensions:min_width=100,min_height=100,ratio=3/2',
@@ -94,7 +94,7 @@ class FileUploadAnalyzerTest extends TestCase
         ], $result['profile_pic']['dimensions']);
     }
 
-    public function testAnalyzesMinMaxSize(): void
+    public function test_analyzes_min_max_size(): void
     {
         $rules = [
             'document' => 'file|min:100|max:10240',
@@ -107,7 +107,7 @@ class FileUploadAnalyzerTest extends TestCase
         $this->assertEquals(10485760, $result['document']['max_size']); // 10240 KB in bytes
     }
 
-    public function testAnalyzesFileRuleObject(): void
+    public function test_analyzes_file_rule_object(): void
     {
         $rules = [
             'video' => [
@@ -127,7 +127,7 @@ class FileUploadAnalyzerTest extends TestCase
         $this->assertEquals(52428800, $result['video']['max_size']); // 50 * 1024 KB in bytes
     }
 
-    public function testAnalyzesMixedFields(): void
+    public function test_analyzes_mixed_fields(): void
     {
         $rules = [
             'title' => 'required|string',
@@ -145,7 +145,7 @@ class FileUploadAnalyzerTest extends TestCase
         $this->assertArrayNotHasKey('description', $result);
     }
 
-    public function testInferMimeTypesForImage(): void
+    public function test_infer_mime_types_for_image(): void
     {
         $fileRules = [
             'type' => 'file',
@@ -163,7 +163,7 @@ class FileUploadAnalyzerTest extends TestCase
         $this->assertContains('image/webp', $result);
     }
 
-    public function testInferMimeTypesFromExtensions(): void
+    public function test_infer_mime_types_from_extensions(): void
     {
         $fileRules = [
             'mimes' => ['pdf', 'doc', 'docx'],
@@ -178,7 +178,7 @@ class FileUploadAnalyzerTest extends TestCase
         ], $result);
     }
 
-    public function testIsMultipleFiles(): void
+    public function test_is_multiple_files(): void
     {
         $this->assertTrue($this->analyzer->isMultipleFiles('photos.*'));
         $this->assertTrue($this->analyzer->isMultipleFiles('documents.*'));
@@ -187,7 +187,7 @@ class FileUploadAnalyzerTest extends TestCase
         $this->assertFalse($this->analyzer->isMultipleFiles('document'));
     }
 
-    public function testAnalyzesOptionalFiles(): void
+    public function test_analyzes_optional_files(): void
     {
         $rules = [
             'profile_image' => 'sometimes|image|mimes:jpeg,png|max:1024',
@@ -202,7 +202,7 @@ class FileUploadAnalyzerTest extends TestCase
         $this->assertTrue($result['background_image']['is_image']);
     }
 
-    public function testAnalyzesComplexArrayStructure(): void
+    public function test_analyzes_complex_array_structure(): void
     {
         $rules = [
             'attachments' => 'array|max:5',

--- a/tests/Unit/Generators/FileUploadSchemaGeneratorTest.php
+++ b/tests/Unit/Generators/FileUploadSchemaGeneratorTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\Generators;
+
+use LaravelSpectrum\Generators\FileUploadSchemaGenerator;
+use PHPUnit\Framework\TestCase;
+
+class FileUploadSchemaGeneratorTest extends TestCase
+{
+    private FileUploadSchemaGenerator $generator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->generator = new FileUploadSchemaGenerator();
+    }
+
+    public function testGenerateBasicFileSchema(): void
+    {
+        $fileField = [
+            'type' => 'file',
+            'is_image' => false,
+            'mimes' => [],
+            'max_size' => null,
+        ];
+
+        $schema = $this->generator->generate($fileField);
+
+        $this->assertEquals('string', $schema['type']);
+        $this->assertEquals('binary', $schema['format']);
+        $this->assertArrayNotHasKey('description', $schema);
+    }
+
+    public function testGenerateFileSchemaWithDescription(): void
+    {
+        $fileField = [
+            'type' => 'file',
+            'is_image' => true,
+            'mimes' => ['jpeg', 'png'],
+            'max_size' => 2097152, // 2MB in bytes
+        ];
+
+        $schema = $this->generator->generate($fileField);
+
+        $this->assertEquals('string', $schema['type']);
+        $this->assertEquals('binary', $schema['format']);
+        $this->assertArrayHasKey('description', $schema);
+        $this->assertStringContainsString('Allowed types: jpeg, png', $schema['description']);
+        $this->assertStringContainsString('Max size: 2MB', $schema['description']);
+    }
+
+    public function testGenerateFileSchemaWithAllConstraints(): void
+    {
+        $fileField = [
+            'type' => 'file',
+            'is_image' => true,
+            'mimes' => ['jpeg', 'png', 'gif'],
+            'max_size' => 5242880, // 5MB
+            'min_size' => 102400, // 100KB
+            'dimensions' => [
+                'min_width' => 100,
+                'min_height' => 100,
+                'max_width' => 2000,
+                'max_height' => 2000,
+            ],
+        ];
+
+        $schema = $this->generator->generate($fileField);
+
+        $this->assertEquals('string', $schema['type']);
+        $this->assertEquals('binary', $schema['format']);
+        $this->assertStringContainsString('Allowed types: jpeg, png, gif', $schema['description']);
+        $this->assertStringContainsString('Max size: 5MB', $schema['description']);
+        $this->assertStringContainsString('Min size: 100KB', $schema['description']);
+        $this->assertStringContainsString('Min dimensions: 100x100', $schema['description']);
+        $this->assertStringContainsString('Max dimensions: 2000x2000', $schema['description']);
+    }
+
+    public function testGenerateMultipartSchema(): void
+    {
+        $fields = [
+            'title' => [
+                'type' => 'string',
+                'required' => true,
+                'maxLength' => 255,
+            ],
+            'description' => [
+                'type' => 'string',
+                'required' => true,
+            ],
+        ];
+
+        $fileFields = [
+            'thumbnail' => [
+                'type' => 'string',
+                'format' => 'binary',
+                'description' => 'Allowed types: jpeg, png. Max size: 2MB',
+                'required' => true,
+            ],
+            'document' => [
+                'type' => 'string',
+                'format' => 'binary',
+                'description' => 'Allowed types: pdf. Max size: 10MB',
+                'required' => false,
+            ],
+        ];
+
+        $schema = $this->generator->generateMultipartSchema($fields, $fileFields);
+
+        $this->assertArrayHasKey('content', $schema);
+        $this->assertArrayHasKey('multipart/form-data', $schema['content']);
+        
+        $multipartSchema = $schema['content']['multipart/form-data']['schema'];
+        $this->assertEquals('object', $multipartSchema['type']);
+        
+        $properties = $multipartSchema['properties'];
+        $this->assertArrayHasKey('title', $properties);
+        $this->assertArrayHasKey('description', $properties);
+        $this->assertArrayHasKey('thumbnail', $properties);
+        $this->assertArrayHasKey('document', $properties);
+        
+        $this->assertEquals('string', $properties['thumbnail']['type']);
+        $this->assertEquals('binary', $properties['thumbnail']['format']);
+        
+        $required = $multipartSchema['required'];
+        $this->assertContains('title', $required);
+        $this->assertContains('description', $required);
+        $this->assertContains('thumbnail', $required);
+        $this->assertNotContains('document', $required);
+    }
+
+    public function testFormatFileSize(): void
+    {
+        $reflection = new \ReflectionClass($this->generator);
+        $method = $reflection->getMethod('formatFileSize');
+        $method->setAccessible(true);
+
+        $this->assertEquals('1KB', $method->invoke($this->generator, 1024));
+        $this->assertEquals('100KB', $method->invoke($this->generator, 102400));
+        $this->assertEquals('1MB', $method->invoke($this->generator, 1048576));
+        $this->assertEquals('2MB', $method->invoke($this->generator, 2097152));
+        $this->assertEquals('1GB', $method->invoke($this->generator, 1073741824));
+        $this->assertEquals('1.5GB', $method->invoke($this->generator, 1610612736));
+        $this->assertEquals('500B', $method->invoke($this->generator, 500));
+    }
+
+    public function testGenerateMultipartSchemaWithArrayFiles(): void
+    {
+        $fields = [
+            'title' => [
+                'type' => 'string',
+                'required' => true,
+            ],
+        ];
+
+        $fileFields = [
+            'photos' => [
+                'type' => 'array',
+                'items' => [
+                    'type' => 'string',
+                    'format' => 'binary',
+                    'description' => 'Image files. Max size: 5MB',
+                ],
+                'required' => true,
+            ],
+        ];
+
+        $schema = $this->generator->generateMultipartSchema($fields, $fileFields);
+
+        $properties = $schema['content']['multipart/form-data']['schema']['properties'];
+        $this->assertArrayHasKey('photos', $properties);
+        $this->assertEquals('array', $properties['photos']['type']);
+        $this->assertEquals('string', $properties['photos']['items']['type']);
+        $this->assertEquals('binary', $properties['photos']['items']['format']);
+    }
+
+    public function testGenerateDescriptionWithRatio(): void
+    {
+        $fileField = [
+            'type' => 'file',
+            'is_image' => true,
+            'mimes' => ['jpeg'],
+            'dimensions' => [
+                'ratio' => '16/9',
+            ],
+        ];
+
+        $schema = $this->generator->generate($fileField);
+
+        $this->assertStringContainsString('Aspect ratio: 16/9', $schema['description']);
+    }
+
+    public function testGenerateDescriptionWithExactDimensions(): void
+    {
+        $fileField = [
+            'type' => 'file',
+            'is_image' => true,
+            'dimensions' => [
+                'width' => 1920,
+                'height' => 1080,
+            ],
+        ];
+
+        $schema = $this->generator->generate($fileField);
+
+        $this->assertStringContainsString('Required dimensions: 1920x1080', $schema['description']);
+    }
+}

--- a/tests/Unit/Generators/FileUploadSchemaGeneratorTest.php
+++ b/tests/Unit/Generators/FileUploadSchemaGeneratorTest.php
@@ -14,10 +14,10 @@ class FileUploadSchemaGeneratorTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->generator = new FileUploadSchemaGenerator();
+        $this->generator = new FileUploadSchemaGenerator;
     }
 
-    public function testGenerateBasicFileSchema(): void
+    public function test_generate_basic_file_schema(): void
     {
         $fileField = [
             'type' => 'file',
@@ -33,7 +33,7 @@ class FileUploadSchemaGeneratorTest extends TestCase
         $this->assertArrayNotHasKey('description', $schema);
     }
 
-    public function testGenerateFileSchemaWithDescription(): void
+    public function test_generate_file_schema_with_description(): void
     {
         $fileField = [
             'type' => 'file',
@@ -51,7 +51,7 @@ class FileUploadSchemaGeneratorTest extends TestCase
         $this->assertStringContainsString('Max size: 2MB', $schema['description']);
     }
 
-    public function testGenerateFileSchemaWithAllConstraints(): void
+    public function test_generate_file_schema_with_all_constraints(): void
     {
         $fileField = [
             'type' => 'file',
@@ -78,7 +78,7 @@ class FileUploadSchemaGeneratorTest extends TestCase
         $this->assertStringContainsString('Max dimensions: 2000x2000', $schema['description']);
     }
 
-    public function testGenerateMultipartSchema(): void
+    public function test_generate_multipart_schema(): void
     {
         $fields = [
             'title' => [
@@ -111,19 +111,19 @@ class FileUploadSchemaGeneratorTest extends TestCase
 
         $this->assertArrayHasKey('content', $schema);
         $this->assertArrayHasKey('multipart/form-data', $schema['content']);
-        
+
         $multipartSchema = $schema['content']['multipart/form-data']['schema'];
         $this->assertEquals('object', $multipartSchema['type']);
-        
+
         $properties = $multipartSchema['properties'];
         $this->assertArrayHasKey('title', $properties);
         $this->assertArrayHasKey('description', $properties);
         $this->assertArrayHasKey('thumbnail', $properties);
         $this->assertArrayHasKey('document', $properties);
-        
+
         $this->assertEquals('string', $properties['thumbnail']['type']);
         $this->assertEquals('binary', $properties['thumbnail']['format']);
-        
+
         $required = $multipartSchema['required'];
         $this->assertContains('title', $required);
         $this->assertContains('description', $required);
@@ -131,7 +131,7 @@ class FileUploadSchemaGeneratorTest extends TestCase
         $this->assertNotContains('document', $required);
     }
 
-    public function testFormatFileSize(): void
+    public function test_format_file_size(): void
     {
         $reflection = new \ReflectionClass($this->generator);
         $method = $reflection->getMethod('formatFileSize');
@@ -146,7 +146,7 @@ class FileUploadSchemaGeneratorTest extends TestCase
         $this->assertEquals('500B', $method->invoke($this->generator, 500));
     }
 
-    public function testGenerateMultipartSchemaWithArrayFiles(): void
+    public function test_generate_multipart_schema_with_array_files(): void
     {
         $fields = [
             'title' => [
@@ -176,7 +176,7 @@ class FileUploadSchemaGeneratorTest extends TestCase
         $this->assertEquals('binary', $properties['photos']['items']['format']);
     }
 
-    public function testGenerateDescriptionWithRatio(): void
+    public function test_generate_description_with_ratio(): void
     {
         $fileField = [
             'type' => 'file',
@@ -192,7 +192,7 @@ class FileUploadSchemaGeneratorTest extends TestCase
         $this->assertStringContainsString('Aspect ratio: 16/9', $schema['description']);
     }
 
-    public function testGenerateDescriptionWithExactDimensions(): void
+    public function test_generate_description_with_exact_dimensions(): void
     {
         $fileField = [
             'type' => 'file',

--- a/tests/Unit/Support/FileUploadDetectorTest.php
+++ b/tests/Unit/Support/FileUploadDetectorTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\Support;
+
+use LaravelSpectrum\Support\FileUploadDetector;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Rules\File;
+
+class FileUploadDetectorTest extends TestCase
+{
+    private FileUploadDetector $detector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->detector = new FileUploadDetector();
+    }
+
+    public function testExtractFileRulesFromStringRules(): void
+    {
+        $rules = [
+            'name' => 'required|string',
+            'avatar' => 'required|image|max:2048',
+            'document' => 'file|mimes:pdf,doc|max:5120',
+            'email' => 'required|email',
+        ];
+
+        $fileRules = $this->detector->extractFileRules($rules);
+
+        $this->assertArrayHasKey('avatar', $fileRules);
+        $this->assertArrayHasKey('document', $fileRules);
+        $this->assertArrayNotHasKey('name', $fileRules);
+        $this->assertArrayNotHasKey('email', $fileRules);
+        $this->assertContains('image', $fileRules['avatar']);
+        $this->assertContains('file', $fileRules['document']);
+    }
+
+    public function testExtractFileRulesFromArrayRules(): void
+    {
+        $rules = [
+            'title' => ['required', 'string', 'max:255'],
+            'photo' => ['required', 'image', 'dimensions:min_width=100'],
+            'attachment' => ['nullable', 'file', 'max:10240'],
+        ];
+
+        $fileRules = $this->detector->extractFileRules($rules);
+
+        $this->assertArrayHasKey('photo', $fileRules);
+        $this->assertArrayHasKey('attachment', $fileRules);
+        $this->assertArrayNotHasKey('title', $fileRules);
+    }
+
+    public function testExtractFileRulesFromRuleObjects(): void
+    {
+        $rules = [
+            'video' => [
+                'required',
+                File::types(['mp4', 'avi'])->max(50 * 1024),
+            ],
+            'description' => 'required|string',
+        ];
+
+        $fileRules = $this->detector->extractFileRules($rules);
+
+        $this->assertArrayHasKey('video', $fileRules);
+        $this->assertArrayNotHasKey('description', $fileRules);
+        $this->assertCount(2, $fileRules['video']);
+        $this->assertInstanceOf(File::class, $fileRules['video'][1]);
+    }
+
+    public function testGetMimeTypeMapping(): void
+    {
+        $mapping = $this->detector->getMimeTypeMapping();
+
+        $this->assertEquals('image/jpeg', $mapping['jpg']);
+        $this->assertEquals('image/jpeg', $mapping['jpeg']);
+        $this->assertEquals('image/png', $mapping['png']);
+        $this->assertEquals('application/pdf', $mapping['pdf']);
+        $this->assertEquals('application/msword', $mapping['doc']);
+        $this->assertEquals('video/mp4', $mapping['mp4']);
+        $this->assertEquals('text/csv', $mapping['csv']);
+    }
+
+    public function testExtractSizeConstraints(): void
+    {
+        $rules = ['required', 'file', 'min:100', 'max:2048'];
+
+        $constraints = $this->detector->extractSizeConstraints($rules);
+
+        $this->assertEquals(102400, $constraints['min']); // 100 KB in bytes
+        $this->assertEquals(2097152, $constraints['max']); // 2048 KB in bytes
+    }
+
+    public function testExtractSizeConstraintsFromString(): void
+    {
+        $rules = ['required|file|min:50|max:1024'];
+
+        $constraints = $this->detector->extractSizeConstraints($rules);
+
+        $this->assertEquals(51200, $constraints['min']); // 50 KB in bytes
+        $this->assertEquals(1048576, $constraints['max']); // 1024 KB in bytes
+    }
+
+    public function testExtractSizeConstraintsEmpty(): void
+    {
+        $rules = ['required', 'image'];
+
+        $constraints = $this->detector->extractSizeConstraints($rules);
+
+        $this->assertArrayNotHasKey('min', $constraints);
+        $this->assertArrayNotHasKey('max', $constraints);
+    }
+
+    public function testExtractDimensionConstraints(): void
+    {
+        $rules = [
+            'required',
+            'image',
+            'dimensions:min_width=100,min_height=200,max_width=1000,max_height=2000,ratio=3/2',
+        ];
+
+        $dimensions = $this->detector->extractDimensionConstraints($rules);
+
+        $this->assertEquals(100, $dimensions['min_width']);
+        $this->assertEquals(200, $dimensions['min_height']);
+        $this->assertEquals(1000, $dimensions['max_width']);
+        $this->assertEquals(2000, $dimensions['max_height']);
+        $this->assertEquals('3/2', $dimensions['ratio']);
+    }
+
+    public function testExtractDimensionConstraintsFromString(): void
+    {
+        $rules = ['required|image|dimensions:width=500,height=500'];
+
+        $dimensions = $this->detector->extractDimensionConstraints($rules);
+
+        $this->assertEquals(500, $dimensions['width']);
+        $this->assertEquals(500, $dimensions['height']);
+    }
+
+    public function testExtractDimensionConstraintsEmpty(): void
+    {
+        $rules = ['required', 'file'];
+
+        $dimensions = $this->detector->extractDimensionConstraints($rules);
+
+        $this->assertEmpty($dimensions);
+    }
+
+    public function testExtractFileRulesHandlesComplexPatterns(): void
+    {
+        $rules = [
+            'documents' => 'array|max:5',
+            'documents.*' => 'file|mimes:pdf,doc,docx|max:10240',
+            'images.*.file' => 'required|image|max:5120',
+            'images.*.caption' => 'required|string|max:255',
+        ];
+
+        $fileRules = $this->detector->extractFileRules($rules);
+
+        $this->assertArrayHasKey('documents.*', $fileRules);
+        $this->assertArrayHasKey('images.*.file', $fileRules);
+        $this->assertArrayNotHasKey('documents', $fileRules);
+        $this->assertArrayNotHasKey('images.*.caption', $fileRules);
+    }
+}

--- a/tests/Unit/Support/FileUploadDetectorTest.php
+++ b/tests/Unit/Support/FileUploadDetectorTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace LaravelSpectrum\Tests\Unit\Support;
 
+use Illuminate\Validation\Rules\File;
 use LaravelSpectrum\Support\FileUploadDetector;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Validation\Rules\File;
 
 class FileUploadDetectorTest extends TestCase
 {
@@ -15,10 +15,10 @@ class FileUploadDetectorTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->detector = new FileUploadDetector();
+        $this->detector = new FileUploadDetector;
     }
 
-    public function testExtractFileRulesFromStringRules(): void
+    public function test_extract_file_rules_from_string_rules(): void
     {
         $rules = [
             'name' => 'required|string',
@@ -37,7 +37,7 @@ class FileUploadDetectorTest extends TestCase
         $this->assertContains('file', $fileRules['document']);
     }
 
-    public function testExtractFileRulesFromArrayRules(): void
+    public function test_extract_file_rules_from_array_rules(): void
     {
         $rules = [
             'title' => ['required', 'string', 'max:255'],
@@ -52,7 +52,7 @@ class FileUploadDetectorTest extends TestCase
         $this->assertArrayNotHasKey('title', $fileRules);
     }
 
-    public function testExtractFileRulesFromRuleObjects(): void
+    public function test_extract_file_rules_from_rule_objects(): void
     {
         $rules = [
             'video' => [
@@ -70,7 +70,7 @@ class FileUploadDetectorTest extends TestCase
         $this->assertInstanceOf(File::class, $fileRules['video'][1]);
     }
 
-    public function testGetMimeTypeMapping(): void
+    public function test_get_mime_type_mapping(): void
     {
         $mapping = $this->detector->getMimeTypeMapping();
 
@@ -83,7 +83,7 @@ class FileUploadDetectorTest extends TestCase
         $this->assertEquals('text/csv', $mapping['csv']);
     }
 
-    public function testExtractSizeConstraints(): void
+    public function test_extract_size_constraints(): void
     {
         $rules = ['required', 'file', 'min:100', 'max:2048'];
 
@@ -93,7 +93,7 @@ class FileUploadDetectorTest extends TestCase
         $this->assertEquals(2097152, $constraints['max']); // 2048 KB in bytes
     }
 
-    public function testExtractSizeConstraintsFromString(): void
+    public function test_extract_size_constraints_from_string(): void
     {
         $rules = ['required|file|min:50|max:1024'];
 
@@ -103,7 +103,7 @@ class FileUploadDetectorTest extends TestCase
         $this->assertEquals(1048576, $constraints['max']); // 1024 KB in bytes
     }
 
-    public function testExtractSizeConstraintsEmpty(): void
+    public function test_extract_size_constraints_empty(): void
     {
         $rules = ['required', 'image'];
 
@@ -113,7 +113,7 @@ class FileUploadDetectorTest extends TestCase
         $this->assertArrayNotHasKey('max', $constraints);
     }
 
-    public function testExtractDimensionConstraints(): void
+    public function test_extract_dimension_constraints(): void
     {
         $rules = [
             'required',
@@ -130,7 +130,7 @@ class FileUploadDetectorTest extends TestCase
         $this->assertEquals('3/2', $dimensions['ratio']);
     }
 
-    public function testExtractDimensionConstraintsFromString(): void
+    public function test_extract_dimension_constraints_from_string(): void
     {
         $rules = ['required|image|dimensions:width=500,height=500'];
 
@@ -140,7 +140,7 @@ class FileUploadDetectorTest extends TestCase
         $this->assertEquals(500, $dimensions['height']);
     }
 
-    public function testExtractDimensionConstraintsEmpty(): void
+    public function test_extract_dimension_constraints_empty(): void
     {
         $rules = ['required', 'file'];
 
@@ -149,7 +149,7 @@ class FileUploadDetectorTest extends TestCase
         $this->assertEmpty($dimensions);
     }
 
-    public function testExtractFileRulesHandlesComplexPatterns(): void
+    public function test_extract_file_rules_handles_complex_patterns(): void
     {
         $rules = [
             'documents' => 'array|max:5',


### PR DESCRIPTION
# 概要

Laravel Spectrumにファイルアップロードを自動検出してOpenAPIドキュメントに`multipart/form-data`として出力する機能を実装しました。

## 変更内容

バリデーションルールからファイルアップロードフィールドを自動検出し、適切なOpenAPIスキーマを生成する機能を追加しました。

### 主な実装内容:

- **FileUploadAnalyzer**: バリデーションルール（`file`, `image`, `mimes`など）からファイルアップロードフィールドを検出
- **FileUploadSchemaGenerator**: multipart/form-dataのOpenAPIスキーマを生成
- **既存クラスの拡張**: FormRequestAnalyzerとInlineValidationAnalyzerにファイル検出機能を統合
- **複数ファイルアップロード対応**: `photos.*`のような配列形式のファイルアップロードに対応
- **詳細な制約情報**: ファイルサイズ、MIME タイプ、画像の寸法制限などをdescriptionに含める

### 生成例:
```yaml
requestBody:
  required: true
  content:
    multipart/form-data:
      schema:
        type: object
        properties:
          avatar:
            type: string
            format: binary
            description: "Profile Picture (Allowed types: jpeg, png. Max size: 2MB)"
```

### テスト:
- 単体テスト: 32個（FileUploadAnalyzer, FileUploadDetector, FileUploadSchemaGenerator）
- 統合テスト: 4個のシナリオ
- デモアプリでの動作確認済み

## 関連情報

- docs/file_upload.md の実装