### PR TITLE
Document: Update CLI and config reference to match implementation

### DIFF
--- a/docs/en/cli-reference.md
+++ b/docs/en/cli-reference.md
@@ -26,16 +26,16 @@ php artisan spectrum:generate [options]
 
 ### Options
 
-| Option | Short | Default | Description |
-|--------|-------|---------|-------------|
-| `--output` | `-o` | storage/app/spectrum/openapi.json | Output file path |
-| `--format` | `-f` | json | Output format (json/yaml) |
-| `--pattern` | | config value | Route patterns to include |
-| `--exclude` | | config value | Route patterns to exclude |
-| `--no-cache` | | false | Don't use cache |
-| `--force` | | false | Overwrite existing files |
-| `--dry-run` | | false | Run without generating files |
-| `--incremental` | `-i` | false | Process only changed files |
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--output` | storage/app/spectrum/openapi.json | Output file path |
+| `--format` | json | Output format (json/yaml/html) |
+| `--no-cache` | false | Don't use cache |
+| `--clear-cache` | false | Clear cache before generation |
+| `--fail-on-error` | false | Stop execution on first error |
+| `--ignore-errors` | false | Continue generation ignoring errors |
+| `--error-report` | none | Save error report to file |
+| `--no-try-it-out` | false | Disable "Try It Out" feature in HTML output |
 
 ### Examples
 
@@ -43,23 +43,29 @@ php artisan spectrum:generate [options]
 # Basic generation
 php artisan spectrum:generate
 
-# Generate only specific patterns
-php artisan spectrum:generate --pattern="api/v2/*"
-
-# Multiple patterns
-php artisan spectrum:generate --pattern="api/users/*" --pattern="api/posts/*"
-
-# Exclude patterns
-php artisan spectrum:generate --exclude="api/admin/*" --exclude="api/debug/*"
-
 # Output in YAML format
 php artisan spectrum:generate --format=yaml --output=docs/api.yaml
 
-# Force regeneration without cache
-php artisan spectrum:generate --no-cache --force
+# Output in HTML format (with Swagger UI)
+php artisan spectrum:generate --format=html --output=docs/api.html
 
-# Dry run (doesn't actually generate)
-php artisan spectrum:generate --dry-run -vvv
+# Clear cache and regenerate
+php artisan spectrum:generate --clear-cache
+
+# Generate without using cache
+php artisan spectrum:generate --no-cache
+
+# Stop on error
+php artisan spectrum:generate --fail-on-error
+
+# Ignore errors and continue
+php artisan spectrum:generate --ignore-errors
+
+# Save error report
+php artisan spectrum:generate --error-report=storage/spectrum-errors.json
+
+# Generate with verbose output
+php artisan spectrum:generate -vvv
 ```
 
 ## ⚡ spectrum:generate:optimized
@@ -76,12 +82,13 @@ php artisan spectrum:generate:optimized [options]
 
 | Option | Default | Description |
 |--------|---------|-------------|
+| `--format` | json | Output format (json/yaml) |
+| `--output` | storage/app/spectrum/openapi.json | Output file path |
+| `--parallel` | false | Enable parallel processing |
 | `--workers` | auto | Number of parallel workers (auto for CPU cores) |
-| `--chunk-size` | 100 | Number of routes processed by each worker |
+| `--chunk-size` | auto | Number of routes processed by each worker |
 | `--memory-limit` | 512M | Memory limit for each worker |
 | `--incremental` | false | Process only changed files |
-| `--progress` | true | Show progress bar |
-| `--stats` | true | Show performance statistics |
 
 ### Examples
 
@@ -89,8 +96,11 @@ php artisan spectrum:generate:optimized [options]
 # Generate with automatic optimization
 php artisan spectrum:generate:optimized
 
+# Enable parallel processing
+php artisan spectrum:generate:optimized --parallel
+
 # Parallel processing with 8 workers
-php artisan spectrum:generate:optimized --workers=8
+php artisan spectrum:generate:optimized --parallel --workers=8
 
 # Adjust memory and chunk size
 php artisan spectrum:generate:optimized --memory-limit=1G --chunk-size=50
@@ -98,8 +108,11 @@ php artisan spectrum:generate:optimized --memory-limit=1G --chunk-size=50
 # Incremental generation
 php artisan spectrum:generate:optimized --incremental
 
-# Run quietly without statistics
-php artisan spectrum:generate:optimized --no-stats --no-progress
+# Output in YAML format
+php artisan spectrum:generate:optimized --format=yaml
+
+# Generate with verbose output
+php artisan spectrum:generate:optimized -v
 ```
 
 ## 👁️ spectrum:watch
@@ -117,10 +130,8 @@ php artisan spectrum:watch [options]
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--port` | 8080 | Preview server port |
-| `--host` | localhost | Preview server host |
+| `--host` | 127.0.0.1 | Preview server host |
 | `--no-open` | false | Don't open browser automatically |
-| `--poll` | false | Use polling mode |
-| `--interval` | 1000 | Polling interval (milliseconds) |
 
 ### Examples
 
@@ -136,9 +147,6 @@ php artisan spectrum:watch --no-open
 
 # Make externally accessible
 php artisan spectrum:watch --host=0.0.0.0
-
-# Polling mode (Docker environments, etc.)
-php artisan spectrum:watch --poll --interval=2000
 ```
 
 ## 🎭 spectrum:mock
@@ -194,11 +202,9 @@ php artisan spectrum:export:postman [options]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--output` | storage/app/spectrum/postman/collection.json | Output file path |
-| `--include-examples` | true | Include request/response examples |
-| `--include-tests` | false | Generate test scripts |
-| `--environment` | false | Also generate environment variables file |
-| `--base-url` | APP_URL | Base URL |
+| `--output` | storage/app/spectrum/postman | Output directory |
+| `--environments` | local | Environments to export (comma-separated) |
+| `--single-file` | false | Export as a single file with embedded environments |
 
 ### Examples
 
@@ -206,20 +212,14 @@ php artisan spectrum:export:postman [options]
 # Basic export
 php artisan spectrum:export:postman
 
-# Export with test scripts
-php artisan spectrum:export:postman --include-tests
-
-# Also generate environment variables file
-php artisan spectrum:export:postman --environment
-
 # Custom output location
-php artisan spectrum:export:postman --output=postman/my-api.json
+php artisan spectrum:export:postman --output=postman/
 
-# Complete export
-php artisan spectrum:export:postman \
-    --include-tests \
-    --environment \
-    --base-url=https://api.example.com
+# Export multiple environments
+php artisan spectrum:export:postman --environments=local,staging,production
+
+# Export as single file
+php artisan spectrum:export:postman --single-file
 ```
 
 ## 🦊 spectrum:export:insomnia
@@ -236,10 +236,7 @@ php artisan spectrum:export:insomnia [options]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--output` | storage/app/spectrum/insomnia/workspace.json | Output file path |
-| `--workspace-name` | APP_NAME API | Workspace name |
-| `--include-environments` | true | Include environment settings |
-| `--folder-structure` | true | Organize with folder structure |
+| `--output` | storage/app/spectrum/insomnia/insomnia_collection.json | Output file path |
 
 ### Examples
 
@@ -247,14 +244,11 @@ php artisan spectrum:export:insomnia [options]
 # Basic export
 php artisan spectrum:export:insomnia
 
-# Custom workspace name
-php artisan spectrum:export:insomnia --workspace-name="My Cool API"
-
-# Flat structure without folders
-php artisan spectrum:export:insomnia --no-folder-structure
-
-# Custom output location
+# Custom output location (file path)
 php artisan spectrum:export:insomnia --output=insomnia/api.json
+
+# Custom output location (directory)
+php artisan spectrum:export:insomnia --output=insomnia/
 ```
 
 ## 🗑️ spectrum:cache

--- a/docs/en/config-reference.md
+++ b/docs/en/config-reference.md
@@ -81,6 +81,28 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
 ],
 ```
 
+### OpenAPI Specification Version
+
+```php
+/*
+|--------------------------------------------------------------------------
+| OpenAPI Specification Version
+|--------------------------------------------------------------------------
+|
+| The OpenAPI specification version to use for generating documentation.
+| Supported versions: '3.0.0', '3.1.0'
+|
+| OpenAPI 3.1.0 includes:
+| - Full JSON Schema Draft 2020-12 compatibility
+| - Type arrays instead of nullable keyword (e.g., ["string", "null"])
+| - Webhooks support
+|
+*/
+'openapi' => [
+    'version' => env('SPECTRUM_OPENAPI_VERSION', '3.0.0'),
+],
+```
+
 ### Server Configuration
 
 ```php
@@ -127,35 +149,17 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
 
 /*
 |--------------------------------------------------------------------------
-| Excluded Routes
+| Custom Route Files
 |--------------------------------------------------------------------------
 |
-| Specific routes to exclude from documentation.
+| Additional route files to analyze beyond the standard Laravel route files.
 |
 */
-'excluded_routes' => [
-    'api/health',
-    'api/ping',
-    'api/debug/*',
-    '_debugbar/*',
-    'telescope/*',
-    'horizon/*',
+'route_files' => [
+    // base_path('routes/custom.php'),
+    // base_path('routes/admin.php'),
 ],
 
-/*
-|--------------------------------------------------------------------------
-| Route Metadata
-|--------------------------------------------------------------------------
-|
-| Add additional metadata to routes.
-|
-*/
-'route_metadata' => [
-    'api/admin/*' => [
-        'deprecated' => true,
-        'x-internal' => true,
-    ],
-],
 ```
 
 ## 🏷️ Tag Configuration
@@ -171,16 +175,27 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
 |
 */
 'tags' => [
-    // Exact matches
-    'api/v1/auth/login' => 'Authentication',
-    'api/v1/auth/logout' => 'Authentication',
-    'api/v1/auth/refresh' => 'Authentication',
-    
-    // Wildcards
-    'api/v1/users/*' => 'User Management',
-    'api/v1/posts/*' => 'Blog Posts',
-    'api/v1/admin/*' => 'Administration',
-    'api/v1/reports/*' => 'Reports',
+    // Exact match
+    // 'api/v1/auth/login' => 'Authentication',
+
+    // Wildcard
+    // 'api/v1/auth/*' => 'Authentication',
+    // 'api/v1/admin/*' => 'Administration',
+],
+
+/*
+|--------------------------------------------------------------------------
+| Tag Groups (x-tagGroups)
+|--------------------------------------------------------------------------
+|
+| Group tags for better organization in documentation viewers
+| that support x-tagGroups extension (e.g., Redoc).
+|
+*/
+'tag_groups' => [
+    // 'User Management' => ['User', 'Profile', 'Auth'],
+    // 'Content' => ['Post', 'Comment', 'Media'],
+    // 'Administration' => ['Admin', 'Settings'],
 ],
 
 /*
@@ -188,30 +203,24 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
 | Tag Descriptions
 |--------------------------------------------------------------------------
 |
-| Description for each tag.
+| Descriptions for each tag, reflected in the OpenAPI tags section.
 |
 */
 'tag_descriptions' => [
-    'Authentication' => 'Authentication and authorization endpoints',
-    'User Management' => 'Create, read, update, and delete users',
-    'Blog Posts' => 'Manage blog posts',
-    'Administration' => 'Admin-only endpoints',
+    // 'User' => 'User management and authentication endpoints',
+    // 'Post' => 'Blog post CRUD operations',
 ],
 
 /*
 |--------------------------------------------------------------------------
-| Tag Order
+| Ungrouped Tags Group Name
 |--------------------------------------------------------------------------
 |
-| Display order for tags. Tags not in the list are displayed alphabetically.
+| Name of the group for tags not assigned to any group.
+| Set to null to hide ungrouped tags from x-tagGroups.
 |
 */
-'tag_order' => [
-    'Authentication',
-    'User Management',
-    'Blog Posts',
-    'Administration',
-],
+'ungrouped_tags_group' => 'Other',
 ```
 
 ## 🔐 Authentication Configuration
@@ -228,102 +237,79 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
 'authentication' => [
     /*
     |--------------------------------------------------------------------------
-    | Default Authentication
+    | Global Authentication
     |--------------------------------------------------------------------------
     |
-    | The default authentication method.
+    | Global authentication settings applied to all endpoints.
+    | Set 'enabled' to true to apply this security scheme to all endpoints.
     |
     */
-    'default' => 'bearer',
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Authentication Flows
-    |--------------------------------------------------------------------------
-    |
-    | Definition of available authentication flows.
-    |
-    */
-    'flows' => [
-        'bearer' => [
+    'global' => [
+        'enabled' => false,
+        'scheme' => [
             'type' => 'http',
             'scheme' => 'bearer',
             'bearerFormat' => 'JWT',
-            'description' => 'JWT Bearer Token authentication',
+            'description' => 'Global JWT authentication',
+            'name' => 'globalAuth',
         ],
-        
-        'apiKey' => [
-            'type' => 'apiKey',
-            'in' => 'header',
-            'name' => 'X-API-Key',
-            'description' => 'API Key authentication',
-        ],
-        
-        'basic' => [
-            'type' => 'http',
-            'scheme' => 'basic',
-            'description' => 'Basic authentication',
-        ],
-        
-        'oauth2' => [
-            'type' => 'oauth2',
-            'flows' => [
-                'authorizationCode' => [
-                    'authorizationUrl' => '/oauth/authorize',
-                    'tokenUrl' => '/oauth/token',
-                    'refreshUrl' => '/oauth/token/refresh',
-                    'scopes' => [
-                        'read' => 'Read permission',
-                        'write' => 'Write permission',
-                        'delete' => 'Delete permission',
-                    ],
+        'required' => false,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Authentication Schemes
+    |--------------------------------------------------------------------------
+    |
+    | Define custom authentication schemes for use in the generated documentation.
+    | Map middleware names to OpenAPI security schemes.
+    |
+    */
+    'custom_schemes' => [
+        // 'custom-auth' => [
+        //     'type' => 'apiKey',
+        //     'in' => 'header',
+        //     'name' => 'X-Custom-Token',
+        //     'description' => 'Custom API token',
+        // ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Patterns
+    |--------------------------------------------------------------------------
+    |
+    | Route patterns that require specific authentication.
+    | Use wildcards (*) for pattern matching.
+    |
+    */
+    'patterns' => [
+        // 'api/admin/*' => 'adminAuth',
+        // 'api/v1/*' => 'bearerAuth',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | OAuth2 Configuration
+    |--------------------------------------------------------------------------
+    |
+    | OAuth2-specific configuration.
+    |
+    */
+    'oauth2' => [
+        'flows' => [
+            'authorizationCode' => [
+                'authorizationUrl' => '/oauth/authorize',
+                'tokenUrl' => '/oauth/token',
+                'refreshUrl' => '/oauth/token/refresh',
+                'scopes' => [
+                    'read' => 'Read permission',
+                    'write' => 'Write permission',
+                    'delete' => 'Delete permission',
                 ],
             ],
         ],
     ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Middleware Mapping
-    |--------------------------------------------------------------------------
-    |
-    | Mapping between Laravel middleware and authentication flows.
-    |
-    */
-    'middleware_map' => [
-        'auth' => 'bearer',
-        'auth:api' => 'bearer',
-        'auth:sanctum' => 'bearer',
-        'auth:passport' => 'oauth2',
-        'auth.basic' => 'basic',
-        'api-key' => 'apiKey',
-    ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Exclude Patterns
-    |--------------------------------------------------------------------------
-    |
-    | Route patterns that don't require authentication.
-    |
-    */
-    'exclude_patterns' => [
-        'api/health',
-        'api/status',
-        'api/auth/login',
-        'api/auth/register',
-        'api/password/forgot',
-    ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Global Security
-    |--------------------------------------------------------------------------
-    |
-    | Whether to apply global security to all endpoints.
-    |
-    */
-    'global_security' => false,
 ],
 ```
 
@@ -419,56 +405,35 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
 'performance' => [
     /*
     |--------------------------------------------------------------------------
-    | Enable Optimization
-    |--------------------------------------------------------------------------
-    |
-    | Whether to enable performance optimization.
-    |
-    */
-    'enabled' => true,
-    
-    /*
-    |--------------------------------------------------------------------------
     | Parallel Processing
     |--------------------------------------------------------------------------
     |
-    | Parallel processing configuration.
+    | Enable parallel processing for large codebases.
+    | Requires spatie/fork package.
     |
     */
-    'parallel_processing' => true,
-    'workers' => env('SPECTRUM_WORKERS', 'auto'), // 'auto' for CPU cores
-    'chunk_size' => env('SPECTRUM_CHUNK_SIZE', 100),
+    'parallel' => env('SPECTRUM_PARALLEL', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Worker Count
+    |--------------------------------------------------------------------------
+    |
+    | Number of workers for parallel processing.
+    | 'auto' uses the number of CPU cores.
+    |
+    */
+    'workers' => env('SPECTRUM_WORKERS', 'auto'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Memory Limit
+    |--------------------------------------------------------------------------
+    |
+    | Memory limit for each worker.
+    |
+    */
     'memory_limit' => env('SPECTRUM_MEMORY_LIMIT', '512M'),
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Analysis Optimization
-    |--------------------------------------------------------------------------
-    |
-    | Analysis optimization settings.
-    |
-    */
-    'analysis' => [
-        'max_depth' => 3,
-        'skip_vendor' => true,
-        'lazy_loading' => true,
-        'use_cache' => true,
-    ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Resource Limits
-    |--------------------------------------------------------------------------
-    |
-    | Resource limits.
-    |
-    */
-    'limits' => [
-        'max_routes' => 10000,
-        'max_file_size' => '50M',
-        'timeout' => 300,
-        'max_schema_depth' => 10,
-    ],
 ],
 ```
 
@@ -480,7 +445,7 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
 | Cache Configuration
 |--------------------------------------------------------------------------
 |
-| Cache settings.
+| Cache settings for analysis results.
 |
 */
 'cache' => [
@@ -489,31 +454,21 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
     | Enable Cache
     |--------------------------------------------------------------------------
     |
-    | Whether to enable caching.
+    | Whether to enable caching of analysis results.
     |
     */
     'enabled' => env('SPECTRUM_CACHE_ENABLED', true),
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Cache Store
-    |--------------------------------------------------------------------------
-    |
-    | The cache store to use.
-    |
-    */
-    'store' => env('SPECTRUM_CACHE_STORE', 'file'),
-    
+
     /*
     |--------------------------------------------------------------------------
     | Cache Directory
     |--------------------------------------------------------------------------
     |
-    | Directory for file cache.
+    | Directory for storing cache files.
     |
     */
     'directory' => storage_path('app/spectrum/cache'),
-    
+
     /*
     |--------------------------------------------------------------------------
     | Cache TTL
@@ -523,45 +478,6 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
     |
     */
     'ttl' => env('SPECTRUM_CACHE_TTL', null),
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Cache Segments
-    |--------------------------------------------------------------------------
-    |
-    | Cache configuration by segment.
-    |
-    */
-    'segments' => [
-        'routes' => ['ttl' => 86400], // 24 hours
-        'schemas' => ['ttl' => 3600], // 1 hour
-        'examples' => ['ttl' => 7200], // 2 hours
-        'analysis' => ['ttl' => 3600], // 1 hour
-    ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Watch Files
-    |--------------------------------------------------------------------------
-    |
-    | Files to watch for changes to invalidate cache.
-    |
-    */
-    'watch_files' => [
-        base_path('composer.json'),
-        base_path('composer.lock'),
-        config_path('spectrum.php'),
-    ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Smart Invalidation
-    |--------------------------------------------------------------------------
-    |
-    | Whether to enable smart cache invalidation.
-    |
-    */
-    'smart_invalidation' => true,
 ],
 ```
 
@@ -573,7 +489,7 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
 | Watch Configuration
 |--------------------------------------------------------------------------
 |
-| File watching configuration.
+| File watching configuration for spectrum:watch command.
 |
 */
 'watch' => [
@@ -582,7 +498,7 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
     | Watch Paths
     |--------------------------------------------------------------------------
     |
-    | Directories and files to watch.
+    | Directories and files to watch for changes.
     |
     */
     'paths' => [
@@ -592,13 +508,13 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
         base_path('routes'),
         config_path(),
     ],
-    
+
     /*
     |--------------------------------------------------------------------------
     | Ignore Patterns
     |--------------------------------------------------------------------------
     |
-    | File patterns to ignore.
+    | File patterns to ignore during file watching.
     |
     */
     'ignore_patterns' => [
@@ -607,90 +523,217 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
         '.DS_Store',
         'Thumbs.db',
     ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Polling
-    |--------------------------------------------------------------------------
-    |
-    | Polling configuration (for Docker environments, etc.).
-    |
-    */
-    'polling' => [
-        'enabled' => env('SPECTRUM_WATCH_POLL', false),
-        'interval' => 1000, // milliseconds
-    ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Server Configuration
-    |--------------------------------------------------------------------------
-    |
-    | Preview server configuration.
-    |
-    */
-    'server' => [
-        'host' => 'localhost',
-        'port' => 8080,
-        'auto_open' => true,
-    ],
 ],
 ```
 
-## 📤 Output Configuration
+## ✅ Validation Configuration
 
 ```php
 /*
 |--------------------------------------------------------------------------
-| Output Configuration
+| Validation Configuration
 |--------------------------------------------------------------------------
 |
-| Output file configuration.
+| Configuration for validation rule analysis.
 |
 */
-'output' => [
+'validation' => [
     /*
     |--------------------------------------------------------------------------
-    | OpenAPI Output
+    | Strict Mode
     |--------------------------------------------------------------------------
     |
-    | OpenAPI document output location.
+    | In strict mode, unrecognized validation rules cause warnings.
     |
     */
-    'openapi' => [
-        'path' => storage_path('app/spectrum/openapi.json'),
-        'format' => 'json', // 'json' or 'yaml'
-        'pretty_print' => true,
-        'version' => '3.0.0',
-    ],
-    
+    'strict_mode' => false,
+],
+```
+
+## 🔄 Transformers Configuration
+
+```php
+/*
+|--------------------------------------------------------------------------
+| Transformers Configuration
+|--------------------------------------------------------------------------
+|
+| Custom type transformers for schema generation.
+|
+*/
+'transformers' => [
+    // \App\Spectrum\Transformers\CustomTransformer::class,
+],
+```
+
+## 📡 Response Detection Configuration
+
+```php
+/*
+|--------------------------------------------------------------------------
+| Response Detection Configuration
+|--------------------------------------------------------------------------
+|
+| Configuration for automatic response detection.
+|
+*/
+'response_detection' => [
     /*
     |--------------------------------------------------------------------------
-    | Export Paths
+    | Enable Response Detection
     |--------------------------------------------------------------------------
     |
-    | Export file output locations.
+    | Whether to enable automatic response type detection.
     |
     */
-    'exports' => [
-        'postman' => storage_path('app/spectrum/postman/'),
-        'insomnia' => storage_path('app/spectrum/insomnia/'),
-    ],
-    
+    'enabled' => true,
+
     /*
     |--------------------------------------------------------------------------
-    | Include Options
+    | Analyze Method Body
     |--------------------------------------------------------------------------
     |
-    | Elements to include in output.
+    | Whether to analyze method bodies for return statements.
     |
     */
-    'include' => [
-        'examples' => true,
-        'descriptions' => true,
-        'deprecated' => true,
-        'x-properties' => true,
+    'analyze_method_body' => true,
+],
+```
+
+## 🌐 HTML Output Configuration
+
+```php
+/*
+|--------------------------------------------------------------------------
+| HTML Output Configuration
+|--------------------------------------------------------------------------
+|
+| Configuration for HTML output with Swagger UI.
+|
+*/
+'html' => [
+    /*
+    |--------------------------------------------------------------------------
+    | Theme
+    |--------------------------------------------------------------------------
+    |
+    | Swagger UI theme. Options: 'default', 'dark'
+    |
+    */
+    'theme' => 'default',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Try It Out
+    |--------------------------------------------------------------------------
+    |
+    | Whether to enable the "Try It Out" feature.
+    |
+    */
+    'try_it_out' => true,
+],
+```
+
+## 📤 Export Configuration
+
+```php
+/*
+|--------------------------------------------------------------------------
+| Export Configuration
+|--------------------------------------------------------------------------
+|
+| Configuration for Postman and Insomnia exports.
+|
+*/
+'export' => [
+    /*
+    |--------------------------------------------------------------------------
+    | Postman Export
+    |--------------------------------------------------------------------------
+    |
+    | Postman export configuration.
+    |
+    */
+    'postman' => [
+        'output_path' => storage_path('app/spectrum/postman'),
+        'environments' => [
+            'local' => [
+                'base_url' => env('APP_URL', 'http://localhost'),
+            ],
+            'staging' => [
+                'base_url' => 'https://staging.example.com',
+            ],
+            'production' => [
+                'base_url' => 'https://api.example.com',
+            ],
+        ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Insomnia Export
+    |--------------------------------------------------------------------------
+    |
+    | Insomnia export configuration.
+    |
+    */
+    'insomnia' => [
+        'output_path' => storage_path('app/spectrum/insomnia/insomnia_collection.json'),
+    ],
+],
+```
+
+## 🎭 Mock Server Configuration
+
+```php
+/*
+|--------------------------------------------------------------------------
+| Mock Server Configuration
+|--------------------------------------------------------------------------
+|
+| Configuration for the mock API server.
+|
+*/
+'mock_server' => [
+    /*
+    |--------------------------------------------------------------------------
+    | Default Host
+    |--------------------------------------------------------------------------
+    |
+    | Default host address to bind the server.
+    |
+    */
+    'host' => env('SPECTRUM_MOCK_HOST', '127.0.0.1'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Port
+    |--------------------------------------------------------------------------
+    |
+    | Default port number for the server.
+    |
+    */
+    'port' => env('SPECTRUM_MOCK_PORT', 8081),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Response Delay
+    |--------------------------------------------------------------------------
+    |
+    | Default response delay in milliseconds.
+    |
+    */
+    'delay' => env('SPECTRUM_MOCK_DELAY', 0),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Scenario
+    |--------------------------------------------------------------------------
+    |
+    | Default response scenario ('success' or 'error').
+    |
+    */
+    'scenario' => 'success',
 ],
 ```
 
@@ -699,7 +742,7 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
 ```php
 /*
 |--------------------------------------------------------------------------
-| Error Handling
+| Error Handling Configuration
 |--------------------------------------------------------------------------
 |
 | Error handling configuration.
@@ -711,106 +754,20 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
     | Fail on Error
     |--------------------------------------------------------------------------
     |
-    | Whether to stop processing on error.
+    | Whether to stop processing when an error is encountered.
     |
     */
     'fail_on_error' => false,
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Error Reporting
-    |--------------------------------------------------------------------------
-    |
-    | Error reporting level.
-    |
-    */
-    'reporting' => [
-        'level' => 'warning', // 'error', 'warning', 'notice'
-        'log_channel' => 'spectrum',
-    ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Error Recovery
-    |--------------------------------------------------------------------------
-    |
-    | Error recovery settings.
-    |
-    */
-    'recovery' => [
-        'continue_on_parse_error' => true,
-        'use_fallback_types' => true,
-        'skip_invalid_routes' => true,
-    ],
-],
-```
 
-## 🎯 Advanced Configuration
-
-```php
-/*
-|--------------------------------------------------------------------------
-| Advanced Configuration
-|--------------------------------------------------------------------------
-|
-| Advanced configuration options.
-|
-*/
-'advanced' => [
     /*
     |--------------------------------------------------------------------------
-    | Custom Analyzers
+    | Ignore Errors
     |--------------------------------------------------------------------------
     |
-    | Register custom analyzers.
+    | Whether to ignore errors and continue processing.
     |
     */
-    'analyzers' => [
-        // 'custom' => \App\Spectrum\Analyzers\CustomAnalyzer::class,
-    ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Custom Generators
-    |--------------------------------------------------------------------------
-    |
-    | Register custom generators.
-    |
-    */
-    'generators' => [
-        // 'custom' => \App\Spectrum\Generators\CustomGenerator::class,
-    ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Hooks
-    |--------------------------------------------------------------------------
-    |
-    | Hook point configuration.
-    |
-    */
-    'hooks' => [
-        'before_analysis' => [],
-        'after_analysis' => [],
-        'before_generation' => [],
-        'after_generation' => [],
-    ],
-    
-    /*
-    |--------------------------------------------------------------------------
-    | Extensions
-    |--------------------------------------------------------------------------
-    |
-    | OpenAPI extension configuration.
-    |
-    */
-    'extensions' => [
-        'x-logo' => [
-            'url' => '/logo.png',
-            'altText' => 'API Logo',
-        ],
-        'x-documentation' => 'https://docs.example.com',
-    ],
+    'ignore_errors' => false,
 ],
 ```
 
@@ -819,23 +776,27 @@ php artisan vendor:publish --provider="LaravelSpectrum\SpectrumServiceProvider" 
 Key settings can be overridden with environment variables:
 
 ```env
-# Basic settings
+# OpenAPI
+SPECTRUM_OPENAPI_VERSION=3.0.0    # or 3.1.0
+
+# Example Generation
 SPECTRUM_USE_FAKER=true
 SPECTRUM_FAKER_LOCALE=en_US
 SPECTRUM_FAKER_SEED=12345
 
 # Performance
+SPECTRUM_PARALLEL=true
 SPECTRUM_WORKERS=8
-SPECTRUM_CHUNK_SIZE=100
 SPECTRUM_MEMORY_LIMIT=1G
 
 # Cache
 SPECTRUM_CACHE_ENABLED=true
-SPECTRUM_CACHE_STORE=redis
 SPECTRUM_CACHE_TTL=3600
 
-# Watch
-SPECTRUM_WATCH_POLL=true
+# Mock Server
+SPECTRUM_MOCK_HOST=127.0.0.1
+SPECTRUM_MOCK_PORT=8081
+SPECTRUM_MOCK_DELAY=0
 ```
 
 ## 📚 Related Documentation

--- a/docs/ja/cli-reference.md
+++ b/docs/ja/cli-reference.md
@@ -32,16 +32,16 @@ php artisan spectrum:generate [options]
 
 ### オプション
 
-| オプション | 短縮形 | デフォルト | 説明 |
-|-----------|--------|-----------|------|
-| `--output` | `-o` | storage/app/spectrum/openapi.json | 出力ファイルパス |
-| `--format` | `-f` | json | 出力形式（json/yaml） |
-| `--pattern` | | config値 | 含めるルートパターン |
-| `--exclude` | | config値 | 除外するルートパターン |
-| `--no-cache` | | false | キャッシュを使用しない |
-| `--force` | | false | 既存ファイルを上書き |
-| `--dry-run` | | false | ファイル生成なしで実行 |
-| `--incremental` | `-i` | false | 変更されたファイルのみ処理 |
+| オプション | デフォルト | 説明 |
+|-----------|-----------|------|
+| `--output` | storage/app/spectrum/openapi.json | 出力ファイルパス |
+| `--format` | json | 出力形式（json/yaml/html） |
+| `--no-cache` | false | キャッシュを使用しない |
+| `--clear-cache` | false | 生成前にキャッシュをクリア |
+| `--fail-on-error` | false | 最初のエラーで実行を停止 |
+| `--ignore-errors` | false | エラーを無視して生成を続行 |
+| `--error-report` | なし | エラーレポートをファイルに保存 |
+| `--no-try-it-out` | false | HTML出力の"Try It Out"機能を無効化 |
 
 ### 使用例
 
@@ -49,23 +49,29 @@ php artisan spectrum:generate [options]
 # 基本的な生成
 php artisan spectrum:generate
 
-# 特定のパターンのみ生成
-php artisan spectrum:generate --pattern="api/v2/*"
-
-# 複数パターンの指定
-php artisan spectrum:generate --pattern="api/users/*" --pattern="api/posts/*"
-
-# 除外パターンの指定
-php artisan spectrum:generate --exclude="api/admin/*" --exclude="api/debug/*"
-
 # YAML形式で出力
 php artisan spectrum:generate --format=yaml --output=docs/api.yaml
 
-# キャッシュなしで強制再生成
-php artisan spectrum:generate --no-cache --force
+# HTML形式で出力（Swagger UI付き）
+php artisan spectrum:generate --format=html --output=docs/api.html
 
-# ドライラン（実際には生成しない）
-php artisan spectrum:generate --dry-run -vvv
+# キャッシュをクリアして再生成
+php artisan spectrum:generate --clear-cache
+
+# キャッシュを使用せず生成
+php artisan spectrum:generate --no-cache
+
+# エラー時に停止
+php artisan spectrum:generate --fail-on-error
+
+# エラーを無視して続行
+php artisan spectrum:generate --ignore-errors
+
+# エラーレポートを保存
+php artisan spectrum:generate --error-report=storage/spectrum-errors.json
+
+# 詳細な出力で生成
+php artisan spectrum:generate -vvv
 ```
 
 ## ⚡ spectrum:generate:optimized
@@ -82,12 +88,13 @@ php artisan spectrum:generate:optimized [options]
 
 | オプション | デフォルト | 説明 |
 |-----------|-----------|------|
+| `--format` | json | 出力形式（json/yaml） |
+| `--output` | storage/app/spectrum/openapi.json | 出力ファイルパス |
+| `--parallel` | false | 並列処理を有効化 |
 | `--workers` | auto | 並列ワーカー数（autoでCPUコア数） |
-| `--chunk-size` | 100 | 各ワーカーが処理するルート数 |
+| `--chunk-size` | auto | 各ワーカーが処理するルート数 |
 | `--memory-limit` | 512M | 各ワーカーのメモリ制限 |
 | `--incremental` | false | 変更されたファイルのみ処理 |
-| `--progress` | true | 進捗バーを表示 |
-| `--stats` | true | パフォーマンス統計を表示 |
 
 ### 使用例
 
@@ -95,8 +102,11 @@ php artisan spectrum:generate:optimized [options]
 # 自動最適化で生成
 php artisan spectrum:generate:optimized
 
+# 並列処理を有効化
+php artisan spectrum:generate:optimized --parallel
+
 # 8ワーカーで並列処理
-php artisan spectrum:generate:optimized --workers=8
+php artisan spectrum:generate:optimized --parallel --workers=8
 
 # メモリとチャンクサイズの調整
 php artisan spectrum:generate:optimized --memory-limit=1G --chunk-size=50
@@ -104,8 +114,11 @@ php artisan spectrum:generate:optimized --memory-limit=1G --chunk-size=50
 # インクリメンタル生成
 php artisan spectrum:generate:optimized --incremental
 
-# 統計なしで静かに実行
-php artisan spectrum:generate:optimized --no-stats --no-progress
+# YAML形式で出力
+php artisan spectrum:generate:optimized --format=yaml
+
+# 詳細な出力で生成
+php artisan spectrum:generate:optimized -v
 ```
 
 ## 👁️ spectrum:watch
@@ -123,10 +136,8 @@ php artisan spectrum:watch [options]
 | オプション | デフォルト | 説明 |
 |-----------|-----------|------|
 | `--port` | 8080 | プレビューサーバーのポート |
-| `--host` | localhost | プレビューサーバーのホスト |
+| `--host` | 127.0.0.1 | プレビューサーバーのホスト |
 | `--no-open` | false | ブラウザを自動で開かない |
-| `--poll` | false | ポーリングモードを使用 |
-| `--interval` | 1000 | ポーリング間隔（ミリ秒） |
 
 ### 使用例
 
@@ -142,9 +153,6 @@ php artisan spectrum:watch --no-open
 
 # 外部アクセス可能にする
 php artisan spectrum:watch --host=0.0.0.0
-
-# ポーリングモード（Docker環境など）
-php artisan spectrum:watch --poll --interval=2000
 ```
 
 ## 🎭 spectrum:mock
@@ -200,11 +208,9 @@ php artisan spectrum:export:postman [options]
 
 | オプション | デフォルト | 説明 |
 |-----------|-----------|------|
-| `--output` | storage/app/spectrum/postman/collection.json | 出力ファイルパス |
-| `--include-examples` | true | リクエスト/レスポンス例を含める |
-| `--include-tests` | false | テストスクリプトを生成 |
-| `--environment` | false | 環境変数ファイルも生成 |
-| `--base-url` | APP_URL | ベースURL |
+| `--output` | storage/app/spectrum/postman | 出力ディレクトリ |
+| `--environments` | local | エクスポートする環境（カンマ区切り） |
+| `--single-file` | false | 環境を埋め込んだ単一ファイルでエクスポート |
 
 ### 使用例
 
@@ -212,20 +218,14 @@ php artisan spectrum:export:postman [options]
 # 基本的なエクスポート
 php artisan spectrum:export:postman
 
-# テストスクリプト付きでエクスポート
-php artisan spectrum:export:postman --include-tests
-
-# 環境変数ファイルも生成
-php artisan spectrum:export:postman --environment
-
 # カスタム出力先
-php artisan spectrum:export:postman --output=postman/my-api.json
+php artisan spectrum:export:postman --output=postman/
 
-# 完全なエクスポート
-php artisan spectrum:export:postman \
-    --include-tests \
-    --environment \
-    --base-url=https://api.example.com
+# 複数環境をエクスポート
+php artisan spectrum:export:postman --environments=local,staging,production
+
+# 単一ファイルでエクスポート
+php artisan spectrum:export:postman --single-file
 ```
 
 ## 🦊 spectrum:export:insomnia
@@ -242,10 +242,7 @@ php artisan spectrum:export:insomnia [options]
 
 | オプション | デフォルト | 説明 |
 |-----------|-----------|------|
-| `--output` | storage/app/spectrum/insomnia/workspace.json | 出力ファイルパス |
-| `--workspace-name` | APP_NAME API | ワークスペース名 |
-| `--include-environments` | true | 環境設定を含める |
-| `--folder-structure` | true | フォルダ構造で整理 |
+| `--output` | storage/app/spectrum/insomnia/insomnia_collection.json | 出力ファイルパス |
 
 ### 使用例
 
@@ -253,14 +250,11 @@ php artisan spectrum:export:insomnia [options]
 # 基本的なエクスポート
 php artisan spectrum:export:insomnia
 
-# カスタムワークスペース名
-php artisan spectrum:export:insomnia --workspace-name="My Cool API"
-
-# フォルダ構造なしでフラット
-php artisan spectrum:export:insomnia --no-folder-structure
-
-# カスタム出力先
+# カスタム出力先（ファイルパス）
 php artisan spectrum:export:insomnia --output=insomnia/api.json
+
+# カスタム出力先（ディレクトリ）
+php artisan spectrum:export:insomnia --output=insomnia/
 ```
 
 ## 🗑️ spectrum:cache


### PR DESCRIPTION
# 概要

CLIコマンドリファレンスと設定リファレンスを、実際のソースコード実装に合わせて更新しました。

## 変更内容

### CLI リファレンス (日英)

- **spectrum:generate** - 正確なオプション一覧に修正
- **spectrum:generate:optimized** - 存在しないオプション（--progress, --stats）を削除し、実際のオプションに修正
- **spectrum:watch** - 存在しないオプション（--poll, --interval）を削除
- **spectrum:export:postman** - --single-file オプションを追加、オプション説明を修正
- **spectrum:export:insomnia** - 実装に合わせて簡素化（--output オプションのみ）
- **spectrum:cache** - アクション説明を更新

### 設定リファレンス (日英)

- **新規セクション追加:**
  - OpenAPI バージョン設定 (`openapi.version`)
  - ルートファイル設定 (`route_files`)
  - タググループ設定 (`tag_groups`, `ungrouped_tags_group`)
  - バリデーション設定 (`validation`)
  - トランスフォーマー設定 (`transformers`)
  - レスポンス検出設定 (`response_detection`)
  - HTML出力設定 (`html`)
  - エクスポート設定 (`export`)
  - モックサーバー設定 (`mock_server`)

- **既存セクション更新:**
  - 認証セクションを実際の設定構造に合わせてリストラクチャ
  - パフォーマンス設定を簡素化
  - キャッシュ設定を簡素化
  - ウォッチ設定から古いサブセクションを削除
  - エラーハンドリング設定を簡素化
  - 環境変数一覧を更新

## 関連情報

- ドキュメントの内容を `config/spectrum.php` および `src/Console/` のコマンド実装と同期