### PR TITLE
Bugfix: PHPStanの配列キー型エラーを修正

### DIFF
--- a/src/Cache/DocumentationCache.php
+++ b/src/Cache/DocumentationCache.php
@@ -351,7 +351,7 @@ class DocumentationCache
     private function humanFilesize(int $bytes): string
     {
         $units = ['B', 'KB', 'MB', 'GB'];
-        $factor = floor((strlen((string) $bytes) - 1) / 3);
+        $factor = (int) floor((strlen((string) $bytes) - 1) / 3);
 
         return sprintf('%.2f', $bytes / pow(1024, $factor)).' '.$units[$factor];
     }


### PR DESCRIPTION
# 概要

PHPStanで検出された配列キー型エラーを修正しました。

## 変更内容

`floor()`関数は`float`型を返しますが、配列のキーとして使用するには`int`型が必要です。

- `src/Cache/DocumentationCache.php`の`humanFilesize()`メソッドで、`floor()`の戻り値を`(int)`にキャスト

## 関連情報

- PHPStan error: `Invalid array key type float. offsetAccess.invalidOffset`