### PR TITLE
refactor: extract ParameterBuilder from FormRequestAnalyzer

### DIFF
--- a/src/Analyzers/FormRequestAnalyzer.php
+++ b/src/Analyzers/FormRequestAnalyzer.php
@@ -62,7 +62,8 @@ class FormRequestAnalyzer
             $this->formatInferrer,
             $this->descriptionGenerator,
             $this->enumAnalyzer,
-            $this->fileUploadAnalyzer
+            $this->fileUploadAnalyzer,
+            $this->errorCollector
         );
     }
 


### PR DESCRIPTION
## Summary
- Extract parameter building logic into dedicated `ParameterBuilder` class
- Reduces `FormRequestAnalyzer` by ~130 lines (from 836 to 707 lines)
- Continues the refactoring effort (originally 1039 lines → now 707 lines)

## Changes
### New Class: `ParameterBuilder`
- `buildFromRules()` - Build parameters from validation rules
- `buildFromConditionalRules()` - Build parameters from conditional rules
- `buildFileParameter()` - Build file upload parameters
- `buildStandardParameter()` - Build regular parameters
- `buildConditionalParameter()` - Build conditional parameters
- `findEnumInfo()` - Find enum information from rules

### Updated: `FormRequestAnalyzer`
- Added `ParameterBuilder` as dependency
- Delegated all parameter building to the new class
- Removed ~130 lines of extracted code

## Refactoring Progress
| PR | Extracted Class | Lines Removed |
|----|-----------------|---------------|
| #130 | RuleRequirementAnalyzer, FormatInferrer | ~100 lines |
| #131 | ValidationDescriptionGenerator | ~200 lines |
| This PR | ParameterBuilder | ~130 lines |
| **Total** | - | **~430 lines** |

**FormRequestAnalyzer: 1039 → 707 lines (32% reduction)**

## Test Plan
- [x] All 1016 existing tests pass
- [x] New `ParameterBuilderTest` with 20 tests, 52 assertions
- [x] PHPStan analysis passes
- [x] Code formatting (Pint) passes