### PR TITLE
test: improve Exporter test coverage #199

### DIFF
--- a/tests/Unit/Exporters/InsomniaExporterTest.php
+++ b/tests/Unit/Exporters/InsomniaExporterTest.php
@@ -417,4 +417,257 @@ class InsomniaExporterTest extends TestCase
         $this->assertContains('Users', $groupNames);
         $this->assertContains('Posts', $groupNames);
     }
+
+    public function test_export_environment_returns_empty_array(): void
+    {
+        // Insomnia environments are included in the main export, so this method returns empty
+        $result = $this->exporter->exportEnvironment(
+            [['url' => 'https://api.example.com']],
+            [['bearerAuth' => []]],
+            'local'
+        );
+
+        $this->assertEmpty($result);
+    }
+
+    public function test_export_with_unsupported_request_body_content_type(): void
+    {
+        // Test when request body has unsupported content type (not JSON or multipart)
+        $openapi = [
+            'openapi' => '3.0.0',
+            'info' => ['title' => 'Test API'],
+            'paths' => [
+                '/users' => [
+                    'post' => [
+                        'summary' => 'Create user',
+                        'tags' => ['Users'],
+                        'requestBody' => [
+                            'content' => [
+                                'text/plain' => [
+                                    'schema' => [
+                                        'type' => 'string',
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'responses' => [
+                            '201' => ['description' => 'Created'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->exporter->export($openapi);
+
+        $request = array_filter($result['resources'], fn ($r) => $r['_type'] === 'request');
+        $request = array_values($request)[0];
+
+        // Body should be empty for unsupported content types
+        $this->assertEmpty($request['body']);
+    }
+
+    public function test_export_with_unrecognized_security_type(): void
+    {
+        // Test when security is present but auth type is not recognized
+        $openapi = [
+            'openapi' => '3.0.0',
+            'info' => ['title' => 'Test API'],
+            'components' => [
+                'securitySchemes' => [
+                    'unknown' => [
+                        'type' => 'custom',
+                    ],
+                ],
+            ],
+            'paths' => [
+                '/protected' => [
+                    'get' => [
+                        'summary' => 'Protected endpoint',
+                        'tags' => ['Protected'],
+                        'security' => [
+                            ['unknown' => []],
+                        ],
+                        'responses' => [
+                            '200' => ['description' => 'Success'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->exporter->export($openapi);
+
+        $request = array_filter($result['resources'], fn ($r) => $r['_type'] === 'request');
+        $request = array_values($request)[0];
+
+        // Authentication should be empty for unrecognized types
+        $this->assertArrayHasKey('authentication', $request);
+        $this->assertEmpty($request['authentication']);
+    }
+
+    public function test_export_with_oauth2_security_scheme(): void
+    {
+        // Test OAuth2 security scheme adds proper environment variables
+        $openapi = [
+            'openapi' => '3.0.0',
+            'info' => ['title' => 'Test API'],
+            'components' => [
+                'securitySchemes' => [
+                    'oauth2' => [
+                        'type' => 'oauth2',
+                        'flows' => [
+                            'authorizationCode' => [
+                                'authorizationUrl' => 'https://auth.example.com/authorize',
+                                'tokenUrl' => 'https://auth.example.com/token',
+                                'scopes' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'paths' => [
+                '/test' => [
+                    'get' => [
+                        'summary' => 'Test endpoint',
+                        'tags' => ['Test'],
+                        'responses' => [
+                            '200' => ['description' => 'Success'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->exporter->export($openapi);
+
+        // Find environment resource
+        $env = array_filter($result['resources'], fn ($r) => $r['_type'] === 'environment' && $r['name'] === 'Production Environment'
+        );
+        $this->assertCount(1, $env);
+
+        $env = array_values($env)[0];
+        $this->assertArrayHasKey('data', $env);
+
+        // OAuth2 environment variables should be present
+        $this->assertArrayHasKey('oauth2_client_id', $env['data']);
+        $this->assertArrayHasKey('oauth2_client_secret', $env['data']);
+        $this->assertArrayHasKey('oauth2_token_url', $env['data']);
+        $this->assertArrayHasKey('oauth2_auth_url', $env['data']);
+    }
+
+    public function test_export_with_custom_environment_variables(): void
+    {
+        // Test custom environment variables from config
+        config(['spectrum.export.environment_variables' => [
+            'custom_var' => 'custom_value',
+            'api_version' => 'v2',
+        ]]);
+
+        $openapi = [
+            'openapi' => '3.0.0',
+            'info' => ['title' => 'Test API'],
+            'paths' => [
+                '/test' => [
+                    'get' => [
+                        'summary' => 'Test endpoint',
+                        'tags' => ['Test'],
+                        'responses' => [
+                            '200' => ['description' => 'Success'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->exporter->export($openapi);
+
+        // Find environment resource
+        $env = array_filter($result['resources'], fn ($r) => $r['_type'] === 'environment' && $r['name'] === 'Production Environment'
+        );
+        $this->assertCount(1, $env);
+
+        $env = array_values($env)[0];
+        $this->assertArrayHasKey('data', $env);
+
+        // Custom environment variables should be present
+        $this->assertArrayHasKey('custom_var', $env['data']);
+        $this->assertEquals('custom_value', $env['data']['custom_var']);
+        $this->assertArrayHasKey('api_version', $env['data']);
+        $this->assertEquals('v2', $env['data']['api_version']);
+    }
+
+    public function test_export_with_header_parameters(): void
+    {
+        // Test header parameters are added to headers
+        $openapi = [
+            'openapi' => '3.0.0',
+            'info' => ['title' => 'Test API'],
+            'paths' => [
+                '/users' => [
+                    'get' => [
+                        'summary' => 'Get users',
+                        'tags' => ['Users'],
+                        'parameters' => [
+                            [
+                                'name' => 'X-Custom-Header',
+                                'in' => 'header',
+                                'schema' => ['type' => 'string'],
+                                'required' => true,
+                            ],
+                            [
+                                'name' => 'X-Correlation-Id',
+                                'in' => 'header',
+                                'schema' => ['type' => 'string'],
+                                'required' => false,
+                            ],
+                        ],
+                        'responses' => [
+                            '200' => ['description' => 'Success'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->exporter->export($openapi);
+
+        $request = array_filter($result['resources'], fn ($r) => $r['_type'] === 'request');
+        $request = array_values($request)[0];
+
+        $this->assertArrayHasKey('headers', $request);
+
+        // Check that header parameters are included
+        $headerNames = array_column($request['headers'], 'name');
+        $this->assertContains('X-Custom-Header', $headerNames);
+        $this->assertContains('X-Correlation-Id', $headerNames);
+        $this->assertContains('Accept', $headerNames); // Default header
+    }
+
+    public function test_export_with_no_tags_uses_default_group(): void
+    {
+        $openapi = [
+            'openapi' => '3.0.0',
+            'info' => ['title' => 'Test API'],
+            'paths' => [
+                '/users' => [
+                    'get' => [
+                        'summary' => 'Get users',
+                        // No tags
+                        'responses' => [
+                            '200' => ['description' => 'Success'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->exporter->export($openapi);
+
+        $groups = array_filter($result['resources'], fn ($r) => $r['_type'] === 'request_group');
+        $this->assertCount(1, $groups);
+
+        $group = array_values($groups)[0];
+        $this->assertEquals('Default', $group['name']);
+    }
 }


### PR DESCRIPTION
## Summary

- Improve PostmanExporter test coverage: 92.53% → 97.15% line coverage
- Improve InsomniaExporter test coverage: 91.35% → 100% line coverage

## Changes

### PostmanExporter Tests (9 new tests)
- `test_export_environment_with_api_key_security`: Tests apiKey environment variable generation
- `test_export_environment_with_custom_variables`: Tests custom config variables
- `test_export_with_api_key_auth`: Tests API key authentication
- `test_export_with_no_tags_uses_default_folder`: Tests default folder behavior
- `test_export_with_accept_header`: Tests Accept header generation
- `test_export_with_content_type_header_for_post`: Tests Content-Type header
- `test_export_with_basic_auth_returns_empty_when_unsupported`: Documents current basic auth behavior
- `test_export_with_response_examples`: Tests response example generation
- `test_export_without_servers_has_empty_variables`: Tests empty servers behavior

### InsomniaExporter Tests (7 new tests)
- `test_export_environment_returns_empty_array`: Tests exportEnvironment method
- `test_export_with_unsupported_request_body_content_type`: Tests fallback for unsupported content
- `test_export_with_unrecognized_security_type`: Tests unknown security type handling
- `test_export_with_oauth2_security_scheme`: Tests OAuth2 environment variable generation
- `test_export_with_custom_environment_variables`: Tests custom config variables
- `test_export_with_header_parameters`: Tests header parameter support
- `test_export_with_no_tags_uses_default_group`: Tests default group behavior

## Test plan

- [x] All new tests pass
- [x] All existing tests continue to pass (2228 tests, 6337 assertions)
- [x] `composer format:fix` passes
- [x] `composer analyze` passes

Closes #199