### PR TITLE
test: add unit tests for ResponseStructureVisitor and IncrementalCache

### DIFF
--- a/src/Cache/IncrementalCache.php
+++ b/src/Cache/IncrementalCache.php
@@ -3,7 +3,6 @@
 namespace LaravelSpectrum\Cache;
 
 use LaravelSpectrum\Performance\DependencyGraph;
-use LaravelSpectrum\Services\DocumentationCache;
 
 class IncrementalCache extends DocumentationCache
 {

--- a/tests/Unit/Analyzers/AST/Visitors/ResponseStructureVisitorTest.php
+++ b/tests/Unit/Analyzers/AST/Visitors/ResponseStructureVisitorTest.php
@@ -1,0 +1,367 @@
+<?php
+
+namespace LaravelSpectrum\Tests\Unit\Analyzers\AST\Visitors;
+
+use LaravelSpectrum\Analyzers\AST\Visitors\ResponseStructureVisitor;
+use LaravelSpectrum\Tests\TestCase;
+use PhpParser\NodeTraverser;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\Test;
+
+class ResponseStructureVisitorTest extends TestCase
+{
+    private $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parser = (new ParserFactory)->createForNewestSupportedVersion();
+    }
+
+    #[Test]
+    public function it_tracks_variable_assignments(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        $name = 'John';
+        $age = 25;
+        PHP;
+
+        $visitor = new ResponseStructureVisitor;
+        $ast = $this->parser->parse($code);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $variables = $visitor->getVariables();
+
+        $this->assertArrayHasKey('name', $variables);
+        $this->assertArrayHasKey('age', $variables);
+    }
+
+    #[Test]
+    public function it_detects_response_json_pattern(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        return response()->json(['message' => 'Success']);
+        PHP;
+
+        $visitor = new ResponseStructureVisitor;
+        $ast = $this->parser->parse($code);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $structure = $visitor->getStructure();
+
+        $this->assertEquals('response_json', $structure['type']);
+        $this->assertArrayHasKey('data', $structure);
+    }
+
+    #[Test]
+    public function it_tracks_collection_operations(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        $users->map(function($user) {
+            return $user->name;
+        });
+        $users->filter('active');
+        $users->pluck('id');
+        $users->only(['name', 'email']);
+        $users->except(['password']);
+        PHP;
+
+        $visitor = new ResponseStructureVisitor;
+        $ast = $this->parser->parse($code);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $structure = $visitor->getStructure();
+
+        $this->assertArrayHasKey('collection_operations', $structure);
+        $this->assertCount(5, $structure['collection_operations']);
+
+        $methods = array_column($structure['collection_operations'], 'method');
+        $this->assertContains('map', $methods);
+        $this->assertContains('filter', $methods);
+        $this->assertContains('pluck', $methods);
+        $this->assertContains('only', $methods);
+        $this->assertContains('except', $methods);
+    }
+
+    #[Test]
+    public function it_analyzes_array_structures(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        $data = [
+            'name' => 'John',
+            'age' => 25,
+            'active' => true,
+        ];
+        PHP;
+
+        $visitor = new ResponseStructureVisitor;
+        $ast = $this->parser->parse($code);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $structure = $visitor->getStructure();
+
+        $this->assertArrayHasKey('array_structures', $structure);
+        $this->assertNotEmpty($structure['array_structures']);
+
+        $arrayStructure = $structure['array_structures'][0];
+        $this->assertEquals('John', $arrayStructure['name']);
+        $this->assertEquals(25, $arrayStructure['age']);
+        $this->assertEquals('true', $arrayStructure['active']);
+    }
+
+    #[Test]
+    public function it_extracts_string_values(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        $message = 'Hello World';
+        PHP;
+
+        $visitor = new ResponseStructureVisitor;
+        $ast = $this->parser->parse($code);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $variables = $visitor->getVariables();
+
+        $this->assertArrayHasKey('message', $variables);
+    }
+
+    #[Test]
+    public function it_extracts_integer_values(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        $count = 42;
+        PHP;
+
+        $visitor = new ResponseStructureVisitor;
+        $ast = $this->parser->parse($code);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $variables = $visitor->getVariables();
+
+        $this->assertArrayHasKey('count', $variables);
+    }
+
+    #[Test]
+    public function it_extracts_float_values(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        $price = 19.99;
+        PHP;
+
+        $visitor = new ResponseStructureVisitor;
+        $ast = $this->parser->parse($code);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $variables = $visitor->getVariables();
+
+        $this->assertArrayHasKey('price', $variables);
+    }
+
+    #[Test]
+    public function it_returns_empty_structure_for_empty_code(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        // Empty file
+        PHP;
+
+        $visitor = new ResponseStructureVisitor;
+        $ast = $this->parser->parse($code);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $structure = $visitor->getStructure();
+        $variables = $visitor->getVariables();
+
+        $this->assertEmpty($structure);
+        $this->assertEmpty($variables);
+    }
+
+    #[Test]
+    public function it_handles_nested_array_in_response_json(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        return response()->json([
+            'user' => [
+                'name' => 'John',
+                'email' => 'john@example.com',
+            ],
+            'status' => 'success',
+        ]);
+        PHP;
+
+        $visitor = new ResponseStructureVisitor;
+        $ast = $this->parser->parse($code);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $structure = $visitor->getStructure();
+
+        $this->assertEquals('response_json', $structure['type']);
+        $this->assertArrayHasKey('data', $structure);
+    }
+
+    #[Test]
+    public function it_handles_response_json_without_data(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        return response()->json();
+        PHP;
+
+        $visitor = new ResponseStructureVisitor;
+        $ast = $this->parser->parse($code);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $structure = $visitor->getStructure();
+
+        $this->assertEquals('response_json', $structure['type']);
+        $this->assertArrayNotHasKey('data', $structure);
+    }
+
+    #[Test]
+    public function it_ignores_non_response_method_calls(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        $service->json(['data' => 'value']);
+        PHP;
+
+        $visitor = new ResponseStructureVisitor;
+        $ast = $this->parser->parse($code);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $structure = $visitor->getStructure();
+
+        $this->assertArrayNotHasKey('type', $structure);
+    }
+
+    #[Test]
+    public function it_handles_method_call_without_identifier_name(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        $obj->$dynamicMethod();
+        PHP;
+
+        $visitor = new ResponseStructureVisitor;
+        $ast = $this->parser->parse($code);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $structure = $visitor->getStructure();
+
+        // Should not crash and return empty structure
+        $this->assertEmpty($structure);
+    }
+
+    #[Test]
+    public function it_resolves_variable_references_in_arrays(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        $name = 'John';
+        $data = [
+            'name' => $name,
+        ];
+        PHP;
+
+        $visitor = new ResponseStructureVisitor;
+        $ast = $this->parser->parse($code);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $structure = $visitor->getStructure();
+
+        $this->assertArrayHasKey('array_structures', $structure);
+        // The variable reference should be resolved to its value
+        $this->assertEquals('John', $structure['array_structures'][0]['name']);
+    }
+
+    #[Test]
+    public function it_handles_collection_operation_with_string_argument(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        $users->pluck('email');
+        PHP;
+
+        $visitor = new ResponseStructureVisitor;
+        $ast = $this->parser->parse($code);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $structure = $visitor->getStructure();
+
+        $this->assertArrayHasKey('collection_operations', $structure);
+        $this->assertEquals('pluck', $structure['collection_operations'][0]['method']);
+        $this->assertEquals(['email'], $structure['collection_operations'][0]['args']);
+    }
+
+    #[Test]
+    public function it_handles_arrays_without_keys(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        $items = ['apple', 'banana', 'cherry'];
+        PHP;
+
+        $visitor = new ResponseStructureVisitor;
+        $ast = $this->parser->parse($code);
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $structure = $visitor->getStructure();
+
+        $this->assertArrayHasKey('array_structures', $structure);
+        // Items without keys should not be added to the structure
+        $this->assertEmpty($structure['array_structures'][0]);
+    }
+}

--- a/tests/Unit/Cache/IncrementalCacheTest.php
+++ b/tests/Unit/Cache/IncrementalCacheTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace LaravelSpectrum\Tests\Unit\Cache;
+
+use LaravelSpectrum\Cache\IncrementalCache;
+use LaravelSpectrum\Performance\DependencyGraph;
+use LaravelSpectrum\Tests\TestCase;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+
+class IncrementalCacheTest extends TestCase
+{
+    private IncrementalCache $cache;
+
+    private $dependencyGraph;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Ensure config is available
+        config(['spectrum.cache.ttl' => 3600]);
+
+        $this->dependencyGraph = Mockery::mock(DependencyGraph::class);
+        $this->cache = new IncrementalCache($this->dependencyGraph);
+        $this->cache->clear();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cache->clear();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_tracks_file_changes(): void
+    {
+        $this->dependencyGraph->shouldReceive('getAffectedNodes')
+            ->andReturn([]);
+
+        $this->cache->trackChange('/path/to/file.php', 'modified');
+        $this->cache->trackChange('/path/to/another.php', 'created');
+
+        // getInvalidatedItems を呼び出してトラッキングが機能していることを確認
+        $invalidated = $this->cache->getInvalidatedItems();
+
+        $this->assertIsArray($invalidated);
+    }
+
+    #[Test]
+    public function it_gets_invalidated_items_from_change_log(): void
+    {
+        $this->dependencyGraph->shouldReceive('getAffectedNodes')
+            ->with(['controller:App\\Http\\Controllers\\UserController'])
+            ->andReturn([
+                'controller:App\\Http\\Controllers\\UserController',
+                'route:GET:/api/users',
+            ]);
+
+        $this->cache->trackChange('/app/Http/Controllers/UserController.php');
+
+        $invalidated = $this->cache->getInvalidatedItems();
+
+        $this->assertContains('controller:App\\Http\\Controllers\\UserController', $invalidated);
+        $this->assertContains('route:GET:/api/users', $invalidated);
+    }
+
+    #[Test]
+    public function it_invalidates_affected_cache_entries(): void
+    {
+        // まずキャッシュにデータを設定
+        $this->cache->remember('controller:App\\Http\\Controllers\\UserController', fn () => ['data' => 'test']);
+        $this->cache->remember('route:GET:/api/users', fn () => ['route' => 'data']);
+
+        $this->dependencyGraph->shouldReceive('getAffectedNodes')
+            ->andReturn(['controller:App\\Http\\Controllers\\UserController']);
+
+        $this->cache->trackChange('/app/Http/Controllers/UserController.php');
+
+        $count = $this->cache->invalidateAffected();
+
+        $this->assertGreaterThanOrEqual(0, $count);
+    }
+
+    #[Test]
+    public function it_converts_controller_file_to_node_id(): void
+    {
+        $this->dependencyGraph->shouldReceive('getAffectedNodes')
+            ->with(['controller:App\\Http\\Controllers\\UserController'])
+            ->once()
+            ->andReturn(['controller:App\\Http\\Controllers\\UserController']);
+
+        $this->cache->trackChange('/app/Http/Controllers/UserController.php');
+        $this->cache->getInvalidatedItems();
+
+        // Mockeryが期待どおりに呼び出されたことを確認
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function it_converts_request_file_to_node_id(): void
+    {
+        $this->dependencyGraph->shouldReceive('getAffectedNodes')
+            ->with(['request:App\\Http\\Requests\\StoreUserRequest'])
+            ->once()
+            ->andReturn(['request:App\\Http\\Requests\\StoreUserRequest']);
+
+        $this->cache->trackChange('/app/Http/Requests/StoreUserRequest.php');
+        $this->cache->getInvalidatedItems();
+
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function it_converts_resource_file_to_node_id(): void
+    {
+        $this->dependencyGraph->shouldReceive('getAffectedNodes')
+            ->with(['resource:App\\Http\\Resources\\UserResource'])
+            ->once()
+            ->andReturn(['resource:App\\Http\\Resources\\UserResource']);
+
+        $this->cache->trackChange('/app/Http/Resources/UserResource.php');
+        $this->cache->getInvalidatedItems();
+
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function it_converts_other_files_to_file_node_id(): void
+    {
+        $this->dependencyGraph->shouldReceive('getAffectedNodes')
+            ->with(['file:/app/Models/User.php'])
+            ->once()
+            ->andReturn(['file:/app/Models/User.php']);
+
+        $this->cache->trackChange('/app/Models/User.php');
+        $this->cache->getInvalidatedItems();
+
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function it_returns_unique_invalidated_items(): void
+    {
+        $this->dependencyGraph->shouldReceive('getAffectedNodes')
+            ->andReturn(['route:GET:/api/users', 'route:GET:/api/users']);
+
+        $this->cache->trackChange('/app/Http/Controllers/UserController.php');
+
+        $invalidated = $this->cache->getInvalidatedItems();
+
+        $this->assertCount(1, array_unique($invalidated));
+    }
+
+    #[Test]
+    public function it_tracks_change_type(): void
+    {
+        $this->dependencyGraph->shouldReceive('getAffectedNodes')
+            ->andReturn([]);
+
+        $this->cache->trackChange('/path/to/file.php', 'created');
+        $this->cache->trackChange('/path/to/another.php', 'deleted');
+
+        // 変更タイプが記録されていることを確認（内部実装に依存しないテスト）
+        $invalidated = $this->cache->getInvalidatedItems();
+        $this->assertIsArray($invalidated);
+    }
+
+    #[Test]
+    public function it_handles_empty_change_log(): void
+    {
+        $this->dependencyGraph->shouldNotReceive('getAffectedNodes');
+
+        $invalidated = $this->cache->getInvalidatedItems();
+
+        $this->assertEmpty($invalidated);
+    }
+
+    #[Test]
+    public function it_handles_multiple_changes_to_same_file(): void
+    {
+        $this->dependencyGraph->shouldReceive('getAffectedNodes')
+            ->andReturn(['controller:App\\Http\\Controllers\\UserController']);
+
+        $this->cache->trackChange('/app/Http/Controllers/UserController.php', 'modified');
+        $this->cache->trackChange('/app/Http/Controllers/UserController.php', 'modified');
+
+        $invalidated = $this->cache->getInvalidatedItems();
+
+        // 重複が除去されていることを確認
+        $this->assertCount(1, array_unique($invalidated));
+    }
+
+    #[Test]
+    public function it_gets_valid_entries_excluding_invalidated(): void
+    {
+        // キャッシュにエントリを設定
+        $this->cache->remember('entry1', fn () => ['data' => 1]);
+        $this->cache->remember('entry2', fn () => ['data' => 2]);
+
+        $this->dependencyGraph->shouldReceive('getAffectedNodes')
+            ->andReturn(['entry1']);
+
+        $this->cache->trackChange('/some/file.php');
+
+        $validEntries = $this->cache->getValidEntries();
+
+        $this->assertNotContains('entry1', $validEntries);
+    }
+
+    #[Test]
+    public function it_handles_nested_controller_paths(): void
+    {
+        $this->dependencyGraph->shouldReceive('getAffectedNodes')
+            ->with(['controller:App\\Http\\Controllers\\Api\\V1\\UserController'])
+            ->once()
+            ->andReturn([]);
+
+        $this->cache->trackChange('/app/Http/Controllers/Api/V1/UserController.php');
+        $this->cache->getInvalidatedItems();
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for two 0% coverage files
- Fix bug in IncrementalCache that was importing the wrong parent class

## Changes

### ResponseStructureVisitor Tests (15 tests)
- Variable tracking and assignment detection
- Response JSON pattern detection  
- Collection operations (map, filter, pluck, only, except)
- Array structure analysis
- Edge cases (empty code, dynamic methods, etc.)

### IncrementalCache Tests (13 tests)
- Change tracking functionality
- Cache invalidation based on file changes
- File-to-node-id conversion for controllers, requests, resources
- Nested paths and duplicate handling

### Bug Fix
- Fixed `IncrementalCache` to use the correct `DocumentationCache` parent class
- Was incorrectly importing `Services\DocumentationCache` instead of using `Cache\DocumentationCache`

## Test Plan
- [x] All 919 tests pass
- [x] PHPStan analysis passes
- [x] Code style checked with Laravel Pint