### PR TITLE
Document: Add modular Claude Code rules

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,85 @@
+# Architecture Rules
+
+## Core Architecture Pattern
+
+Laravel Spectrum follows a pipeline architecture:
+
+```
+Route Analysis → Controller Analysis → Resource Analysis → Schema Generation → Document Assembly
+```
+
+## Component Categories
+
+### Analyzers (`src/Analyzers/`)
+Extract information from code without modifying it.
+
+**Pattern:**
+```php
+public function analyze($input): array
+{
+    // 1. Validate input
+    // 2. Extract relevant data using AST or Reflection
+    // 3. Convert to standard format
+    // 4. Return structured array
+}
+```
+
+**Key Analyzers:**
+- `RouteAnalyzer` - Route definitions
+- `FormRequestAnalyzer` - Validation rules
+- `ControllerAnalyzer` - Controller methods
+- `ResourceAnalyzer` - API Resources
+
+### Generators (`src/Generators/`)
+Convert analyzed data to OpenAPI format.
+
+**Key Generators:**
+- `OpenApiGenerator` - Main orchestrator
+- `SchemaGenerator` - Validation to OpenAPI schemas
+- `ExampleGenerator` - Realistic examples via Faker
+
+### Services (`src/Services/`)
+Supporting functionality like caching and file watching.
+
+## AST Visitor Pattern
+
+For static code analysis, use PHP-Parser visitors:
+
+```php
+class MyVisitor extends NodeVisitorAbstract
+{
+    public function enterNode(Node $node)
+    {
+        // Extract information from AST nodes
+    }
+}
+```
+
+## Error Collection Pattern
+
+**DO NOT throw exceptions from analyzers.** Instead:
+
+1. Use `ErrorCollector` to collect errors
+2. Categorize with `AnalyzerErrorType` enum
+3. Continue analysis even when errors occur
+4. Report all errors at the end
+
+## Adding New Components
+
+### New Analyzer
+1. Create test in `tests/Unit/Analyzers/`
+2. Implement in `src/Analyzers/`
+3. Register in `OpenApiGenerator` if needed
+4. Add integration tests
+
+### New Generator
+1. Follow existing generator patterns
+2. Accept analyzed data as input
+3. Return OpenAPI-compliant structure
+
+## Performance Considerations
+
+- Use parallel processing for large codebases
+- Cache expensive computations
+- Chunk large datasets
+- Avoid reading entire files when AST is sufficient

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,0 +1,34 @@
+# Code Style Rules
+
+## PHP Code Standards
+
+### Static Analysis
+- PHPStan Level 6 is required
+- No new baseline additions allowed without explicit approval
+- All errors must be fixed, not suppressed
+
+### Code Formatting
+- Use Laravel Pint with Laravel preset
+- Run `composer format:fix` before committing
+- Follow PSR-12 coding standards
+
+### Type Declarations
+- Always use strict types: `declare(strict_types=1);`
+- Provide complete PHPDoc for generic types (e.g., `@param \ReflectionClass<object>`)
+- Use union types sparingly; prefer interfaces when possible
+
+### Naming Conventions
+- Analyzers: `{Name}Analyzer` (e.g., `FormRequestAnalyzer`)
+- Generators: `{Name}Generator` (e.g., `SchemaGenerator`)
+- Visitors: `{Name}Visitor` (e.g., `ValidationRuleVisitor`)
+- Traits: `Has{Feature}` (e.g., `HasErrorCollection`)
+
+### Error Handling
+- Use `AnalyzerErrorType` enum for categorizing errors
+- Collect errors via `ErrorCollector` instead of throwing exceptions
+- Log warnings for unsupported features, not errors
+
+### Comments and Documentation
+- PHPDoc blocks for all public methods
+- Explain "why", not "what" in inline comments
+- Use Japanese comments only when explaining domain-specific logic

--- a/.claude/rules/critical-requirements.md
+++ b/.claude/rules/critical-requirements.md
@@ -1,0 +1,39 @@
+# Critical Requirements
+
+These rules are MANDATORY and must NEVER be bypassed.
+
+## Serena MCP Server
+
+**MUST use the Serena MCP server under all circumstances.**
+
+- Use Serena's symbolic tools for code exploration
+- Prefer `get_symbols_overview` and `find_symbol` over reading entire files
+- Use `replace_symbol_body` for precise code modifications
+- Leverage `find_referencing_symbols` for refactoring
+
+## Code Quality Gates
+
+Before ANY code is merged:
+
+1. `composer format:fix` - MUST pass
+2. `composer analyze` - MUST pass (PHPStan Level 6)
+3. `composer test` - ALL tests MUST pass
+4. Demo app verification - MUST work correctly
+
+## No Baseline Additions
+
+- PHPStan baseline additions are NOT allowed
+- All static analysis errors must be properly fixed
+- Use `reportUnmatchedIgnoredErrors: false` for PHP version compatibility
+
+## Test-First Development
+
+- NO feature code without tests
+- Write failing test FIRST
+- Then implement minimal code to pass
+
+## Error Handling
+
+- NEVER throw exceptions from analyzers
+- ALWAYS use ErrorCollector pattern
+- ALWAYS log unsupported features as warnings

--- a/.claude/rules/development-workflow.md
+++ b/.claude/rules/development-workflow.md
@@ -1,0 +1,53 @@
+# Development Workflow Rules
+
+## Pre-PR Checklist (Required)
+
+**PR作成前に必ずcode-qualityスキルを実行すること。**
+
+Execute these steps in order:
+
+1. `composer format:fix` - Auto-fix code style issues
+2. `composer analyze` - Pass PHPStan static analysis
+3. `composer test` - All tests must pass
+4. Test in demo-app - Verify real-world functionality
+
+## Post-PR Review (Required)
+
+**PR作成後に必ずpost-pr-reviewスキルを実行すること。**
+
+1. Run `/post-pr-review` skill after PR creation
+2. Review all Critical and Important issues
+3. Address suggestions where appropriate
+4. Push fixes and re-run if needed
+
+## Git Workflow
+
+### Branch Naming
+- Features: `feature/{description}`
+- Bug fixes: `fix/{description}`
+- Refactoring: `refactor/{description}`
+
+### Commit Messages
+- Use conventional commits format
+- Be concise but descriptive
+- Reference issues when applicable
+
+### Pull Requests
+- Create from feature branch to `main`
+- Include summary of changes
+- Add test plan if applicable
+
+## Available Skills
+
+### Code Quality
+- `/code-quality` - Run all quality checks (PHPStan, Pint, PHPUnit)
+
+### PR Review
+- `/post-pr-review` - Self-review and fix PR issues
+- `/pr-review-toolkit:review-pr` - Comprehensive PR review
+
+## CI/CD Considerations
+
+- Tests run on PHP 8.1, 8.2, 8.3, 8.4
+- PHPStan baseline must work across all PHP versions
+- Use `reportUnmatchedIgnoredErrors: false` for cross-version compatibility

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,57 @@
+# Testing Rules
+
+## Test-First Development (Mandatory)
+
+All new features and bug fixes MUST follow TDD:
+
+1. Write a failing test first
+2. Implement minimal code to make it pass
+3. Refactor while keeping tests green
+
+## Test Structure
+
+```
+tests/
+├── Unit/           # Unit tests for individual components
+├── Feature/        # Integration tests
+├── E2E/            # End-to-end tests
+├── Performance/    # Performance benchmarks
+└── Fixtures/       # Test data and mock classes
+```
+
+## Test Commands
+
+```bash
+composer test                 # Run all PHPUnit tests
+composer test-coverage        # Generate HTML coverage report
+vendor/bin/phpunit tests/Unit/FormRequestAnalyzerTest.php  # Specific file
+vendor/bin/phpunit --filter testMethodName                  # Specific method
+```
+
+## Test Naming Conventions
+
+- Test classes: `{ClassName}Test` (e.g., `FormRequestAnalyzerTest`)
+- Test methods: `test_{action}_{condition}_{expected_result}` or camelCase with `@test` annotation
+- Use descriptive names that explain the scenario
+
+## Test Fixtures
+
+- Place test fixtures in `tests/Fixtures/`
+- Use realistic data that represents actual use cases
+- Prefer factories for complex object creation
+
+## Demo App Testing (Required)
+
+Before submitting PRs, verify functionality in the demo app:
+
+```bash
+cd demo-app/laravel-12-app
+php artisan spectrum:generate
+# Check output in storage/app/spectrum/openapi.json
+```
+
+## Coverage Requirements
+
+- Aim for high coverage on Analyzers and Generators
+- Critical paths must have 100% coverage
+- Edge cases should be explicitly tested


### PR DESCRIPTION
# 概要

Claude Codeのルールをモジュール化して `.claude/rules/` ディレクトリに整理しました。これにより、ルールの管理と更新が容易になります。

## 変更内容

`.claude/rules/` ディレクトリに以下の5つのルールファイルを追加：

- **architecture.md** - パイプラインアーキテクチャ、Analyzerパターン、AST Visitorパターン
- **code-style.md** - PHPStan Level 6、Laravel Pint、命名規則、型宣言
- **critical-requirements.md** - Serena MCP使用義務、品質ゲート、ベースライン禁止
- **development-workflow.md** - PR前後のチェックリスト、Git ワークフロー、スキル
- **testing.md** - TDD、テスト構造、デモアプリテスト

## 関連情報

- 前回のPR #172 マージ後のドキュメント整理作業