### PR TITLE
feat: Introduce AuthenticationType and AuthenticationScheme DTOs (#231)

### DIFF
--- a/src/DTO/AuthenticationScheme.php
+++ b/src/DTO/AuthenticationScheme.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\DTO;
+
+/**
+ * Represents an authentication scheme for OpenAPI security definitions.
+ */
+final readonly class AuthenticationScheme
+{
+    /**
+     * @param  AuthenticationType  $type  The authentication type (http, apiKey, oauth2)
+     * @param  string  $name  The unique name for this scheme
+     * @param  string|null  $scheme  The HTTP scheme (bearer, basic) - for http type
+     * @param  string|null  $bearerFormat  The bearer format (e.g., JWT) - for bearer scheme
+     * @param  string|null  $in  Where the API key is located (header, query, cookie) - for apiKey type
+     * @param  string|null  $headerName  The actual header/query/cookie name - for apiKey type
+     * @param  array<string, array<string, mixed>>|null  $flows  OAuth2 flows - for oauth2 type
+     * @param  string|null  $description  Description of the authentication scheme
+     */
+    public function __construct(
+        public AuthenticationType $type,
+        public string $name,
+        public ?string $scheme = null,
+        public ?string $bearerFormat = null,
+        public ?string $in = null,
+        public ?string $headerName = null,
+        public ?array $flows = null,
+        public ?string $description = null,
+    ) {}
+
+    /**
+     * Create from an array.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $typeString = $data['type'] ?? 'http';
+        $type = AuthenticationType::tryFrom($typeString) ?? AuthenticationType::HTTP;
+
+        return new self(
+            type: $type,
+            name: $data['name'] ?? '',
+            scheme: $data['scheme'] ?? null,
+            bearerFormat: $data['bearerFormat'] ?? null,
+            in: $data['in'] ?? null,
+            headerName: $data['headerName'] ?? null,
+            flows: $data['flows'] ?? null,
+            description: $data['description'] ?? null,
+        );
+    }
+
+    /**
+     * Convert to array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $result = [
+            'type' => $this->type->value,
+            'name' => $this->name,
+        ];
+
+        if ($this->scheme !== null) {
+            $result['scheme'] = $this->scheme;
+        }
+
+        if ($this->bearerFormat !== null) {
+            $result['bearerFormat'] = $this->bearerFormat;
+        }
+
+        if ($this->in !== null) {
+            $result['in'] = $this->in;
+        }
+
+        if ($this->headerName !== null) {
+            $result['headerName'] = $this->headerName;
+        }
+
+        if ($this->flows !== null) {
+            $result['flows'] = $this->flows;
+        }
+
+        if ($this->description !== null) {
+            $result['description'] = $this->description;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Convert to OpenAPI security scheme format.
+     *
+     * @return array<string, mixed>
+     */
+    public function toOpenApiSecurityScheme(): array
+    {
+        $result = [
+            'type' => $this->type->value,
+        ];
+
+        // HTTP type (bearer, basic)
+        if ($this->type->isHttp()) {
+            if ($this->scheme !== null) {
+                $result['scheme'] = $this->scheme;
+            }
+
+            if ($this->bearerFormat !== null) {
+                $result['bearerFormat'] = $this->bearerFormat;
+            }
+        }
+
+        // API Key type
+        if ($this->type->isApiKey()) {
+            if ($this->in !== null) {
+                $result['in'] = $this->in;
+            }
+
+            // Use headerName as the OpenAPI 'name' field
+            if ($this->headerName !== null) {
+                $result['name'] = $this->headerName;
+            }
+        }
+
+        // OAuth2 type
+        if ($this->type->isOAuth2() && $this->flows !== null) {
+            $result['flows'] = $this->flows;
+        }
+
+        // Description is common to all types
+        if ($this->description !== null) {
+            $result['description'] = $this->description;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if this is a Bearer authentication scheme.
+     */
+    public function isBearer(): bool
+    {
+        return $this->type->isHttp() && $this->scheme === 'bearer';
+    }
+
+    /**
+     * Check if this is a Basic authentication scheme.
+     */
+    public function isBasic(): bool
+    {
+        return $this->type->isHttp() && $this->scheme === 'basic';
+    }
+
+    /**
+     * Check if this is an API Key authentication scheme.
+     */
+    public function isApiKey(): bool
+    {
+        return $this->type->isApiKey();
+    }
+
+    /**
+     * Check if this is an OAuth2 authentication scheme.
+     */
+    public function isOAuth2(): bool
+    {
+        return $this->type->isOAuth2();
+    }
+
+    /**
+     * Check if this is an HTTP authentication scheme.
+     */
+    public function isHttp(): bool
+    {
+        return $this->type->isHttp();
+    }
+}

--- a/src/DTO/AuthenticationType.php
+++ b/src/DTO/AuthenticationType.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\DTO;
+
+/**
+ * Represents the type of authentication scheme.
+ */
+enum AuthenticationType: string
+{
+    case HTTP = 'http';
+    case API_KEY = 'apiKey';
+    case OAUTH2 = 'oauth2';
+
+    /**
+     * Check if this is an HTTP authentication type.
+     */
+    public function isHttp(): bool
+    {
+        return $this === self::HTTP;
+    }
+
+    /**
+     * Check if this is an API Key authentication type.
+     */
+    public function isApiKey(): bool
+    {
+        return $this === self::API_KEY;
+    }
+
+    /**
+     * Check if this is an OAuth2 authentication type.
+     */
+    public function isOAuth2(): bool
+    {
+        return $this === self::OAUTH2;
+    }
+}

--- a/tests/Unit/DTO/AuthenticationSchemeTest.php
+++ b/tests/Unit/DTO/AuthenticationSchemeTest.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\DTO;
+
+use LaravelSpectrum\DTO\AuthenticationScheme;
+use LaravelSpectrum\DTO\AuthenticationType;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class AuthenticationSchemeTest extends TestCase
+{
+    #[Test]
+    public function it_can_be_constructed_for_bearer_auth(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'bearerAuth',
+            scheme: 'bearer',
+            bearerFormat: 'JWT',
+            description: 'Bearer token authentication',
+        );
+
+        $this->assertEquals(AuthenticationType::HTTP, $scheme->type);
+        $this->assertEquals('bearerAuth', $scheme->name);
+        $this->assertEquals('bearer', $scheme->scheme);
+        $this->assertEquals('JWT', $scheme->bearerFormat);
+        $this->assertEquals('Bearer token authentication', $scheme->description);
+    }
+
+    #[Test]
+    public function it_can_be_constructed_for_basic_auth(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'basicAuth',
+            scheme: 'basic',
+            description: 'Basic HTTP authentication',
+        );
+
+        $this->assertEquals('basic', $scheme->scheme);
+        $this->assertNull($scheme->bearerFormat);
+    }
+
+    #[Test]
+    public function it_can_be_constructed_for_api_key(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::API_KEY,
+            name: 'apiKeyAuth',
+            in: 'header',
+            headerName: 'X-API-Key',
+            description: 'API Key authentication',
+        );
+
+        $this->assertEquals(AuthenticationType::API_KEY, $scheme->type);
+        $this->assertEquals('header', $scheme->in);
+        $this->assertEquals('X-API-Key', $scheme->headerName);
+    }
+
+    #[Test]
+    public function it_can_be_constructed_for_oauth2(): void
+    {
+        $flows = [
+            'authorizationCode' => [
+                'authorizationUrl' => '/oauth/authorize',
+                'tokenUrl' => '/oauth/token',
+                'scopes' => [],
+            ],
+        ];
+
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::OAUTH2,
+            name: 'oauth2Auth',
+            flows: $flows,
+            description: 'OAuth2 authentication',
+        );
+
+        $this->assertEquals(AuthenticationType::OAUTH2, $scheme->type);
+        $this->assertEquals($flows, $scheme->flows);
+    }
+
+    #[Test]
+    public function it_creates_from_array_for_http_type(): void
+    {
+        $data = [
+            'type' => 'http',
+            'name' => 'sanctumAuth',
+            'scheme' => 'bearer',
+            'bearerFormat' => 'JWT',
+            'description' => 'Laravel Sanctum authentication',
+        ];
+
+        $scheme = AuthenticationScheme::fromArray($data);
+
+        $this->assertEquals(AuthenticationType::HTTP, $scheme->type);
+        $this->assertEquals('sanctumAuth', $scheme->name);
+        $this->assertEquals('bearer', $scheme->scheme);
+        $this->assertEquals('JWT', $scheme->bearerFormat);
+    }
+
+    #[Test]
+    public function it_creates_from_array_for_api_key_type(): void
+    {
+        $data = [
+            'type' => 'apiKey',
+            'name' => 'apiKeyAuth',
+            'in' => 'header',
+            'headerName' => 'X-API-Key',
+        ];
+
+        $scheme = AuthenticationScheme::fromArray($data);
+
+        $this->assertEquals(AuthenticationType::API_KEY, $scheme->type);
+        $this->assertEquals('header', $scheme->in);
+        $this->assertEquals('X-API-Key', $scheme->headerName);
+    }
+
+    #[Test]
+    public function it_creates_from_array_for_oauth2_type(): void
+    {
+        $flows = [
+            'password' => [
+                'tokenUrl' => '/oauth/token',
+                'scopes' => [],
+            ],
+        ];
+
+        $data = [
+            'type' => 'oauth2',
+            'name' => 'passportAuth',
+            'flows' => $flows,
+        ];
+
+        $scheme = AuthenticationScheme::fromArray($data);
+
+        $this->assertEquals(AuthenticationType::OAUTH2, $scheme->type);
+        $this->assertEquals($flows, $scheme->flows);
+    }
+
+    #[Test]
+    public function it_converts_to_array(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'bearerAuth',
+            scheme: 'bearer',
+            bearerFormat: 'JWT',
+            description: 'Bearer authentication',
+        );
+
+        $array = $scheme->toArray();
+
+        $this->assertEquals([
+            'type' => 'http',
+            'name' => 'bearerAuth',
+            'scheme' => 'bearer',
+            'bearerFormat' => 'JWT',
+            'description' => 'Bearer authentication',
+        ], $array);
+    }
+
+    #[Test]
+    public function it_converts_to_array_without_null_values(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'basicAuth',
+            scheme: 'basic',
+        );
+
+        $array = $scheme->toArray();
+
+        $this->assertArrayNotHasKey('bearerFormat', $array);
+        $this->assertArrayNotHasKey('in', $array);
+        $this->assertArrayNotHasKey('headerName', $array);
+        $this->assertArrayNotHasKey('flows', $array);
+        $this->assertArrayNotHasKey('description', $array);
+    }
+
+    #[Test]
+    public function it_converts_to_openapi_security_scheme_for_bearer(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'bearerAuth',
+            scheme: 'bearer',
+            bearerFormat: 'JWT',
+            description: 'JWT authentication',
+        );
+
+        $openApi = $scheme->toOpenApiSecurityScheme();
+
+        $this->assertEquals([
+            'type' => 'http',
+            'scheme' => 'bearer',
+            'bearerFormat' => 'JWT',
+            'description' => 'JWT authentication',
+        ], $openApi);
+    }
+
+    #[Test]
+    public function it_converts_to_openapi_security_scheme_for_basic(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'basicAuth',
+            scheme: 'basic',
+        );
+
+        $openApi = $scheme->toOpenApiSecurityScheme();
+
+        $this->assertEquals([
+            'type' => 'http',
+            'scheme' => 'basic',
+        ], $openApi);
+    }
+
+    #[Test]
+    public function it_converts_to_openapi_security_scheme_for_api_key(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::API_KEY,
+            name: 'apiKeyAuth',
+            in: 'header',
+            headerName: 'X-API-Key',
+        );
+
+        $openApi = $scheme->toOpenApiSecurityScheme();
+
+        $this->assertEquals([
+            'type' => 'apiKey',
+            'in' => 'header',
+            'name' => 'X-API-Key',
+        ], $openApi);
+    }
+
+    #[Test]
+    public function it_converts_to_openapi_security_scheme_for_oauth2(): void
+    {
+        $flows = [
+            'authorizationCode' => [
+                'authorizationUrl' => '/oauth/authorize',
+                'tokenUrl' => '/oauth/token',
+                'scopes' => [],
+            ],
+        ];
+
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::OAUTH2,
+            name: 'oauth2Auth',
+            flows: $flows,
+        );
+
+        $openApi = $scheme->toOpenApiSecurityScheme();
+
+        $this->assertEquals([
+            'type' => 'oauth2',
+            'flows' => $flows,
+        ], $openApi);
+    }
+
+    #[Test]
+    public function it_checks_if_is_bearer(): void
+    {
+        $bearer = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'bearerAuth',
+            scheme: 'bearer',
+        );
+        $basic = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'basicAuth',
+            scheme: 'basic',
+        );
+        $apiKey = new AuthenticationScheme(
+            type: AuthenticationType::API_KEY,
+            name: 'apiKeyAuth',
+            in: 'header',
+        );
+
+        $this->assertTrue($bearer->isBearer());
+        $this->assertFalse($basic->isBearer());
+        $this->assertFalse($apiKey->isBearer());
+    }
+
+    #[Test]
+    public function it_checks_if_is_basic(): void
+    {
+        $basic = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'basicAuth',
+            scheme: 'basic',
+        );
+        $bearer = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'bearerAuth',
+            scheme: 'bearer',
+        );
+
+        $this->assertTrue($basic->isBasic());
+        $this->assertFalse($bearer->isBasic());
+    }
+
+    #[Test]
+    public function it_checks_if_is_api_key(): void
+    {
+        $apiKey = new AuthenticationScheme(
+            type: AuthenticationType::API_KEY,
+            name: 'apiKeyAuth',
+            in: 'header',
+        );
+        $bearer = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'bearerAuth',
+            scheme: 'bearer',
+        );
+
+        $this->assertTrue($apiKey->isApiKey());
+        $this->assertFalse($bearer->isApiKey());
+    }
+
+    #[Test]
+    public function it_checks_if_is_oauth2(): void
+    {
+        $oauth2 = new AuthenticationScheme(
+            type: AuthenticationType::OAUTH2,
+            name: 'oauth2Auth',
+            flows: [],
+        );
+        $bearer = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'bearerAuth',
+            scheme: 'bearer',
+        );
+
+        $this->assertTrue($oauth2->isOAuth2());
+        $this->assertFalse($bearer->isOAuth2());
+    }
+
+    #[Test]
+    public function it_checks_if_is_http(): void
+    {
+        $http = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'bearerAuth',
+            scheme: 'bearer',
+        );
+        $apiKey = new AuthenticationScheme(
+            type: AuthenticationType::API_KEY,
+            name: 'apiKeyAuth',
+            in: 'header',
+        );
+
+        $this->assertTrue($http->isHttp());
+        $this->assertFalse($apiKey->isHttp());
+    }
+
+    #[Test]
+    public function it_survives_serialization_round_trip(): void
+    {
+        $original = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'sanctumAuth',
+            scheme: 'bearer',
+            bearerFormat: 'JWT',
+            description: 'Laravel Sanctum authentication',
+        );
+
+        $restored = AuthenticationScheme::fromArray($original->toArray());
+
+        $this->assertEquals($original->type, $restored->type);
+        $this->assertEquals($original->name, $restored->name);
+        $this->assertEquals($original->scheme, $restored->scheme);
+        $this->assertEquals($original->bearerFormat, $restored->bearerFormat);
+        $this->assertEquals($original->description, $restored->description);
+    }
+}

--- a/tests/Unit/DTO/AuthenticationTypeTest.php
+++ b/tests/Unit/DTO/AuthenticationTypeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\DTO;
+
+use LaravelSpectrum\DTO\AuthenticationType;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class AuthenticationTypeTest extends TestCase
+{
+    #[Test]
+    public function it_has_all_expected_cases(): void
+    {
+        $cases = AuthenticationType::cases();
+
+        $this->assertCount(3, $cases);
+        $this->assertContains(AuthenticationType::HTTP, $cases);
+        $this->assertContains(AuthenticationType::API_KEY, $cases);
+        $this->assertContains(AuthenticationType::OAUTH2, $cases);
+    }
+
+    #[Test]
+    public function it_has_correct_string_values(): void
+    {
+        $this->assertEquals('http', AuthenticationType::HTTP->value);
+        $this->assertEquals('apiKey', AuthenticationType::API_KEY->value);
+        $this->assertEquals('oauth2', AuthenticationType::OAUTH2->value);
+    }
+
+    #[Test]
+    public function it_creates_from_string(): void
+    {
+        $this->assertEquals(AuthenticationType::HTTP, AuthenticationType::from('http'));
+        $this->assertEquals(AuthenticationType::API_KEY, AuthenticationType::from('apiKey'));
+        $this->assertEquals(AuthenticationType::OAUTH2, AuthenticationType::from('oauth2'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_invalid_string_with_try_from(): void
+    {
+        $this->assertNull(AuthenticationType::tryFrom('invalid'));
+        $this->assertNull(AuthenticationType::tryFrom(''));
+        $this->assertNull(AuthenticationType::tryFrom('bearer')); // Not a type
+    }
+
+    #[Test]
+    public function it_checks_if_http(): void
+    {
+        $this->assertTrue(AuthenticationType::HTTP->isHttp());
+        $this->assertFalse(AuthenticationType::API_KEY->isHttp());
+        $this->assertFalse(AuthenticationType::OAUTH2->isHttp());
+    }
+
+    #[Test]
+    public function it_checks_if_api_key(): void
+    {
+        $this->assertTrue(AuthenticationType::API_KEY->isApiKey());
+        $this->assertFalse(AuthenticationType::HTTP->isApiKey());
+        $this->assertFalse(AuthenticationType::OAUTH2->isApiKey());
+    }
+
+    #[Test]
+    public function it_checks_if_oauth2(): void
+    {
+        $this->assertTrue(AuthenticationType::OAUTH2->isOAuth2());
+        $this->assertFalse(AuthenticationType::HTTP->isOAuth2());
+        $this->assertFalse(AuthenticationType::API_KEY->isOAuth2());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `AuthenticationType` enum for authentication type classification (http, apiKey, oauth2)
- Add `AuthenticationScheme` DTO for OpenAPI security scheme definitions
- Note: `FractalInfo` already exists with comprehensive tests

## Changes

### New Files
- `src/DTO/AuthenticationType.php` - Enum for security scheme types
- `src/DTO/AuthenticationScheme.php` - DTO for authentication scheme definitions
- `tests/Unit/DTO/AuthenticationTypeTest.php` - 7 tests
- `tests/Unit/DTO/AuthenticationSchemeTest.php` - 19 tests

### Features
- Type-safe representation of OpenAPI 3.0 security scheme types
- `toOpenApiSecurityScheme()` for generating OpenAPI-compliant output
- Helper methods for scheme type detection (isBearer, isBasic, isApiKey, isOAuth2)
- Supports all authentication types: HTTP (bearer/basic), API Key, OAuth2

## Test plan

- [x] All 26 new tests pass
- [x] PHPStan analysis passes
- [x] Laravel Pint formatting passes
- [x] Existing tests unaffected (2567 total tests)

Closes #231