### PR TITLE
feat: add OpenID Connect authentication type support

### DIFF
--- a/src/DTO/AuthenticationScheme.php
+++ b/src/DTO/AuthenticationScheme.php
@@ -10,13 +10,14 @@ namespace LaravelSpectrum\DTO;
 final readonly class AuthenticationScheme
 {
     /**
-     * @param  AuthenticationType  $type  The authentication type (http, apiKey, oauth2)
+     * @param  AuthenticationType  $type  The authentication type (http, apiKey, oauth2, openIdConnect)
      * @param  string  $name  The unique name for this scheme
      * @param  string|null  $scheme  The HTTP scheme (bearer, basic) - for http type
      * @param  string|null  $bearerFormat  The bearer format (e.g., JWT) - for bearer scheme
      * @param  string|null  $in  Where the API key is located (header, query, cookie) - for apiKey type
      * @param  string|null  $headerName  The actual header/query/cookie name - for apiKey type
      * @param  array<string, array<string, mixed>>|null  $flows  OAuth2 flows - for oauth2 type
+     * @param  string|null  $openIdConnectUrl  The OpenID Connect URL - for openIdConnect type
      * @param  string|null  $description  Description of the authentication scheme
      */
     public function __construct(
@@ -27,6 +28,7 @@ final readonly class AuthenticationScheme
         public ?string $in = null,
         public ?string $headerName = null,
         public ?array $flows = null,
+        public ?string $openIdConnectUrl = null,
         public ?string $description = null,
     ) {}
 
@@ -48,6 +50,7 @@ final readonly class AuthenticationScheme
             in: $data['in'] ?? null,
             headerName: $data['headerName'] ?? null,
             flows: $data['flows'] ?? null,
+            openIdConnectUrl: $data['openIdConnectUrl'] ?? null,
             description: $data['description'] ?? null,
         );
     }
@@ -82,6 +85,10 @@ final readonly class AuthenticationScheme
 
         if ($this->flows !== null) {
             $result['flows'] = $this->flows;
+        }
+
+        if ($this->openIdConnectUrl !== null) {
+            $result['openIdConnectUrl'] = $this->openIdConnectUrl;
         }
 
         if ($this->description !== null) {
@@ -130,6 +137,11 @@ final readonly class AuthenticationScheme
             $result['flows'] = $this->flows;
         }
 
+        // OpenID Connect type
+        if ($this->type->isOpenIdConnect() && $this->openIdConnectUrl !== null) {
+            $result['openIdConnectUrl'] = $this->openIdConnectUrl;
+        }
+
         // Description is common to all types
         if ($this->description !== null) {
             $result['description'] = $this->description;
@@ -176,5 +188,13 @@ final readonly class AuthenticationScheme
     public function isHttp(): bool
     {
         return $this->type->isHttp();
+    }
+
+    /**
+     * Check if this is an OpenID Connect authentication scheme.
+     */
+    public function isOpenIdConnect(): bool
+    {
+        return $this->type->isOpenIdConnect();
     }
 }

--- a/src/DTO/AuthenticationType.php
+++ b/src/DTO/AuthenticationType.php
@@ -12,6 +12,7 @@ enum AuthenticationType: string
     case HTTP = 'http';
     case API_KEY = 'apiKey';
     case OAUTH2 = 'oauth2';
+    case OPENID_CONNECT = 'openIdConnect';
 
     /**
      * Check if this is an HTTP authentication type.
@@ -35,5 +36,13 @@ enum AuthenticationType: string
     public function isOAuth2(): bool
     {
         return $this === self::OAUTH2;
+    }
+
+    /**
+     * Check if this is an OpenID Connect authentication type.
+     */
+    public function isOpenIdConnect(): bool
+    {
+        return $this === self::OPENID_CONNECT;
     }
 }

--- a/tests/Unit/DTO/AuthenticationTypeTest.php
+++ b/tests/Unit/DTO/AuthenticationTypeTest.php
@@ -15,10 +15,11 @@ class AuthenticationTypeTest extends TestCase
     {
         $cases = AuthenticationType::cases();
 
-        $this->assertCount(3, $cases);
+        $this->assertCount(4, $cases);
         $this->assertContains(AuthenticationType::HTTP, $cases);
         $this->assertContains(AuthenticationType::API_KEY, $cases);
         $this->assertContains(AuthenticationType::OAUTH2, $cases);
+        $this->assertContains(AuthenticationType::OPENID_CONNECT, $cases);
     }
 
     #[Test]
@@ -27,6 +28,7 @@ class AuthenticationTypeTest extends TestCase
         $this->assertEquals('http', AuthenticationType::HTTP->value);
         $this->assertEquals('apiKey', AuthenticationType::API_KEY->value);
         $this->assertEquals('oauth2', AuthenticationType::OAUTH2->value);
+        $this->assertEquals('openIdConnect', AuthenticationType::OPENID_CONNECT->value);
     }
 
     #[Test]
@@ -35,6 +37,7 @@ class AuthenticationTypeTest extends TestCase
         $this->assertEquals(AuthenticationType::HTTP, AuthenticationType::from('http'));
         $this->assertEquals(AuthenticationType::API_KEY, AuthenticationType::from('apiKey'));
         $this->assertEquals(AuthenticationType::OAUTH2, AuthenticationType::from('oauth2'));
+        $this->assertEquals(AuthenticationType::OPENID_CONNECT, AuthenticationType::from('openIdConnect'));
     }
 
     #[Test]
@@ -51,6 +54,7 @@ class AuthenticationTypeTest extends TestCase
         $this->assertTrue(AuthenticationType::HTTP->isHttp());
         $this->assertFalse(AuthenticationType::API_KEY->isHttp());
         $this->assertFalse(AuthenticationType::OAUTH2->isHttp());
+        $this->assertFalse(AuthenticationType::OPENID_CONNECT->isHttp());
     }
 
     #[Test]
@@ -59,6 +63,7 @@ class AuthenticationTypeTest extends TestCase
         $this->assertTrue(AuthenticationType::API_KEY->isApiKey());
         $this->assertFalse(AuthenticationType::HTTP->isApiKey());
         $this->assertFalse(AuthenticationType::OAUTH2->isApiKey());
+        $this->assertFalse(AuthenticationType::OPENID_CONNECT->isApiKey());
     }
 
     #[Test]
@@ -67,5 +72,15 @@ class AuthenticationTypeTest extends TestCase
         $this->assertTrue(AuthenticationType::OAUTH2->isOAuth2());
         $this->assertFalse(AuthenticationType::HTTP->isOAuth2());
         $this->assertFalse(AuthenticationType::API_KEY->isOAuth2());
+        $this->assertFalse(AuthenticationType::OPENID_CONNECT->isOAuth2());
+    }
+
+    #[Test]
+    public function it_checks_if_openid_connect(): void
+    {
+        $this->assertTrue(AuthenticationType::OPENID_CONNECT->isOpenIdConnect());
+        $this->assertFalse(AuthenticationType::HTTP->isOpenIdConnect());
+        $this->assertFalse(AuthenticationType::API_KEY->isOpenIdConnect());
+        $this->assertFalse(AuthenticationType::OAUTH2->isOpenIdConnect());
     }
 }


### PR DESCRIPTION
## Summary

- Add `OPENID_CONNECT` case to `AuthenticationType` enum to comply with OpenAPI 3.0 specification
- Add `openIdConnectUrl` property to `AuthenticationScheme` DTO
- Add `isOpenIdConnect()` helper methods to both classes
- Update `toOpenApiSecurityScheme()` for OpenID Connect type
- Add comprehensive tests for new functionality
- Add edge case tests for `fromArray()` defaults

## Context

This follows up on PR #239 based on review feedback. The OpenAPI 3.0 specification defines four valid security scheme types:
- `apiKey`
- `http`
- `oauth2`
- `openIdConnect`

The initial implementation only included the first three. This PR adds the missing `openIdConnect` type.

## Test plan

- [x] All 35 authentication DTO tests pass
- [x] PHPStan static analysis passes
- [x] Laravel Pint code style passes