### PR TITLE
feat: use configured OpenAPI version in base structure

### DIFF
--- a/src/Generators/OpenApiGenerator.php
+++ b/src/Generators/OpenApiGenerator.php
@@ -130,7 +130,7 @@ class OpenApiGenerator
     protected function buildBaseStructure(array $authenticationInfo): array
     {
         return [
-            'openapi' => '3.0.0',
+            'openapi' => $this->getOpenApiVersion(),
             'info' => [
                 'title' => config('spectrum.title', config('app.name').' API'),
                 'version' => config('spectrum.version', '1.0.0'),
@@ -150,6 +150,19 @@ class OpenApiGenerator
                 ),
             ],
         ];
+    }
+
+    /**
+     * Get the validated OpenAPI version from configuration.
+     *
+     * Only accepts valid OpenAPI versions (3.0.0 or 3.1.0).
+     * Falls back to 3.0.0 for invalid or missing values.
+     */
+    protected function getOpenApiVersion(): string
+    {
+        $version = config('spectrum.openapi.version', '3.0.0');
+
+        return in_array($version, ['3.0.0', '3.1.0'], true) ? $version : '3.0.0';
     }
 
     /**


### PR DESCRIPTION
## Summary

Uses the configured OpenAPI version directly in `buildBaseStructure()` instead of hardcoding `3.0.0`.

### Changes
- Add `getOpenApiVersion()` method to validate and return config value
- Use config value directly in `buildBaseStructure()`
- Only accept `3.0.0` or `3.1.0` as valid versions, fall back to `3.0.0`

### Before
```php
// buildBaseStructure() always returned 3.0.0
'openapi' => '3.0.0',  // Hardcoded

// Then converter changed it to 3.1.0 if configured
if (config('spectrum.openapi.version') === '3.1.0') {
    $openapi = $this->openApi31Converter->convert($openapi);
}
```

### After
```php
// buildBaseStructure() now uses config
'openapi' => $this->getOpenApiVersion(),

// getOpenApiVersion() validates and returns the configured version
protected function getOpenApiVersion(): string
{
    $version = config('spectrum.openapi.version', '3.0.0');
    return in_array($version, ['3.0.0', '3.1.0'], true) ? $version : '3.0.0';
}
```

The converter still runs for 3.1.0 to handle nullable type conversions and add webhooks.

Closes #207

## Test plan
- [x] All 2189 existing tests pass
- [x] Existing OpenAPI version tests verify the behavior
- [x] PHPStan passes
- [x] Code formatted with Pint