### PR TITLE
fix: support inline validation detection for anonymous classes #200

### DIFF
--- a/src/Analyzers/AST/Visitors/AnonymousClassFindingVisitor.php
+++ b/src/Analyzers/AST/Visitors/AnonymousClassFindingVisitor.php
@@ -12,11 +12,32 @@ class AnonymousClassFindingVisitor extends NodeVisitorAbstract
 
     private bool $extendsFormRequest = false;
 
+    private ?int $targetLine = null;
+
+    /**
+     * Create a new visitor instance.
+     *
+     * @param  int|null  $targetLine  If provided, only match anonymous class starting at this line
+     */
+    public function __construct(?int $targetLine = null)
+    {
+        $this->targetLine = $targetLine;
+    }
+
     public function enterNode(Node $node)
     {
         // Look for anonymous class nodes in various contexts
         if ($node instanceof Node\Expr\New_ &&
             $node->class instanceof Node\Stmt\Class_) {
+
+            // If target line is specified, only match if the class starts at that line
+            if ($this->targetLine !== null) {
+                $classStartLine = $node->class->getStartLine();
+                if ($classStartLine !== $this->targetLine) {
+                    return null; // Continue searching
+                }
+            }
+
             $this->classNode = $node->class;
 
             // Check if it extends FormRequest

--- a/src/Analyzers/ControllerAnalyzer.php
+++ b/src/Analyzers/ControllerAnalyzer.php
@@ -258,8 +258,15 @@ class ControllerAnalyzer implements HasErrors, MethodAnalyzer
                 return null;
             }
 
-            // クラスノードを探す
-            $classNode = $this->astHelper->findClassNode($ast, $reflection->getShortName());
+            // Handle anonymous classes by finding them by line number
+            if ($reflection->isAnonymous()) {
+                $startLine = $reflection->getStartLine();
+                $classNode = $this->astHelper->findAnonymousClassNode($ast, $startLine);
+            } else {
+                // クラスノードを探す
+                $classNode = $this->astHelper->findClassNode($ast, $reflection->getShortName());
+            }
+
             if (! $classNode) {
                 return null;
             }

--- a/src/Analyzers/Support/AstHelper.php
+++ b/src/Analyzers/Support/AstHelper.php
@@ -180,11 +180,12 @@ class AstHelper
      * Find an anonymous class node in the AST.
      *
      * @param  array<Node\Stmt>  $ast  The parsed AST nodes from PhpParser
+     * @param  int|null  $atLine  If provided, only match anonymous class starting at this line
      * @return Node\Stmt\Class_|null The found anonymous class node or null if not found
      */
-    public function findAnonymousClassNode(array $ast): ?Node\Stmt\Class_
+    public function findAnonymousClassNode(array $ast, ?int $atLine = null): ?Node\Stmt\Class_
     {
-        $visitor = new AST\Visitors\AnonymousClassFindingVisitor;
+        $visitor = new AST\Visitors\AnonymousClassFindingVisitor($atLine);
         $this->traverse($ast, $visitor);
 
         return $visitor->getClassNode();

--- a/tests/Feature/QueryParameterDetectionTest.php
+++ b/tests/Feature/QueryParameterDetectionTest.php
@@ -182,15 +182,13 @@ class QueryParameterDetectionTest extends TestCase
         $pageParam = $this->findParameter($operation['parameters'], 'page');
         $this->assertNotNull($pageParam);
         $this->assertEquals('integer', $pageParam['schema']['type']);
-        // TODO: Fix inline validation detection for anonymous classes
-        // $this->assertEquals(1, $pageParam['schema']['minimum']);
+        $this->assertEquals(1, $pageParam['schema']['minimum']);
 
         $perPageParam = $this->findParameter($operation['parameters'], 'per_page');
         $this->assertNotNull($perPageParam);
         $this->assertEquals('integer', $perPageParam['schema']['type']);
-        // TODO: Fix inline validation detection for anonymous classes
-        // $this->assertEquals(10, $perPageParam['schema']['minimum']);
-        // $this->assertEquals(100, $perPageParam['schema']['maximum']);
+        $this->assertEquals(10, $perPageParam['schema']['minimum']);
+        $this->assertEquals(100, $perPageParam['schema']['maximum']);
 
         // Check that non-validated parameter is still detected
         $sortParam = $this->findParameter($operation['parameters'], 'sort');


### PR DESCRIPTION
## Summary

Fixed inline validation detection for anonymous classes. Previously, validation rules like `min:1`, `max:100`, `between:10,100` were not properly extracted from anonymous class controllers because the AST parser couldn't locate the anonymous class nodes.

## Problem

When using anonymous classes in tests (like `new class { ... }`), the `ControllerAnalyzer::getMethodNode` was unable to find the class node because:
1. It used `findClassNode($ast, $reflection->getShortName())` which doesn't work for anonymous classes
2. Anonymous classes don't have a proper class name to search for

## Solution

Updated the analyzer to:
1. Check if the class is anonymous using `ReflectionClass::isAnonymous()`
2. Find the anonymous class node by its start line number
3. Enhanced `AnonymousClassFindingVisitor` to accept a target line parameter
4. Enhanced `AstHelper::findAnonymousClassNode` to accept an optional line number

## Files Changed

| File | Changes |
|------|---------|
| `src/Analyzers/AST/Visitors/AnonymousClassFindingVisitor.php` | Added `$targetLine` parameter to find specific anonymous class |
| `src/Analyzers/Support/AstHelper.php` | Added optional `$atLine` parameter to `findAnonymousClassNode` |
| `src/Analyzers/ControllerAnalyzer.php` | Handle anonymous classes in `getMethodNode` |
| `tests/Feature/QueryParameterDetectionTest.php` | Enabled previously skipped assertions |

## Test Plan

- [x] All 2228 tests pass
- [x] Previously skipped assertions now enabled and passing
- [x] `composer format:fix` passes
- [x] `composer analyze` passes

## Assertions Enabled

```php
// Previously commented out:
$this->assertEquals(1, $pageParam['schema']['minimum']);
$this->assertEquals(10, $perPageParam['schema']['minimum']);
$this->assertEquals(100, $perPageParam['schema']['maximum']);
```

Closes #200