### PR TITLE
feat(ci): add Infection mutation testing

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,75 @@
+name: Mutation Testing
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      full_test:
+        description: 'Run full mutation testing (not just changed files)'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    name: Infection Mutation Testing
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
+          coverage: pcov
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction
+
+      - name: Run mutation testing (changed files only)
+        if: github.event_name == 'pull_request'
+        run: |
+          vendor/bin/infection \
+            --threads=max \
+            --git-diff-filter=AM \
+            --git-diff-base=origin/${{ github.base_ref }} \
+            --min-msi=50 \
+            --min-covered-msi=65 \
+            --ignore-msi-with-no-mutations \
+            --logger-github
+        env:
+          XDEBUG_MODE: coverage
+
+      - name: Run full mutation testing
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.full_test == 'true')
+        run: |
+          vendor/bin/infection \
+            --threads=max \
+            --min-msi=50 \
+            --min-covered-msi=65 \
+            --logger-github
+        env:
+          XDEBUG_MODE: coverage
+
+      - name: Skip mutation testing (manual trigger without full test)
+        if: github.event_name == 'workflow_dispatch' && inputs.full_test != 'true'
+        run: echo "Skipped - use full_test=true for complete mutation testing"

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ CLAUDE.local.md
 
 /.serena/
 test-app/
+
+# Infection mutation testing
+infection.log
+infection.html
+infection-cache/

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     "require-dev": {
         "devizzent/cebe-php-openapi": "^1.1",
         "fakerphp/faker": "^1.23",
+        "infection/infection": "*",
         "laravel/pint": "^1.23",
         "orchestra/testbench": "^9.0|^10.0",
         "phpstan/phpstan": "^2.1",
@@ -62,17 +63,22 @@
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
         "format": "vendor/bin/pint --test",
         "format:fix": "vendor/bin/pint",
-        "analyze": "vendor/bin/phpstan analyse"
+        "analyze": "vendor/bin/phpstan analyse",
+        "infection": "XDEBUG_MODE=coverage vendor/bin/infection --threads=max --show-mutations --only-covered"
     },
     "scripts-descriptions": {
         "test": "Run the tests",
         "test-coverage": "Run the tests with coverage",
         "format": "Check the code style",
         "format:fix": "Format the code using Laravel Pint",
-        "analyze": "Analyse the code using PHPStan"
+        "analyze": "Analyse the code using PHPStan",
+        "infection": "Run mutation testing with Infection"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "infection/extension-installer": true
+        }
     },
     "extra": {
         "laravel": {

--- a/infection.json5
+++ b/infection.json5
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://raw.githubusercontent.com/infection/infection/0.31.0/resources/schema.json",
+    "source": {
+        "directories": [
+            "src"
+        ],
+        "excludes": [
+            "Console",
+            "Facades"
+        ]
+    },
+    "logs": {
+        "text": "infection.log",
+        "github": true
+    },
+    "mutators": {
+        "@default": true
+    },
+    "testFramework": "phpunit",
+    "testFrameworkOptions": "--testsuite=Unit",
+    "timeout": 30,
+    "minMsi": 50,
+    "minCoveredMsi": 65
+}


### PR DESCRIPTION
## Summary
- Infectionミューテーションテストを導入し、テストの品質検証を改善
- PR時は変更ファイルのみ、main pushやmanual dispatch時はフルテスト
- 閾値: minMsi=50, minCoveredMsi=65

## Changes
- `infection.json5` - Infection設定ファイル
- `.github/workflows/mutation-testing.yml` - CI ワークフロー
- `composer.json` - Infectionスクリプト追加
- `.gitignore` - infection.logなど除外

## Test plan
- [ ] PRのmutation-testing CIが成功することを確認
- [ ] mainへのマージ後、フルミューテーションテストが実行されることを確認