### PR TITLE
fix(phpstan): resolve strict comparison and missing type errors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,12 +25,6 @@ parameters:
 			path: src/Analyzers/AST/Visitors/ArrayReturnExtractorVisitor.php
 
 		-
-			message: '#^Strict comparison using \!\=\= between array\|int\|string and null will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 1
-			path: src/Analyzers/AST/Visitors/ArrayReturnExtractorVisitor.php
-
-		-
 			message: '#^Method LaravelSpectrum\\Analyzers\\AST\\Visitors\\CollectionMapVisitor\:\:beforeTraverse\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -136,12 +130,6 @@ parameters:
 			message: '#^Property LaravelSpectrum\\Analyzers\\AST\\Visitors\\ConditionalRulesExtractorVisitor\:\:\$ruleSets type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 2
-			path: src/Analyzers/AST/Visitors/ConditionalRulesExtractorVisitor.php
-
-		-
-			message: '#^Strict comparison using \!\=\= between array\|string and null will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 1
 			path: src/Analyzers/AST/Visitors/ConditionalRulesExtractorVisitor.php
 
 		-
@@ -349,12 +337,6 @@ parameters:
 			path: src/Analyzers/AST/Visitors/RulesExtractorVisitor.php
 
 		-
-			message: '#^Strict comparison using \!\=\= between array\|string and null will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 2
-			path: src/Analyzers/AST/Visitors/RulesExtractorVisitor.php
-
-		-
 			message: '#^Method LaravelSpectrum\\Analyzers\\AST\\Visitors\\UseStatementExtractorVisitor\:\:getUseStatements\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -547,18 +529,6 @@ parameters:
 			path: src/Analyzers/FractalTransformerAnalyzer.php
 
 		-
-			message: '#^Property PhpParser\\NodeVisitorAbstract@anonymous/src/Analyzers/FractalTransformerAnalyzer\.php\:146\:\:\$returnArray has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/Analyzers/FractalTransformerAnalyzer.php
-
-		-
-			message: '#^Property PhpParser\\NodeVisitorAbstract@anonymous/src/Analyzers/FractalTransformerAnalyzer\.php\:401\:\:\$returnInfo has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/Analyzers/FractalTransformerAnalyzer.php
-
-		-
 			message: '#^Method LaravelSpectrum\\Analyzers\\InlineValidationAnalyzer\:\:generateDescription\(\) has parameter \$attributes with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -625,19 +595,19 @@ parameters:
 			path: src/Analyzers/InlineValidationAnalyzer.php
 
 		-
-			message: '#^Method PhpParser\\NodeVisitorAbstract@anonymous/src/Analyzers/InlineValidationAnalyzer\.php\:257\:\:extractArray\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method PhpParser\\NodeVisitorAbstract@anonymous/src/Analyzers/InlineValidationAnalyzer\.php\:258\:\:extractArray\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Analyzers/InlineValidationAnalyzer.php
 
 		-
-			message: '#^Method PhpParser\\NodeVisitorAbstract@anonymous/src/Analyzers/InlineValidationAnalyzer\.php\:257\:\:extractValue\(\) has no return type specified\.$#'
+			message: '#^Method PhpParser\\NodeVisitorAbstract@anonymous/src/Analyzers/InlineValidationAnalyzer\.php\:258\:\:extractValue\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Analyzers/InlineValidationAnalyzer.php
 
 		-
-			message: '#^Method PhpParser\\NodeVisitorAbstract@anonymous/src/Analyzers/InlineValidationAnalyzer\.php\:257\:\:getNodeValue\(\) has no return type specified\.$#'
+			message: '#^Method PhpParser\\NodeVisitorAbstract@anonymous/src/Analyzers/InlineValidationAnalyzer\.php\:258\:\:getNodeValue\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Analyzers/InlineValidationAnalyzer.php
@@ -693,18 +663,6 @@ parameters:
 		-
 			message: '#^Method PhpParser\\NodeVisitorAbstract@anonymous/src/Analyzers/InlineValidationAnalyzer\.php\:44\:\:getNodeValue\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Analyzers/InlineValidationAnalyzer.php
-
-		-
-			message: '#^Property PhpParser\\NodeVisitorAbstract@anonymous/src/Analyzers/InlineValidationAnalyzer\.php\:257\:\:\$returnedArray has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/Analyzers/InlineValidationAnalyzer.php
-
-		-
-			message: '#^Property PhpParser\\NodeVisitorAbstract@anonymous/src/Analyzers/InlineValidationAnalyzer\.php\:44\:\:\$validations has no type specified\.$#'
-			identifier: missingType.property
 			count: 1
 			path: src/Analyzers/InlineValidationAnalyzer.php
 
@@ -3433,26 +3391,8 @@ parameters:
 			path: src/Services/LiveReloadServer.php
 
 		-
-			message: '#^Property LaravelSpectrum\\Services\\LiveReloadServer\:\:\$clients has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/Services/LiveReloadServer.php
-
-		-
-			message: '#^Property LaravelSpectrum\\Services\\LiveReloadServer\:\:\$httpWorker has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/Services/LiveReloadServer.php
-
-		-
-			message: '#^Property LaravelSpectrum\\Services\\LiveReloadServer\:\:\$instance has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/Services/LiveReloadServer.php
-
-		-
-			message: '#^Property LaravelSpectrum\\Services\\LiveReloadServer\:\:\$wsWorker has no type specified\.$#'
-			identifier: missingType.property
+			message: '#^Property LaravelSpectrum\\Services\\LiveReloadServer\:\:\$clients with generic class SplObjectStorage does not specify its types\: TObject, TData$#'
+			identifier: missingType.generics
 			count: 1
 			path: src/Services/LiveReloadServer.php
 

--- a/src/Analyzers/AST/Visitors/ArrayReturnExtractorVisitor.php
+++ b/src/Analyzers/AST/Visitors/ArrayReturnExtractorVisitor.php
@@ -32,12 +32,13 @@ class ArrayReturnExtractorVisitor extends NodeVisitorAbstract
         $result = [];
 
         foreach ($array->items as $item) {
+            if ($item === null || $item->key === null) {
+                continue;
+            }
+
             $key = $this->evaluateExpression($item->key);
             $value = $this->evaluateExpression($item->value);
-
-            if ($key !== null) {
-                $result[$key] = $value;
-            }
+            $result[$key] = $value;
         }
 
         return $result;

--- a/src/Analyzers/AST/Visitors/ConditionalRulesExtractorVisitor.php
+++ b/src/Analyzers/AST/Visitors/ConditionalRulesExtractorVisitor.php
@@ -476,7 +476,7 @@ class ConditionalRulesExtractorVisitor extends NodeVisitorAbstract
             $key = $this->evaluateKey($item->key);
             $value = $this->evaluateRuleValue($item->value);
 
-            if ($key !== null && $value !== null) {
+            if ($key !== null) {
                 $rules[$key] = $value;
             }
         }

--- a/src/Analyzers/AST/Visitors/RulesExtractorVisitor.php
+++ b/src/Analyzers/AST/Visitors/RulesExtractorVisitor.php
@@ -76,12 +76,13 @@ class RulesExtractorVisitor extends NodeVisitorAbstract
         $rules = [];
 
         foreach ($array->items as $item) {
+            if ($item === null) {
+                continue;
+            }
+
             $key = $this->evaluateKey($item->key);
             $value = $this->evaluateValue($item->value);
-
-            if ($value !== null) {
-                $rules[$key] = $value;
-            }
+            $rules[$key] = $value;
         }
 
         return $rules;
@@ -160,10 +161,11 @@ class RulesExtractorVisitor extends NodeVisitorAbstract
         if ($expr instanceof Node\Expr\Array_) {
             $result = [];
             foreach ($expr->items as $item) {
-                $value = $this->evaluateValue($item->value);
-                if ($value !== null) {
-                    $result[] = $value;
+                if ($item === null) {
+                    continue;
                 }
+                $value = $this->evaluateValue($item->value);
+                $result[] = $value;
             }
 
             return $result;

--- a/src/Analyzers/FractalTransformerAnalyzer.php
+++ b/src/Analyzers/FractalTransformerAnalyzer.php
@@ -145,7 +145,8 @@ class FractalTransformerAnalyzer implements ClassAnalyzer, HasErrors
         // return文を探す
         $visitor = new class extends NodeVisitorAbstract
         {
-            public $returnArray = null;
+            /** @var Node\Expr\Array_|null */
+            public ?\PhpParser\Node\Expr\Array_ $returnArray = null;
 
             public function enterNode(Node $node)
             {
@@ -400,7 +401,8 @@ class FractalTransformerAnalyzer implements ClassAnalyzer, HasErrors
     {
         $visitor = new class extends NodeVisitorAbstract
         {
-            public $returnInfo = [];
+            /** @var array<string, mixed> */
+            public array $returnInfo = [];
 
             public function enterNode(Node $node)
             {

--- a/src/Analyzers/InlineValidationAnalyzer.php
+++ b/src/Analyzers/InlineValidationAnalyzer.php
@@ -43,7 +43,8 @@ class InlineValidationAnalyzer implements AstMethodAnalyzer, HasErrors
 
             $visitor = new class extends NodeVisitorAbstract
             {
-                public $validations = [];
+                /** @var array<string, mixed> */
+                public array $validations = [];
 
                 public function enterNode(Node $node)
                 {
@@ -256,7 +257,8 @@ class InlineValidationAnalyzer implements AstMethodAnalyzer, HasErrors
 
                     $visitor = new class extends NodeVisitorAbstract
                     {
-                        public $returnedArray = [];
+                        /** @var array<string, mixed> */
+                        public array $returnedArray = [];
 
                         public function enterNode(Node $node): ?int
                         {

--- a/src/Services/LiveReloadServer.php
+++ b/src/Services/LiveReloadServer.php
@@ -9,13 +9,13 @@ use Workerman\Worker;
 
 class LiveReloadServer
 {
-    protected static $clients;
+    protected static ?\SplObjectStorage $clients = null;
 
-    protected $httpWorker;
+    protected ?Worker $httpWorker = null;
 
-    protected $wsWorker;
+    protected ?Worker $wsWorker = null;
 
-    protected static $instance;
+    protected static ?self $instance = null;
 
     public function __construct()
     {


### PR DESCRIPTION
## Summary
PHPStanのstrict comparisonエラーとmissing typeエラーを修正

## Changes

### Strict Comparison修正
ユニオン型導入により、戻り値がnullにならないメソッドへの冗長な`!== null`チェックを削除：
- `ArrayReturnExtractorVisitor::extractArray`
- `ConditionalRulesExtractorVisitor::extractArrayRules`
- `RulesExtractorVisitor::extractArrayRules`
- `RulesExtractorVisitor::evaluateValue`

### 匿名クラスの型追加
- `InlineValidationAnalyzer`: `$validations`, `$returnedArray`
- `FractalTransformerAnalyzer`: `$returnArray`, `$returnInfo`

### LiveReloadServerのプロパティ型追加
- `$clients`: `?\SplObjectStorage`
- `$httpWorker`, `$wsWorker`: `?Worker`
- `$instance`: `?self`

## Baseline Progress
| 項目 | Before | After |
|------|--------|-------|
| Strict comparison | 3 | 0 |
| Missing type | 8 | 0 |
| **合計** | **657** | **650** |

## Test plan
- [x] `composer test` 全テスト通過 (1367 tests)
- [x] `composer format` コードスタイルチェック通過
- [x] `composer analyze` PHPStan解析通過
- [ ] CI通過