### PR TITLE
refactor: apply OpenApiRequestBody DTO to RequestBodyGenerator

### DIFF
--- a/src/Generators/OpenApiGenerator.php
+++ b/src/Generators/OpenApiGenerator.php
@@ -203,8 +203,8 @@ class OpenApiGenerator
         // Generate request body for POST, PUT, PATCH
         if (in_array($method, ['post', 'put', 'patch'])) {
             $requestBody = $this->requestBodyGenerator->generate($controllerInfo, $route);
-            if ($requestBody) {
-                $operation['requestBody'] = $requestBody;
+            if ($requestBody !== null) {
+                $operation['requestBody'] = $requestBody->toArray();
             }
         }
 

--- a/tests/Unit/Generators/OpenApiGeneratorTest.php
+++ b/tests/Unit/Generators/OpenApiGeneratorTest.php
@@ -8,6 +8,7 @@ use LaravelSpectrum\Analyzers\ControllerAnalyzer;
 use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
 use LaravelSpectrum\Analyzers\ResourceAnalyzer;
 use LaravelSpectrum\Converters\OpenApi31Converter;
+use LaravelSpectrum\DTO\OpenApiRequestBody;
 use LaravelSpectrum\Generators\ErrorResponseGenerator;
 use LaravelSpectrum\Generators\ExampleGenerator;
 use LaravelSpectrum\Generators\OpenApiGenerator;
@@ -367,9 +368,8 @@ class OpenApiGeneratorTest extends TestCase
 
         $this->requestBodyGenerator->shouldReceive('generate')
             ->once()
-            ->andReturn([
-                'required' => true,
-                'content' => [
+            ->andReturn(new OpenApiRequestBody(
+                content: [
                     'application/json' => [
                         'schema' => [
                             'type' => 'object',
@@ -380,7 +380,8 @@ class OpenApiGeneratorTest extends TestCase
                         ],
                     ],
                 ],
-            ]);
+                required: true,
+            ));
 
         $this->requestAnalyzer->shouldReceive('analyzeWithDetails')
             ->once()

--- a/tests/Unit/Generators/RequestBodyGeneratorTest.php
+++ b/tests/Unit/Generators/RequestBodyGeneratorTest.php
@@ -4,6 +4,7 @@ namespace LaravelSpectrum\Tests\Unit\Generators;
 
 use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
 use LaravelSpectrum\Analyzers\InlineValidationAnalyzer;
+use LaravelSpectrum\DTO\OpenApiRequestBody;
 use LaravelSpectrum\Generators\RequestBodyGenerator;
 use LaravelSpectrum\Generators\SchemaGenerator;
 use LaravelSpectrum\Tests\TestCase;
@@ -83,10 +84,10 @@ class RequestBodyGeneratorTest extends TestCase
 
         $result = $this->generator->generate($controllerInfo, $route);
 
-        $this->assertNotNull($result);
-        $this->assertTrue($result['required']);
-        $this->assertArrayHasKey('application/json', $result['content']);
-        $this->assertEquals('object', $result['content']['application/json']['schema']['type']);
+        $this->assertInstanceOf(OpenApiRequestBody::class, $result);
+        $this->assertTrue($result->required);
+        $this->assertTrue($result->isJson());
+        $this->assertEquals('object', $result->getSchemaFor('application/json')['type']);
     }
 
     #[Test]
@@ -119,8 +120,8 @@ class RequestBodyGeneratorTest extends TestCase
 
         $result = $this->generator->generate($controllerInfo, $route);
 
-        $this->assertNotNull($result);
-        $this->assertArrayHasKey('application/json', $result['content']);
+        $this->assertInstanceOf(OpenApiRequestBody::class, $result);
+        $this->assertTrue($result->isJson());
     }
 
     #[Test]
@@ -155,8 +156,8 @@ class RequestBodyGeneratorTest extends TestCase
 
         $result = $this->generator->generate($controllerInfo, $route);
 
-        $this->assertNotNull($result);
-        $this->assertArrayHasKey('oneOf', $result['content']['application/json']['schema']);
+        $this->assertInstanceOf(OpenApiRequestBody::class, $result);
+        $this->assertArrayHasKey('oneOf', $result->getSchemaFor('application/json'));
     }
 
     #[Test]
@@ -194,10 +195,10 @@ class RequestBodyGeneratorTest extends TestCase
 
         $result = $this->generator->generate($controllerInfo, $route);
 
-        $this->assertNotNull($result);
-        $this->assertTrue($result['required']);
-        $this->assertArrayHasKey('multipart/form-data', $result['content']);
-        $this->assertStringContainsString('file uploads', $result['description']);
+        $this->assertInstanceOf(OpenApiRequestBody::class, $result);
+        $this->assertTrue($result->required);
+        $this->assertTrue($result->isMultipart());
+        $this->assertStringContainsString('file uploads', $result->description);
     }
 
     #[Test]
@@ -238,8 +239,8 @@ class RequestBodyGeneratorTest extends TestCase
 
         $result = $this->generator->generate($controllerInfo, $route);
 
-        $this->assertNotNull($result);
-        $this->assertStringContainsString('Multiple files allowed', $result['description']);
+        $this->assertInstanceOf(OpenApiRequestBody::class, $result);
+        $this->assertStringContainsString('Multiple files allowed', $result->description);
     }
 
     #[Test]
@@ -270,9 +271,9 @@ class RequestBodyGeneratorTest extends TestCase
 
         $result = $this->generator->generate($controllerInfo, $route);
 
-        $this->assertNotNull($result);
-        $this->assertArrayHasKey('application/xml', $result['content']);
-        $this->assertArrayNotHasKey('application/json', $result['content']);
+        $this->assertInstanceOf(OpenApiRequestBody::class, $result);
+        $this->assertContains('application/xml', $result->getContentTypes());
+        $this->assertNotContains('application/json', $result->getContentTypes());
     }
 
     #[Test]
@@ -310,7 +311,7 @@ class RequestBodyGeneratorTest extends TestCase
 
         $result = $this->generator->generate($controllerInfo, $route);
 
-        $this->assertNotNull($result);
+        $this->assertInstanceOf(OpenApiRequestBody::class, $result);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Update `RequestBodyGenerator` to return `OpenApiRequestBody` DTO instead of array
- Update `OpenApiGenerator` to call `toArray()` on the DTO
- Update tests to assert on DTO instances

## Benefits

- Improved type safety with explicit DTO return type
- Enables use of DTO helper methods (`isJson()`, `isMultipart()`, etc.)
- Better IDE support and code completion
- Cleaner API with well-defined structure

## Test plan

- [x] All 2576 tests pass
- [x] PHPStan static analysis passes
- [x] Laravel Pint code style passes