### PR TITLE
style: unify null check pattern in extractArrayRules

### DIFF
--- a/src/Analyzers/AST/Visitors/ConditionalRulesExtractorVisitor.php
+++ b/src/Analyzers/AST/Visitors/ConditionalRulesExtractorVisitor.php
@@ -469,7 +469,7 @@ class ConditionalRulesExtractorVisitor extends NodeVisitorAbstract
         $rules = [];
 
         foreach ($array->items as $item) {
-            if (! $item || ! isset($item->key)) {
+            if ($item === null || $item->key === null) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary
nullチェックのスタイルを統一

## Changes
`ConditionalRulesExtractorVisitor::extractArrayRules`のnullチェックパターンを
他のファイルと統一:

```php
// Before
if (! $item || ! isset($item->key)) {

// After
if ($item === null || $item->key === null) {
```

## Reason
PR #170のレビューで指摘されたスタイル不一致を修正。
`ArrayReturnExtractorVisitor`や`RulesExtractorVisitor`と同じパターンに統一。

## Test plan
- [x] `composer test` 全テスト通過
- [x] `composer analyze` PHPStan通過