### PR TITLE
feat: Introduce Response DTOs (#227)

### DIFF
--- a/src/DTO/ResourceInfo.php
+++ b/src/DTO/ResourceInfo.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\DTO;
+
+/**
+ * Represents the result of analyzing an API Resource class.
+ */
+final readonly class ResourceInfo
+{
+    /**
+     * @param  array<string, array<string, mixed>>  $properties  The resource properties/schema
+     * @param  array<string, array<string, mixed>>  $with  Additional data from 'with' method
+     * @param  bool  $hasExamples  Whether the resource has example data
+     * @param  mixed  $customExample  Custom example data
+     * @param  array<int, array<string, mixed>>|null  $customExamples  Multiple custom examples
+     * @param  bool  $isCollection  Whether this is a collection resource
+     */
+    public function __construct(
+        public array $properties,
+        public array $with = [],
+        public bool $hasExamples = false,
+        public mixed $customExample = null,
+        public ?array $customExamples = null,
+        public bool $isCollection = false,
+    ) {}
+
+    /**
+     * Create from an array.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            properties: $data['properties'] ?? [],
+            with: $data['with'] ?? [],
+            hasExamples: $data['hasExamples'] ?? false,
+            customExample: $data['customExample'] ?? null,
+            customExamples: $data['customExamples'] ?? null,
+            isCollection: $data['isCollection'] ?? false,
+        );
+    }
+
+    /**
+     * Convert to array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $result = [
+            'properties' => $this->properties,
+        ];
+
+        if (count($this->with) > 0) {
+            $result['with'] = $this->with;
+        }
+
+        if ($this->hasExamples) {
+            $result['hasExamples'] = $this->hasExamples;
+        }
+
+        if ($this->customExample !== null) {
+            $result['customExample'] = $this->customExample;
+        }
+
+        if ($this->customExamples !== null) {
+            $result['customExamples'] = $this->customExamples;
+        }
+
+        if ($this->isCollection) {
+            $result['isCollection'] = $this->isCollection;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Create an empty resource info.
+     */
+    public static function empty(): self
+    {
+        return new self(
+            properties: [],
+        );
+    }
+
+    /**
+     * Check if this resource info is empty.
+     */
+    public function isEmpty(): bool
+    {
+        return count($this->properties) === 0;
+    }
+
+    /**
+     * Check if this resource has a custom example.
+     */
+    public function hasCustomExample(): bool
+    {
+        return $this->customExample !== null;
+    }
+
+    /**
+     * Check if this resource has multiple custom examples.
+     */
+    public function hasCustomExamples(): bool
+    {
+        return $this->customExamples !== null;
+    }
+
+    /**
+     * Check if this resource has 'with' data.
+     */
+    public function hasWithData(): bool
+    {
+        return count($this->with) > 0;
+    }
+
+    /**
+     * Get a property by name.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getPropertyByName(string $name): ?array
+    {
+        return $this->properties[$name] ?? null;
+    }
+
+    /**
+     * Get all property names.
+     *
+     * @return array<int, string>
+     */
+    public function getPropertyNames(): array
+    {
+        return array_keys($this->properties);
+    }
+
+    /**
+     * Count the number of properties.
+     */
+    public function count(): int
+    {
+        return count($this->properties);
+    }
+
+    /**
+     * Get all properties including 'with' data.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function getAllProperties(): array
+    {
+        return array_merge($this->properties, $this->with);
+    }
+}

--- a/src/DTO/ResponseInfo.php
+++ b/src/DTO/ResponseInfo.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\DTO;
+
+/**
+ * Represents the result of analyzing a controller method's response.
+ */
+final readonly class ResponseInfo
+{
+    /**
+     * @param  ResponseType  $type  The type of response
+     * @param  array<string, array<string, mixed>>  $properties  The response properties/schema
+     * @param  string|null  $resourceClass  The resource class name (for resource type)
+     * @param  string|null  $error  Error message if analysis failed
+     */
+    public function __construct(
+        public ResponseType $type,
+        public array $properties = [],
+        public ?string $resourceClass = null,
+        public ?string $error = null,
+    ) {}
+
+    /**
+     * Create from an array.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $typeString = $data['type'] ?? 'unknown';
+        $type = ResponseType::tryFrom($typeString) ?? ResponseType::UNKNOWN;
+
+        return new self(
+            type: $type,
+            properties: $data['properties'] ?? [],
+            resourceClass: $data['class'] ?? null,
+            error: $data['error'] ?? null,
+        );
+    }
+
+    /**
+     * Convert to array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $result = [
+            'type' => $this->type->value,
+            'properties' => $this->properties,
+        ];
+
+        if ($this->resourceClass !== null) {
+            $result['class'] = $this->resourceClass;
+        }
+
+        if ($this->error !== null) {
+            $result['error'] = $this->error;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Create a void response info.
+     */
+    public static function void(): self
+    {
+        return new self(
+            type: ResponseType::VOID,
+            properties: [],
+        );
+    }
+
+    /**
+     * Create an unknown response info.
+     */
+    public static function unknown(): self
+    {
+        return new self(
+            type: ResponseType::UNKNOWN,
+            properties: [],
+        );
+    }
+
+    /**
+     * Create an unknown response info with error.
+     */
+    public static function unknownWithError(string $error): self
+    {
+        return new self(
+            type: ResponseType::UNKNOWN,
+            properties: [],
+            error: $error,
+        );
+    }
+
+    /**
+     * Check if this is a void response.
+     */
+    public function isVoid(): bool
+    {
+        return $this->type->isVoid();
+    }
+
+    /**
+     * Check if this is a collection response.
+     */
+    public function isCollection(): bool
+    {
+        return $this->type->isCollection();
+    }
+
+    /**
+     * Check if this is a resource response.
+     */
+    public function isResource(): bool
+    {
+        return $this->type->isResource();
+    }
+
+    /**
+     * Check if this response has an error.
+     */
+    public function hasError(): bool
+    {
+        return $this->error !== null;
+    }
+
+    /**
+     * Check if this response has properties.
+     */
+    public function hasProperties(): bool
+    {
+        return count($this->properties) > 0;
+    }
+
+    /**
+     * Check if this response has a resource class.
+     */
+    public function hasResourceClass(): bool
+    {
+        return $this->resourceClass !== null;
+    }
+
+    /**
+     * Get all property names.
+     *
+     * @return array<int, string>
+     */
+    public function getPropertyNames(): array
+    {
+        return array_keys($this->properties);
+    }
+}

--- a/src/DTO/ResponseType.php
+++ b/src/DTO/ResponseType.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\DTO;
+
+/**
+ * Represents the type of response from a controller method.
+ */
+enum ResponseType: string
+{
+    case VOID = 'void';
+    case RESOURCE = 'resource';
+    case OBJECT = 'object';
+    case COLLECTION = 'collection';
+    case UNKNOWN = 'unknown';
+
+    /**
+     * Check if this response type is void.
+     */
+    public function isVoid(): bool
+    {
+        return $this === self::VOID;
+    }
+
+    /**
+     * Check if this response type is a collection.
+     */
+    public function isCollection(): bool
+    {
+        return $this === self::COLLECTION;
+    }
+
+    /**
+     * Check if this response type is a resource.
+     */
+    public function isResource(): bool
+    {
+        return $this === self::RESOURCE;
+    }
+
+    /**
+     * Check if this response type has a structure (properties).
+     */
+    public function hasStructure(): bool
+    {
+        return in_array($this, [self::OBJECT, self::COLLECTION, self::RESOURCE], true);
+    }
+}

--- a/tests/Unit/DTO/ResourceInfoTest.php
+++ b/tests/Unit/DTO/ResourceInfoTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\DTO;
+
+use LaravelSpectrum\DTO\ResourceInfo;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ResourceInfoTest extends TestCase
+{
+    #[Test]
+    public function it_can_be_constructed(): void
+    {
+        $info = new ResourceInfo(
+            properties: ['id' => ['type' => 'integer'], 'name' => ['type' => 'string']],
+            with: ['meta' => ['type' => 'object']],
+            hasExamples: true,
+            customExample: ['id' => 1, 'name' => 'John'],
+            customExamples: [['id' => 1], ['id' => 2]],
+            isCollection: false,
+        );
+
+        $this->assertCount(2, $info->properties);
+        $this->assertCount(1, $info->with);
+        $this->assertTrue($info->hasExamples);
+        $this->assertEquals(['id' => 1, 'name' => 'John'], $info->customExample);
+        $this->assertCount(2, $info->customExamples);
+        $this->assertFalse($info->isCollection);
+    }
+
+    #[Test]
+    public function it_can_be_constructed_with_defaults(): void
+    {
+        $info = new ResourceInfo(
+            properties: ['id' => ['type' => 'integer']],
+        );
+
+        $this->assertCount(1, $info->properties);
+        $this->assertEquals([], $info->with);
+        $this->assertFalse($info->hasExamples);
+        $this->assertNull($info->customExample);
+        $this->assertNull($info->customExamples);
+        $this->assertFalse($info->isCollection);
+    }
+
+    #[Test]
+    public function it_creates_from_array(): void
+    {
+        $array = [
+            'properties' => ['id' => ['type' => 'integer']],
+            'with' => ['links' => ['type' => 'object']],
+            'hasExamples' => true,
+            'customExample' => ['id' => 42],
+            'customExamples' => [['id' => 1], ['id' => 2]],
+            'isCollection' => true,
+        ];
+
+        $info = ResourceInfo::fromArray($array);
+
+        $this->assertCount(1, $info->properties);
+        $this->assertCount(1, $info->with);
+        $this->assertTrue($info->hasExamples);
+        $this->assertEquals(['id' => 42], $info->customExample);
+        $this->assertCount(2, $info->customExamples);
+        $this->assertTrue($info->isCollection);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_defaults(): void
+    {
+        $array = [];
+
+        $info = ResourceInfo::fromArray($array);
+
+        $this->assertEquals([], $info->properties);
+        $this->assertEquals([], $info->with);
+        $this->assertFalse($info->hasExamples);
+        $this->assertNull($info->customExample);
+        $this->assertNull($info->customExamples);
+        $this->assertFalse($info->isCollection);
+    }
+
+    #[Test]
+    public function it_converts_to_array(): void
+    {
+        $info = new ResourceInfo(
+            properties: ['id' => ['type' => 'integer']],
+            with: ['meta' => []],
+            hasExamples: true,
+            customExample: ['id' => 1],
+            customExamples: [['id' => 1]],
+            isCollection: true,
+        );
+
+        $array = $info->toArray();
+
+        $this->assertArrayHasKey('properties', $array);
+        $this->assertArrayHasKey('with', $array);
+        $this->assertArrayHasKey('hasExamples', $array);
+        $this->assertArrayHasKey('customExample', $array);
+        $this->assertArrayHasKey('customExamples', $array);
+        $this->assertArrayHasKey('isCollection', $array);
+        $this->assertTrue($array['isCollection']);
+    }
+
+    #[Test]
+    public function it_converts_to_array_without_optional_fields_when_empty(): void
+    {
+        $info = new ResourceInfo(
+            properties: ['id' => []],
+        );
+
+        $array = $info->toArray();
+
+        $this->assertArrayHasKey('properties', $array);
+        $this->assertArrayNotHasKey('with', $array);
+        $this->assertArrayNotHasKey('hasExamples', $array);
+        $this->assertArrayNotHasKey('customExample', $array);
+        $this->assertArrayNotHasKey('customExamples', $array);
+        $this->assertArrayNotHasKey('isCollection', $array);
+    }
+
+    #[Test]
+    public function it_creates_empty_instance(): void
+    {
+        $info = ResourceInfo::empty();
+
+        $this->assertEquals([], $info->properties);
+        $this->assertEquals([], $info->with);
+        $this->assertFalse($info->hasExamples);
+        $this->assertNull($info->customExample);
+        $this->assertNull($info->customExamples);
+        $this->assertFalse($info->isCollection);
+    }
+
+    #[Test]
+    public function it_checks_if_empty(): void
+    {
+        $empty = ResourceInfo::empty();
+        $notEmpty = new ResourceInfo(properties: ['id' => []]);
+
+        $this->assertTrue($empty->isEmpty());
+        $this->assertFalse($notEmpty->isEmpty());
+    }
+
+    #[Test]
+    public function it_checks_if_has_custom_example(): void
+    {
+        $withExample = new ResourceInfo(properties: [], customExample: ['id' => 1]);
+        $withoutExample = new ResourceInfo(properties: []);
+
+        $this->assertTrue($withExample->hasCustomExample());
+        $this->assertFalse($withoutExample->hasCustomExample());
+    }
+
+    #[Test]
+    public function it_checks_if_has_custom_examples(): void
+    {
+        $withExamples = new ResourceInfo(properties: [], customExamples: [['id' => 1]]);
+        $withoutExamples = new ResourceInfo(properties: []);
+
+        $this->assertTrue($withExamples->hasCustomExamples());
+        $this->assertFalse($withoutExamples->hasCustomExamples());
+    }
+
+    #[Test]
+    public function it_checks_if_has_with_data(): void
+    {
+        $withData = new ResourceInfo(properties: [], with: ['meta' => []]);
+        $withoutData = new ResourceInfo(properties: []);
+
+        $this->assertTrue($withData->hasWithData());
+        $this->assertFalse($withoutData->hasWithData());
+    }
+
+    #[Test]
+    public function it_gets_property_by_name(): void
+    {
+        $info = new ResourceInfo(
+            properties: [
+                'id' => ['type' => 'integer'],
+                'name' => ['type' => 'string'],
+            ],
+        );
+
+        $id = $info->getPropertyByName('id');
+        $name = $info->getPropertyByName('name');
+        $missing = $info->getPropertyByName('nonexistent');
+
+        $this->assertEquals(['type' => 'integer'], $id);
+        $this->assertEquals(['type' => 'string'], $name);
+        $this->assertNull($missing);
+    }
+
+    #[Test]
+    public function it_gets_property_names(): void
+    {
+        $info = new ResourceInfo(
+            properties: ['id' => [], 'name' => [], 'email' => []],
+        );
+
+        $names = $info->getPropertyNames();
+
+        $this->assertEquals(['id', 'name', 'email'], $names);
+    }
+
+    #[Test]
+    public function it_counts_properties(): void
+    {
+        $empty = ResourceInfo::empty();
+        $withProps = new ResourceInfo(properties: ['a' => [], 'b' => [], 'c' => []]);
+
+        $this->assertEquals(0, $empty->count());
+        $this->assertEquals(3, $withProps->count());
+    }
+
+    #[Test]
+    public function it_survives_serialization_round_trip(): void
+    {
+        $original = new ResourceInfo(
+            properties: ['id' => ['type' => 'integer'], 'name' => ['type' => 'string']],
+            with: ['meta' => ['type' => 'object']],
+            hasExamples: true,
+            customExample: ['id' => 1, 'name' => 'Test'],
+            customExamples: [['id' => 1], ['id' => 2]],
+            isCollection: true,
+        );
+
+        $restored = ResourceInfo::fromArray($original->toArray());
+
+        $this->assertEquals($original->properties, $restored->properties);
+        $this->assertEquals($original->with, $restored->with);
+        $this->assertEquals($original->hasExamples, $restored->hasExamples);
+        $this->assertEquals($original->customExample, $restored->customExample);
+        $this->assertEquals($original->customExamples, $restored->customExamples);
+        $this->assertEquals($original->isCollection, $restored->isCollection);
+    }
+
+    #[Test]
+    public function it_merges_with_data_into_properties(): void
+    {
+        $info = new ResourceInfo(
+            properties: ['id' => ['type' => 'integer']],
+            with: ['meta' => ['type' => 'object']],
+        );
+
+        $merged = $info->getAllProperties();
+
+        $this->assertArrayHasKey('id', $merged);
+        $this->assertArrayHasKey('meta', $merged);
+        $this->assertEquals(['type' => 'integer'], $merged['id']);
+        $this->assertEquals(['type' => 'object'], $merged['meta']);
+    }
+}

--- a/tests/Unit/DTO/ResponseInfoTest.php
+++ b/tests/Unit/DTO/ResponseInfoTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\DTO;
+
+use LaravelSpectrum\DTO\ResponseInfo;
+use LaravelSpectrum\DTO\ResponseType;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ResponseInfoTest extends TestCase
+{
+    #[Test]
+    public function it_can_be_constructed(): void
+    {
+        $info = new ResponseInfo(
+            type: ResponseType::OBJECT,
+            properties: ['id' => ['type' => 'integer'], 'name' => ['type' => 'string']],
+            resourceClass: null,
+            error: null,
+        );
+
+        $this->assertEquals(ResponseType::OBJECT, $info->type);
+        $this->assertCount(2, $info->properties);
+        $this->assertNull($info->resourceClass);
+        $this->assertNull($info->error);
+    }
+
+    #[Test]
+    public function it_can_be_constructed_with_resource_class(): void
+    {
+        $info = new ResponseInfo(
+            type: ResponseType::RESOURCE,
+            properties: [],
+            resourceClass: 'App\\Http\\Resources\\UserResource',
+        );
+
+        $this->assertEquals(ResponseType::RESOURCE, $info->type);
+        $this->assertEquals('App\\Http\\Resources\\UserResource', $info->resourceClass);
+    }
+
+    #[Test]
+    public function it_can_be_constructed_with_error(): void
+    {
+        $info = new ResponseInfo(
+            type: ResponseType::UNKNOWN,
+            properties: [],
+            error: 'Failed to analyze response',
+        );
+
+        $this->assertEquals(ResponseType::UNKNOWN, $info->type);
+        $this->assertEquals('Failed to analyze response', $info->error);
+    }
+
+    #[Test]
+    public function it_creates_from_array(): void
+    {
+        $array = [
+            'type' => 'object',
+            'properties' => ['id' => ['type' => 'integer']],
+        ];
+
+        $info = ResponseInfo::fromArray($array);
+
+        $this->assertEquals(ResponseType::OBJECT, $info->type);
+        $this->assertCount(1, $info->properties);
+        $this->assertNull($info->resourceClass);
+        $this->assertNull($info->error);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_resource_class(): void
+    {
+        $array = [
+            'type' => 'resource',
+            'class' => 'App\\Http\\Resources\\PostResource',
+        ];
+
+        $info = ResponseInfo::fromArray($array);
+
+        $this->assertEquals(ResponseType::RESOURCE, $info->type);
+        $this->assertEquals('App\\Http\\Resources\\PostResource', $info->resourceClass);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_error(): void
+    {
+        $array = [
+            'type' => 'unknown',
+            'error' => 'Some error occurred',
+        ];
+
+        $info = ResponseInfo::fromArray($array);
+
+        $this->assertEquals(ResponseType::UNKNOWN, $info->type);
+        $this->assertEquals('Some error occurred', $info->error);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_defaults(): void
+    {
+        $array = ['type' => 'void'];
+
+        $info = ResponseInfo::fromArray($array);
+
+        $this->assertEquals(ResponseType::VOID, $info->type);
+        $this->assertEquals([], $info->properties);
+        $this->assertNull($info->resourceClass);
+        $this->assertNull($info->error);
+    }
+
+    #[Test]
+    public function it_converts_to_array(): void
+    {
+        $info = new ResponseInfo(
+            type: ResponseType::OBJECT,
+            properties: ['id' => ['type' => 'integer']],
+            resourceClass: null,
+            error: null,
+        );
+
+        $array = $info->toArray();
+
+        $this->assertEquals('object', $array['type']);
+        $this->assertEquals(['id' => ['type' => 'integer']], $array['properties']);
+        $this->assertArrayNotHasKey('class', $array);
+        $this->assertArrayNotHasKey('error', $array);
+    }
+
+    #[Test]
+    public function it_converts_to_array_with_resource_class(): void
+    {
+        $info = new ResponseInfo(
+            type: ResponseType::RESOURCE,
+            properties: [],
+            resourceClass: 'UserResource',
+        );
+
+        $array = $info->toArray();
+
+        $this->assertEquals('resource', $array['type']);
+        $this->assertEquals('UserResource', $array['class']);
+    }
+
+    #[Test]
+    public function it_converts_to_array_with_error(): void
+    {
+        $info = new ResponseInfo(
+            type: ResponseType::UNKNOWN,
+            properties: [],
+            error: 'Analysis failed',
+        );
+
+        $array = $info->toArray();
+
+        $this->assertEquals('unknown', $array['type']);
+        $this->assertEquals('Analysis failed', $array['error']);
+    }
+
+    #[Test]
+    public function it_creates_void_instance(): void
+    {
+        $info = ResponseInfo::void();
+
+        $this->assertEquals(ResponseType::VOID, $info->type);
+        $this->assertEquals([], $info->properties);
+        $this->assertNull($info->resourceClass);
+        $this->assertNull($info->error);
+    }
+
+    #[Test]
+    public function it_creates_unknown_instance(): void
+    {
+        $info = ResponseInfo::unknown();
+
+        $this->assertEquals(ResponseType::UNKNOWN, $info->type);
+        $this->assertEquals([], $info->properties);
+    }
+
+    #[Test]
+    public function it_creates_unknown_with_error(): void
+    {
+        $info = ResponseInfo::unknownWithError('Something went wrong');
+
+        $this->assertEquals(ResponseType::UNKNOWN, $info->type);
+        $this->assertEquals('Something went wrong', $info->error);
+    }
+
+    #[Test]
+    public function it_checks_if_void(): void
+    {
+        $void = ResponseInfo::void();
+        $object = new ResponseInfo(type: ResponseType::OBJECT, properties: []);
+
+        $this->assertTrue($void->isVoid());
+        $this->assertFalse($object->isVoid());
+    }
+
+    #[Test]
+    public function it_checks_if_collection(): void
+    {
+        $collection = new ResponseInfo(type: ResponseType::COLLECTION, properties: []);
+        $object = new ResponseInfo(type: ResponseType::OBJECT, properties: []);
+
+        $this->assertTrue($collection->isCollection());
+        $this->assertFalse($object->isCollection());
+    }
+
+    #[Test]
+    public function it_checks_if_resource(): void
+    {
+        $resource = new ResponseInfo(type: ResponseType::RESOURCE, properties: [], resourceClass: 'UserResource');
+        $object = new ResponseInfo(type: ResponseType::OBJECT, properties: []);
+
+        $this->assertTrue($resource->isResource());
+        $this->assertFalse($object->isResource());
+    }
+
+    #[Test]
+    public function it_checks_if_has_error(): void
+    {
+        $withError = ResponseInfo::unknownWithError('Error');
+        $withoutError = ResponseInfo::unknown();
+
+        $this->assertTrue($withError->hasError());
+        $this->assertFalse($withoutError->hasError());
+    }
+
+    #[Test]
+    public function it_checks_if_has_properties(): void
+    {
+        $withProps = new ResponseInfo(type: ResponseType::OBJECT, properties: ['id' => []]);
+        $withoutProps = ResponseInfo::void();
+
+        $this->assertTrue($withProps->hasProperties());
+        $this->assertFalse($withoutProps->hasProperties());
+    }
+
+    #[Test]
+    public function it_checks_if_has_resource_class(): void
+    {
+        $withClass = new ResponseInfo(type: ResponseType::RESOURCE, properties: [], resourceClass: 'UserResource');
+        $withoutClass = new ResponseInfo(type: ResponseType::RESOURCE, properties: []);
+
+        $this->assertTrue($withClass->hasResourceClass());
+        $this->assertFalse($withoutClass->hasResourceClass());
+    }
+
+    #[Test]
+    public function it_gets_property_names(): void
+    {
+        $info = new ResponseInfo(
+            type: ResponseType::OBJECT,
+            properties: ['id' => [], 'name' => [], 'email' => []],
+        );
+
+        $names = $info->getPropertyNames();
+
+        $this->assertEquals(['id', 'name', 'email'], $names);
+    }
+
+    #[Test]
+    public function it_survives_serialization_round_trip(): void
+    {
+        $original = new ResponseInfo(
+            type: ResponseType::OBJECT,
+            properties: ['id' => ['type' => 'integer'], 'name' => ['type' => 'string']],
+            resourceClass: null,
+            error: null,
+        );
+
+        $restored = ResponseInfo::fromArray($original->toArray());
+
+        $this->assertEquals($original->type, $restored->type);
+        $this->assertEquals($original->properties, $restored->properties);
+        $this->assertEquals($original->resourceClass, $restored->resourceClass);
+        $this->assertEquals($original->error, $restored->error);
+    }
+
+    #[Test]
+    public function it_survives_serialization_round_trip_with_resource(): void
+    {
+        $original = new ResponseInfo(
+            type: ResponseType::RESOURCE,
+            properties: [],
+            resourceClass: 'App\\Http\\Resources\\UserResource',
+        );
+
+        $restored = ResponseInfo::fromArray($original->toArray());
+
+        $this->assertEquals($original->type, $restored->type);
+        $this->assertEquals($original->resourceClass, $restored->resourceClass);
+    }
+}

--- a/tests/Unit/DTO/ResponseTypeTest.php
+++ b/tests/Unit/DTO/ResponseTypeTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\DTO;
+
+use LaravelSpectrum\DTO\ResponseType;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ResponseTypeTest extends TestCase
+{
+    #[Test]
+    public function it_has_all_expected_cases(): void
+    {
+        $cases = ResponseType::cases();
+
+        $this->assertCount(5, $cases);
+        $this->assertContains(ResponseType::VOID, $cases);
+        $this->assertContains(ResponseType::RESOURCE, $cases);
+        $this->assertContains(ResponseType::OBJECT, $cases);
+        $this->assertContains(ResponseType::COLLECTION, $cases);
+        $this->assertContains(ResponseType::UNKNOWN, $cases);
+    }
+
+    #[Test]
+    public function it_has_correct_string_values(): void
+    {
+        $this->assertEquals('void', ResponseType::VOID->value);
+        $this->assertEquals('resource', ResponseType::RESOURCE->value);
+        $this->assertEquals('object', ResponseType::OBJECT->value);
+        $this->assertEquals('collection', ResponseType::COLLECTION->value);
+        $this->assertEquals('unknown', ResponseType::UNKNOWN->value);
+    }
+
+    #[Test]
+    public function it_creates_from_string(): void
+    {
+        $this->assertEquals(ResponseType::VOID, ResponseType::from('void'));
+        $this->assertEquals(ResponseType::RESOURCE, ResponseType::from('resource'));
+        $this->assertEquals(ResponseType::OBJECT, ResponseType::from('object'));
+        $this->assertEquals(ResponseType::COLLECTION, ResponseType::from('collection'));
+        $this->assertEquals(ResponseType::UNKNOWN, ResponseType::from('unknown'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_invalid_string_with_try_from(): void
+    {
+        $this->assertNull(ResponseType::tryFrom('invalid'));
+        $this->assertNull(ResponseType::tryFrom(''));
+    }
+
+    #[Test]
+    public function it_checks_if_void(): void
+    {
+        $this->assertTrue(ResponseType::VOID->isVoid());
+        $this->assertFalse(ResponseType::RESOURCE->isVoid());
+        $this->assertFalse(ResponseType::OBJECT->isVoid());
+        $this->assertFalse(ResponseType::COLLECTION->isVoid());
+        $this->assertFalse(ResponseType::UNKNOWN->isVoid());
+    }
+
+    #[Test]
+    public function it_checks_if_collection(): void
+    {
+        $this->assertTrue(ResponseType::COLLECTION->isCollection());
+        $this->assertFalse(ResponseType::VOID->isCollection());
+        $this->assertFalse(ResponseType::RESOURCE->isCollection());
+        $this->assertFalse(ResponseType::OBJECT->isCollection());
+        $this->assertFalse(ResponseType::UNKNOWN->isCollection());
+    }
+
+    #[Test]
+    public function it_checks_if_resource(): void
+    {
+        $this->assertTrue(ResponseType::RESOURCE->isResource());
+        $this->assertFalse(ResponseType::VOID->isResource());
+        $this->assertFalse(ResponseType::OBJECT->isResource());
+        $this->assertFalse(ResponseType::COLLECTION->isResource());
+        $this->assertFalse(ResponseType::UNKNOWN->isResource());
+    }
+
+    #[Test]
+    public function it_checks_if_has_structure(): void
+    {
+        $this->assertTrue(ResponseType::OBJECT->hasStructure());
+        $this->assertTrue(ResponseType::COLLECTION->hasStructure());
+        $this->assertTrue(ResponseType::RESOURCE->hasStructure());
+        $this->assertFalse(ResponseType::VOID->hasStructure());
+        $this->assertFalse(ResponseType::UNKNOWN->hasStructure());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ResponseType` enum with 5 response type cases (void, resource, object, collection, unknown)
- Add `ResponseInfo` DTO for controller method response analysis results
- Add `ResourceInfo` DTO for API Resource class analysis results

## DTOs Added

### ResponseType Enum
- 5 cases: `VOID`, `RESOURCE`, `OBJECT`, `COLLECTION`, `UNKNOWN`
- Helper methods: `isVoid()`, `isCollection()`, `isResource()`, `hasStructure()`

### ResponseInfo DTO
- Properties: `type`, `properties`, `resourceClass`, `error`
- Factory methods: `void()`, `unknown()`, `unknownWithError()`
- Serialization: `fromArray()`, `toArray()`

### ResourceInfo DTO
- Properties: `properties`, `with`, `hasExamples`, `customExample`, `customExamples`, `isCollection`
- Factory method: `empty()`
- Utility methods: `hasCustomExample()`, `hasCustomExamples()`, `hasWithData()`, `getPropertyByName()`, `getAllProperties()`

## Test Plan

- [x] All DTO unit tests pass (49 tests)
- [x] PHPStan analysis passes
- [x] Laravel Pint formatting passes
- [x] Full test suite passes (2435 tests)

Closes #227