### PR TITLE
refactor: apply OpenApiResponse DTO to ErrorResponseGenerator

### DIFF
--- a/src/Generators/OpenApiGenerator.php
+++ b/src/Generators/OpenApiGenerator.php
@@ -257,15 +257,21 @@ class OpenApiGenerator
             ];
         }
 
-        // Generate error responses
-        $allErrorResponses = $this->errorResponseGenerator->generateErrorResponses($validationData);
+        // Generate error responses (returns DTOs)
+        $allErrorResponseDTOs = $this->errorResponseGenerator->generateErrorResponses($validationData);
 
-        // Get default error responses
-        $defaultErrorResponses = $this->errorResponseGenerator->getDefaultErrorResponses(
+        // Get default error responses (returns DTOs)
+        $defaultErrorResponseDTOs = $this->errorResponseGenerator->getDefaultErrorResponses(
             $method,
             $requiresAuth,
             ! empty($validationData)
         );
+
+        // Convert DTOs to arrays for modification
+        $defaultErrorResponses = [];
+        foreach ($defaultErrorResponseDTOs as $statusCode => $dto) {
+            $defaultErrorResponses[$statusCode] = $dto->toArray();
+        }
 
         if (empty($validationData)) {
             foreach ($defaultErrorResponses as $statusCode => &$errorResponse) {
@@ -279,8 +285,8 @@ class OpenApiGenerator
         }
 
         $responses = $defaultErrorResponses;
-        if (isset($allErrorResponses['422'])) {
-            $responses['422'] = $allErrorResponses['422'];
+        if (isset($allErrorResponseDTOs['422'])) {
+            $responses['422'] = $allErrorResponseDTOs['422']->toArray();
             $validationExample = $this->exampleGenerator->generateErrorExample(422, $validationData['rules'] ?? []);
             if (isset($responses['422']['content']['application/json'])) {
                 $responses['422']['content']['application/json']['example'] = $validationExample;

--- a/tests/Unit/Generators/OpenApiGeneratorTest.php
+++ b/tests/Unit/Generators/OpenApiGeneratorTest.php
@@ -9,6 +9,7 @@ use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
 use LaravelSpectrum\Analyzers\ResourceAnalyzer;
 use LaravelSpectrum\Converters\OpenApi31Converter;
 use LaravelSpectrum\DTO\OpenApiRequestBody;
+use LaravelSpectrum\DTO\OpenApiResponse;
 use LaravelSpectrum\Generators\ErrorResponseGenerator;
 use LaravelSpectrum\Generators\ExampleGenerator;
 use LaravelSpectrum\Generators\OpenApiGenerator;
@@ -394,14 +395,15 @@ class OpenApiGeneratorTest extends TestCase
         $this->errorResponseGenerator->shouldReceive('generateErrorResponses')
             ->once()
             ->andReturn([
-                '422' => [
-                    'description' => 'Validation Error',
-                    'content' => [
+                '422' => new OpenApiResponse(
+                    statusCode: 422,
+                    description: 'Validation Error',
+                    content: [
                         'application/json' => [
                             'schema' => ['type' => 'object'],
                         ],
                     ],
-                ],
+                ),
             ]);
 
         $this->errorResponseGenerator->shouldReceive('getDefaultErrorResponses')
@@ -516,14 +518,15 @@ class OpenApiGeneratorTest extends TestCase
         $this->errorResponseGenerator->shouldReceive('getDefaultErrorResponses')
             ->once()
             ->andReturn([
-                '401' => [
-                    'description' => 'Unauthorized',
-                    'content' => [
+                '401' => new OpenApiResponse(
+                    statusCode: 401,
+                    description: 'Unauthorized',
+                    content: [
                         'application/json' => [
                             'schema' => ['type' => 'object'],
                         ],
                     ],
-                ],
+                ),
             ]);
 
         $this->exampleGenerator->shouldReceive('generateErrorExample')
@@ -1193,7 +1196,15 @@ class OpenApiGeneratorTest extends TestCase
             ->once()
             ->with('get', true, false)
             ->andReturn([
-                '401' => ['description' => 'Unauthorized'],
+                '401' => new OpenApiResponse(
+                    statusCode: 401,
+                    description: 'Unauthorized',
+                    content: [
+                        'application/json' => [
+                            'schema' => ['type' => 'object'],
+                        ],
+                    ],
+                ),
             ]);
 
         $this->exampleGenerator->shouldReceive('generateErrorExample')
@@ -1281,7 +1292,15 @@ class OpenApiGeneratorTest extends TestCase
             ->once()
             ->with('get', true, false)
             ->andReturn([
-                '401' => ['description' => 'Unauthorized'],
+                '401' => new OpenApiResponse(
+                    statusCode: 401,
+                    description: 'Unauthorized',
+                    content: [
+                        'application/json' => [
+                            'schema' => ['type' => 'object'],
+                        ],
+                    ],
+                ),
             ]);
 
         $this->exampleGenerator->shouldReceive('generateErrorExample')


### PR DESCRIPTION
## Summary

- Update `ErrorResponseGenerator` methods to return `OpenApiResponse` DTOs instead of raw arrays
- Update `OpenApiGenerator.generateErrorResponses()` to convert DTOs to arrays for in-place modification
- Update test assertions to leverage DTO helper methods (`isClientError()`, `isServerError()`, `hasContent()`, etc.)

## Changes

### ErrorResponseGenerator
- All `generate*Response()` methods now return `OpenApiResponse` instances
- Type annotations updated to `array<int|string, OpenApiResponse>` to handle PHP's numeric string key behavior

### OpenApiGenerator
- `generateErrorResponses()` now converts DTO instances to arrays before modification
- Uses `$dto->toArray()` for each response

### Tests
- Updated assertions to use DTO instance checks and helper methods
- Mock return values updated to return `OpenApiResponse` DTOs

## Test plan
- [x] All 2576 existing tests pass
- [x] PHPStan analysis passes
- [x] Laravel Pint formatting passes