### PR TITLE
test: improve method coverage (Phase 12)

### DIFF
--- a/tests/Feature/Console/MockServerCommandTest.php
+++ b/tests/Feature/Console/MockServerCommandTest.php
@@ -189,6 +189,94 @@ class MockServerCommandTest extends TestCase
         File::delete($customSpecPath);
     }
 
+    public function test_command_rejects_yaml_spec_format(): void
+    {
+        // Create YAML spec file
+        $yamlSpecPath = base_path('custom-openapi.yaml');
+        File::put($yamlSpecPath, "openapi: '3.0.0'\ninfo:\n  title: Test API\n  version: '1.0.0'\n");
+
+        $this->artisan('spectrum:mock', ['--spec' => $yamlSpecPath])
+            ->expectsOutput('YAML format is not yet supported. Please use JSON format.')
+            ->assertExitCode(1);
+
+        // Cleanup
+        File::delete($yamlSpecPath);
+    }
+
+    public function test_command_loads_spec_from_base_path(): void
+    {
+        // Delete default spec file
+        if (File::exists(storage_path('app/spectrum/openapi.json'))) {
+            File::delete(storage_path('app/spectrum/openapi.json'));
+        }
+
+        // Create spec at base_path('openapi.json')
+        $basePath = base_path('openapi.json');
+        $spec = [
+            'openapi' => '3.0.0',
+            'info' => [
+                'title' => 'Base Path API',
+                'version' => '1.0.0',
+            ],
+            'paths' => [],
+        ];
+        File::put($basePath, json_encode($spec, JSON_PRETTY_PRINT));
+
+        // Mock the MockServer to prevent actual server startup
+        $this->mockMockServer();
+
+        $this->artisan('spectrum:mock')
+            ->expectsOutputToContain('Loading spec from: '.$basePath)
+            ->expectsOutputToContain('Base Path API')
+            ->assertExitCode(0);
+
+        // Cleanup
+        File::delete($basePath);
+    }
+
+    public function test_command_loads_spec_from_docs_directory(): void
+    {
+        // Delete default spec files
+        if (File::exists(storage_path('app/spectrum/openapi.json'))) {
+            File::delete(storage_path('app/spectrum/openapi.json'));
+        }
+        if (File::exists(base_path('openapi.json'))) {
+            File::delete(base_path('openapi.json'));
+        }
+
+        // Create spec at base_path('docs/openapi.json')
+        File::ensureDirectoryExists(base_path('docs'));
+        $docsPath = base_path('docs/openapi.json');
+        $spec = [
+            'openapi' => '3.0.0',
+            'info' => [
+                'title' => 'Docs API',
+                'version' => '1.0.0',
+            ],
+            'paths' => [],
+        ];
+        File::put($docsPath, json_encode($spec, JSON_PRETTY_PRINT));
+
+        // Mock the MockServer to prevent actual server startup
+        $this->mockMockServer();
+
+        $this->artisan('spectrum:mock')
+            ->expectsOutputToContain('Loading spec from: '.$docsPath)
+            ->expectsOutputToContain('Docs API')
+            ->assertExitCode(0);
+
+        // Cleanup
+        File::delete($docsPath);
+        File::deleteDirectory(base_path('docs'));
+    }
+
+    public function test_command_handles_nonexistent_spec_path(): void
+    {
+        $this->artisan('spectrum:mock', ['--spec' => '/nonexistent/path.json'])
+            ->expectsOutput('OpenAPI specification file not found.')
+            ->assertExitCode(1);
+    }
+
     private function createTestOpenApiSpec(): void
     {
         $spec = [

--- a/tests/Unit/Support/EnumExtractorTest.php
+++ b/tests/Unit/Support/EnumExtractorTest.php
@@ -90,4 +90,30 @@ class EnumExtractorTest extends TestCase
         $this->assertSame([1, 2, 3], $values);
         $this->assertNotSame([3, 2, 1], $values);
     }
+
+    public function test_get_enum_type_throws_exception_for_non_enum(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not a valid enum');
+        $this->extractor->getEnumType(\stdClass::class);
+    }
+
+    public function test_is_backed_enum_throws_exception_for_non_enum(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not a valid enum');
+        $this->extractor->isBackedEnum(\stdClass::class);
+    }
+
+    public function test_get_enum_type_throws_for_non_existent_class(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->extractor->getEnumType('NonExistentEnumClass');
+    }
+
+    public function test_is_backed_enum_throws_for_non_existent_class(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->extractor->isBackedEnum('NonExistentEnumClass');
+    }
 }


### PR DESCRIPTION
## Summary
- Add 12 new tests for DynamicExampleGenerator covering setFaker, pattern generation, additionalProperties, arrays without items schema, integer/number enums, min/max items, default/unknown types, and realistic string generation
- Add 12 new tests for ExampleGenerator covering error examples (403, 500, default), validation rules (array and string formats), various field types, schemas without properties, and custom example mappings
- Add 4 new tests for MockServerCommand covering YAML spec rejection, loading from alternative paths (base_path, docs directory), and nonexistent spec path handling
- Add 4 new tests for EnumExtractor covering exception handling for getEnumType and isBackedEnum methods

## Test plan
- [x] All tests pass (`composer test`)
- [x] Code style passes (`composer format:fix`)
- [x] PHPStan passes (`composer analyze`)
- [x] Method coverage improved from 73.55% to 75.35% (+1.8%)