### PR TITLE
Refactoring: ParameterDefinition DTOの適用

### DIFF
--- a/src/DTO/ParameterDefinition.php
+++ b/src/DTO/ParameterDefinition.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\DTO;
+
+/**
+ * Represents a parameter definition for API documentation.
+ *
+ * This DTO encapsulates all information about a single parameter including
+ * its type, validation rules, and optional metadata like enums and file info.
+ */
+final readonly class ParameterDefinition
+{
+    /**
+     * @param  string  $name  The parameter name
+     * @param  string  $in  Where the parameter appears (e.g., 'body', 'query', 'path')
+     * @param  bool  $required  Whether the parameter is required
+     * @param  string  $type  The OpenAPI type (string, integer, number, boolean, array, file)
+     * @param  string  $description  Human-readable description
+     * @param  mixed  $example  Example value for documentation
+     * @param  array<string>  $validation  Validation rules from Laravel
+     * @param  string|null  $format  OpenAPI format (email, date, date-time, uuid, binary, etc.)
+     * @param  bool|null  $conditionalRequired  Whether conditionally required (only set when true)
+     * @param  array<array<string, mixed>>|null  $conditionalRules  Conditional rule details
+     * @param  EnumInfo|null  $enum  Enum information if this is an enum field
+     * @param  FileUploadInfo|null  $fileInfo  File upload metadata if this is a file field
+     */
+    public function __construct(
+        public string $name,
+        public string $in,
+        public bool $required,
+        public string $type,
+        public string $description,
+        public mixed $example,
+        public array $validation,
+        public ?string $format = null,
+        public ?bool $conditionalRequired = null,
+        public ?array $conditionalRules = null,
+        public ?EnumInfo $enum = null,
+        public ?FileUploadInfo $fileInfo = null,
+    ) {}
+
+    /**
+     * Check if this is a file upload parameter.
+     */
+    public function isFileUpload(): bool
+    {
+        return $this->type === 'file';
+    }
+
+    /**
+     * Check if this parameter has conditional rules.
+     */
+    public function hasConditionalRules(): bool
+    {
+        return $this->conditionalRules !== null && count($this->conditionalRules) > 0;
+    }
+
+    /**
+     * Check if this parameter has enum information.
+     */
+    public function hasEnum(): bool
+    {
+        return $this->enum !== null;
+    }
+
+    /**
+     * Create from an array.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $enum = null;
+        if (isset($data['enum']) && $data['enum'] instanceof EnumInfo) {
+            $enum = $data['enum'];
+        }
+
+        $fileInfo = null;
+        if (isset($data['file_info']) && $data['file_info'] instanceof FileUploadInfo) {
+            $fileInfo = $data['file_info'];
+        }
+
+        return new self(
+            name: $data['name'],
+            in: $data['in'] ?? 'body',
+            required: $data['required'] ?? false,
+            type: $data['type'] ?? 'string',
+            description: $data['description'] ?? '',
+            example: $data['example'] ?? null,
+            validation: $data['validation'] ?? [],
+            format: $data['format'] ?? null,
+            conditionalRequired: $data['conditional_required'] ?? null,
+            conditionalRules: $data['conditional_rules'] ?? null,
+            enum: $enum,
+            fileInfo: $fileInfo,
+        );
+    }
+
+    /**
+     * Convert to array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $result = [
+            'name' => $this->name,
+            'in' => $this->in,
+            'required' => $this->required,
+            'type' => $this->type,
+            'description' => $this->description,
+            'example' => $this->example,
+            'validation' => $this->validation,
+        ];
+
+        if ($this->format !== null) {
+            $result['format'] = $this->format;
+        }
+
+        if ($this->conditionalRequired !== null) {
+            $result['conditional_required'] = $this->conditionalRequired;
+        }
+
+        if ($this->conditionalRules !== null) {
+            $result['conditional_rules'] = $this->conditionalRules;
+        }
+
+        if ($this->enum !== null) {
+            $result['enum'] = $this->enum;
+        }
+
+        if ($this->fileInfo !== null) {
+            $result['file_info'] = $this->fileInfo->toArray();
+        }
+
+        return $result;
+    }
+}

--- a/tests/Unit/Analyzers/Support/AnonymousClassAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Support/AnonymousClassAnalyzerTest.php
@@ -187,13 +187,13 @@ class AnonymousClassAnalyzerTest extends TestCase
 
         $this->parameterBuilder->shouldReceive('buildFromRules')
             ->with([], [], '')
-            ->andReturn(['param1']);
+            ->andReturn([['name' => 'param1', 'type' => 'string', 'required' => false]]);
 
         $result = $this->analyzer->analyzeWithConditionalRules($reflection);
 
         $this->assertArrayHasKey('parameters', $result);
         $this->assertArrayHasKey('conditional_rules', $result);
-        $this->assertEquals(['param1'], $result['parameters']);
+        $this->assertEquals([['name' => 'param1', 'type' => 'string', 'required' => false]], $result['parameters']);
     }
 
     // ========== createMockInstance() tests (via analyze) ==========

--- a/tests/Unit/Analyzers/Support/ParameterBuilderTest.php
+++ b/tests/Unit/Analyzers/Support/ParameterBuilderTest.php
@@ -10,6 +10,7 @@ use LaravelSpectrum\Analyzers\Support\RuleRequirementAnalyzer;
 use LaravelSpectrum\Analyzers\Support\ValidationDescriptionGenerator;
 use LaravelSpectrum\DTO\EnumBackingType;
 use LaravelSpectrum\DTO\EnumInfo;
+use LaravelSpectrum\DTO\ParameterDefinition;
 use LaravelSpectrum\Support\TypeInference;
 use LaravelSpectrum\Tests\TestCase;
 use Mockery;
@@ -68,15 +69,17 @@ class ParameterBuilderTest extends TestCase
 
         $nameParam = $this->findParameter($parameters, 'name');
         $this->assertNotNull($nameParam);
-        $this->assertTrue($nameParam['required']);
-        $this->assertEquals('string', $nameParam['type']);
-        $this->assertEquals('body', $nameParam['in']);
+        $this->assertInstanceOf(ParameterDefinition::class, $nameParam);
+        $this->assertTrue($nameParam->required);
+        $this->assertEquals('string', $nameParam->type);
+        $this->assertEquals('body', $nameParam->in);
 
         $emailParam = $this->findParameter($parameters, 'email');
         $this->assertNotNull($emailParam);
-        $this->assertTrue($emailParam['required']);
-        $this->assertEquals('string', $emailParam['type']);
-        $this->assertEquals('email', $emailParam['format']);
+        $this->assertInstanceOf(ParameterDefinition::class, $emailParam);
+        $this->assertTrue($emailParam->required);
+        $this->assertEquals('string', $emailParam->type);
+        $this->assertEquals('email', $emailParam->format);
     }
 
     #[Test]
@@ -90,8 +93,8 @@ class ParameterBuilderTest extends TestCase
 
         $ageParam = $this->findParameter($parameters, 'age');
         $this->assertNotNull($ageParam);
-        $this->assertTrue($ageParam['required']);
-        $this->assertEquals('integer', $ageParam['type']);
+        $this->assertTrue($ageParam->required);
+        $this->assertEquals('integer', $ageParam->type);
     }
 
     #[Test]
@@ -106,7 +109,7 @@ class ParameterBuilderTest extends TestCase
         $parameters = $this->builder->buildFromRules($rules);
 
         $this->assertCount(1, $parameters);
-        $this->assertEquals('name', $parameters[0]['name']);
+        $this->assertEquals('name', $parameters[0]->name);
     }
 
     #[Test]
@@ -122,7 +125,7 @@ class ParameterBuilderTest extends TestCase
         $parameters = $this->builder->buildFromRules($rules, $attributes);
 
         $emailParam = $this->findParameter($parameters, 'email');
-        $this->assertEquals('メールアドレス', $emailParam['description']);
+        $this->assertEquals('メールアドレス', $emailParam->description);
     }
 
     #[Test]
@@ -135,8 +138,8 @@ class ParameterBuilderTest extends TestCase
         $parameters = $this->builder->buildFromRules($rules);
 
         $param = $this->findParameter($parameters, 'user_name');
-        $this->assertStringContainsString('User Name', $param['description']);
-        $this->assertStringContainsString('(最大100文字)', $param['description']);
+        $this->assertStringContainsString('User Name', $param->description);
+        $this->assertStringContainsString('(最大100文字)', $param->description);
     }
 
     #[Test]
@@ -150,10 +153,10 @@ class ParameterBuilderTest extends TestCase
         $parameters = $this->builder->buildFromRules($rules);
 
         $birthDate = $this->findParameter($parameters, 'birth_date');
-        $this->assertEquals('date', $birthDate['format']);
+        $this->assertEquals('date', $birthDate->format);
 
         $createdAt = $this->findParameter($parameters, 'created_at');
-        $this->assertEquals('date-time', $createdAt['format']);
+        $this->assertEquals('date-time', $createdAt->format);
     }
 
     #[Test]
@@ -167,10 +170,10 @@ class ParameterBuilderTest extends TestCase
         $parameters = $this->builder->buildFromRules($rules);
 
         $nickname = $this->findParameter($parameters, 'nickname');
-        $this->assertFalse($nickname['required']);
+        $this->assertFalse($nickname->required);
 
         $bio = $this->findParameter($parameters, 'bio');
-        $this->assertFalse($bio['required']);
+        $this->assertFalse($bio->required);
     }
 
     #[Test]
@@ -183,8 +186,8 @@ class ParameterBuilderTest extends TestCase
         $parameters = $this->builder->buildFromRules($rules);
 
         $phone = $this->findParameter($parameters, 'phone');
-        $this->assertTrue($phone['conditional_required']);
-        $this->assertArrayHasKey('conditional_rules', $phone);
+        $this->assertTrue($phone->conditionalRequired);
+        $this->assertTrue($phone->hasConditionalRules());
     }
 
     #[Test]
@@ -198,11 +201,11 @@ class ParameterBuilderTest extends TestCase
         $parameters = $this->builder->buildFromRules($rules);
 
         $email = $this->findParameter($parameters, 'email');
-        $this->assertArrayHasKey('example', $email);
+        $this->assertNotNull($email->example);
 
         $age = $this->findParameter($parameters, 'age');
-        $this->assertArrayHasKey('example', $age);
-        $this->assertIsInt($age['example']);
+        $this->assertNotNull($age->example);
+        $this->assertIsInt($age->example);
     }
 
     // ========== File upload tests ==========
@@ -218,9 +221,10 @@ class ParameterBuilderTest extends TestCase
 
         $avatar = $this->findParameter($parameters, 'avatar');
         $this->assertNotNull($avatar);
-        $this->assertEquals('file', $avatar['type']);
-        $this->assertEquals('binary', $avatar['format']);
-        $this->assertArrayHasKey('file_info', $avatar);
+        $this->assertEquals('file', $avatar->type);
+        $this->assertEquals('binary', $avatar->format);
+        $this->assertNotNull($avatar->fileInfo);
+        $this->assertTrue($avatar->isFileUpload());
     }
 
     #[Test]
@@ -233,8 +237,8 @@ class ParameterBuilderTest extends TestCase
         $parameters = $this->builder->buildFromRules($rules);
 
         $photo = $this->findParameter($parameters, 'photo');
-        $this->assertEquals('file', $photo['type']);
-        $this->assertArrayHasKey('file_info', $photo);
+        $this->assertEquals('file', $photo->type);
+        $this->assertNotNull($photo->fileInfo);
     }
 
     // ========== buildFromConditionalRules tests ==========
@@ -269,7 +273,7 @@ class ParameterBuilderTest extends TestCase
 
         $cardNumber = $this->findParameter($parameters, 'card_number');
         $this->assertNotNull($cardNumber);
-        $this->assertArrayHasKey('conditional_rules', $cardNumber);
+        $this->assertTrue($cardNumber->hasConditionalRules());
 
         $accountNumber = $this->findParameter($parameters, 'account_number');
         $this->assertNotNull($accountNumber);
@@ -301,7 +305,7 @@ class ParameterBuilderTest extends TestCase
         $parameters = $this->builder->buildFromConditionalRules($conditionalRules);
 
         $email = $this->findParameter($parameters, 'email');
-        $this->assertCount(2, $email['conditional_rules']);
+        $this->assertCount(2, $email->conditionalRules);
     }
 
     #[Test]
@@ -327,7 +331,7 @@ class ParameterBuilderTest extends TestCase
         $parameters = $this->builder->buildFromConditionalRules($conditionalRules, $attributes);
 
         $payment = $this->findParameter($parameters, 'payment_method');
-        $this->assertEquals('支払い方法', $payment['description']);
+        $this->assertEquals('支払い方法', $payment->description);
     }
 
     // ========== Enum tests ==========
@@ -366,9 +370,9 @@ class ParameterBuilderTest extends TestCase
         $parameters = $builder->buildFromRules($rules);
 
         $status = $this->findParameter($parameters, 'status');
-        $this->assertArrayHasKey('enum', $status);
-        $this->assertInstanceOf(EnumInfo::class, $status['enum']);
-        $this->assertEquals('App\\Enums\\UserStatus', $status['enum']->class);
+        $this->assertTrue($status->hasEnum());
+        $this->assertInstanceOf(EnumInfo::class, $status->enum);
+        $this->assertEquals('App\\Enums\\UserStatus', $status->enum->class);
     }
 
     // ========== Edge cases ==========
@@ -406,7 +410,7 @@ class ParameterBuilderTest extends TestCase
         $parameters = $this->builder->buildFromRules($rules);
 
         $name = $this->findParameter($parameters, 'name');
-        $this->assertEquals(['required', 'string', 'max:255'], $name['validation']);
+        $this->assertEquals(['required', 'string', 'max:255'], $name->validation);
     }
 
     #[Test]
@@ -436,10 +440,10 @@ class ParameterBuilderTest extends TestCase
 
         $parameters = $this->builder->buildFromRules($rules);
 
-        $this->assertEquals('integer', $this->findParameter($parameters, 'count')['type']);
-        $this->assertEquals('number', $this->findParameter($parameters, 'price')['type']);
-        $this->assertEquals('boolean', $this->findParameter($parameters, 'is_active')['type']);
-        $this->assertEquals('array', $this->findParameter($parameters, 'tags')['type']);
+        $this->assertEquals('integer', $this->findParameter($parameters, 'count')->type);
+        $this->assertEquals('number', $this->findParameter($parameters, 'price')->type);
+        $this->assertEquals('boolean', $this->findParameter($parameters, 'is_active')->type);
+        $this->assertEquals('array', $this->findParameter($parameters, 'tags')->type);
     }
 
     // ========== Malformed input edge cases ==========
@@ -558,8 +562,8 @@ class ParameterBuilderTest extends TestCase
         $this->assertCount(1, $parameters);
         $field = $this->findParameter($parameters, 'field');
         $this->assertNotNull($field);
-        $this->assertArrayHasKey('conditional_rules', $field);
-        $this->assertEquals([], $field['conditional_rules'][0]['conditions']);
+        $this->assertTrue($field->hasConditionalRules());
+        $this->assertEquals([], $field->conditionalRules[0]['conditions']);
     }
 
     // ========== Suggested improvements tests ==========
@@ -602,9 +606,9 @@ class ParameterBuilderTest extends TestCase
         $parameters = $builder->buildFromConditionalRules($conditionalRules);
 
         $payment = $this->findParameter($parameters, 'payment');
-        $this->assertArrayHasKey('enum', $payment);
-        $this->assertInstanceOf(EnumInfo::class, $payment['enum']);
-        $this->assertEquals('App\\Enums\\PaymentType', $payment['enum']->class);
+        $this->assertTrue($payment->hasEnum());
+        $this->assertInstanceOf(EnumInfo::class, $payment->enum);
+        $this->assertEquals('App\\Enums\\PaymentType', $payment->enum->class);
     }
 
     #[Test]
@@ -620,7 +624,7 @@ class ParameterBuilderTest extends TestCase
         $parameters = $this->builder->buildFromRules($rules, $attributes);
 
         $document = $this->findParameter($parameters, 'document');
-        $this->assertStringContainsString('PDFドキュメント', $document['description']);
+        $this->assertStringContainsString('PDFドキュメント', $document->description);
     }
 
     #[Test]
@@ -654,17 +658,20 @@ class ParameterBuilderTest extends TestCase
         $parameters = $builder->buildFromRules($rules, [], 'App\\Http\\Requests', ['Status' => 'App\\Enums\\Status']);
 
         $status = $this->findParameter($parameters, 'status');
-        $this->assertArrayHasKey('enum', $status);
-        $this->assertInstanceOf(EnumInfo::class, $status['enum']);
-        $this->assertEquals('App\\Enums\\Status', $status['enum']->class);
+        $this->assertTrue($status->hasEnum());
+        $this->assertInstanceOf(EnumInfo::class, $status->enum);
+        $this->assertEquals('App\\Enums\\Status', $status->enum->class);
     }
 
     // ========== Helper methods ==========
 
-    private function findParameter(array $parameters, string $name): ?array
+    /**
+     * @param  array<ParameterDefinition>  $parameters
+     */
+    private function findParameter(array $parameters, string $name): ?ParameterDefinition
     {
         foreach ($parameters as $parameter) {
-            if ($parameter['name'] === $name) {
+            if ($parameter->name === $name) {
                 return $parameter;
             }
         }

--- a/tests/Unit/DTO/ParameterDefinitionTest.php
+++ b/tests/Unit/DTO/ParameterDefinitionTest.php
@@ -1,0 +1,481 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\DTO;
+
+use LaravelSpectrum\DTO\EnumBackingType;
+use LaravelSpectrum\DTO\EnumInfo;
+use LaravelSpectrum\DTO\FileUploadInfo;
+use LaravelSpectrum\DTO\ParameterDefinition;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ParameterDefinitionTest extends TestCase
+{
+    #[Test]
+    public function it_can_create_standard_parameter(): void
+    {
+        $param = new ParameterDefinition(
+            name: 'email',
+            in: 'body',
+            required: true,
+            type: 'string',
+            description: 'User email address',
+            example: 'user@example.com',
+            validation: ['required', 'email'],
+            format: 'email',
+        );
+
+        $this->assertEquals('email', $param->name);
+        $this->assertEquals('body', $param->in);
+        $this->assertTrue($param->required);
+        $this->assertEquals('string', $param->type);
+        $this->assertEquals('User email address', $param->description);
+        $this->assertEquals('user@example.com', $param->example);
+        $this->assertEquals(['required', 'email'], $param->validation);
+        $this->assertEquals('email', $param->format);
+        $this->assertNull($param->conditionalRequired);
+        $this->assertNull($param->conditionalRules);
+        $this->assertNull($param->enum);
+        $this->assertNull($param->fileInfo);
+    }
+
+    #[Test]
+    public function it_can_create_file_upload_parameter(): void
+    {
+        $fileInfo = new FileUploadInfo(isImage: true, mimes: ['jpeg', 'png']);
+
+        $param = new ParameterDefinition(
+            name: 'avatar',
+            in: 'body',
+            required: true,
+            type: 'file',
+            description: 'User avatar image',
+            example: null,
+            validation: ['required', 'image', 'max:2048'],
+            format: 'binary',
+            fileInfo: $fileInfo,
+        );
+
+        $this->assertEquals('avatar', $param->name);
+        $this->assertEquals('file', $param->type);
+        $this->assertEquals('binary', $param->format);
+        $this->assertSame($fileInfo, $param->fileInfo);
+    }
+
+    #[Test]
+    public function it_can_create_parameter_with_enum(): void
+    {
+        $enumInfo = new EnumInfo(
+            class: 'App\\Enums\\Status',
+            values: ['active', 'inactive', 'pending'],
+            backingType: EnumBackingType::STRING,
+        );
+
+        $param = new ParameterDefinition(
+            name: 'status',
+            in: 'body',
+            required: true,
+            type: 'string',
+            description: 'User status',
+            example: 'active',
+            validation: ['required'],
+            enum: $enumInfo,
+        );
+
+        $this->assertSame($enumInfo, $param->enum);
+        $this->assertTrue($param->hasEnum());
+    }
+
+    #[Test]
+    public function it_can_create_parameter_with_conditional_rules(): void
+    {
+        $conditionalRules = [
+            ['conditions' => ['type' => 'http_method', 'method' => 'POST'], 'rules' => ['required']],
+        ];
+
+        $param = new ParameterDefinition(
+            name: 'password',
+            in: 'body',
+            required: false,
+            type: 'string',
+            description: 'User password',
+            example: 'secret123',
+            validation: ['sometimes', 'string', 'min:8'],
+            conditionalRequired: true,
+            conditionalRules: $conditionalRules,
+        );
+
+        $this->assertTrue($param->conditionalRequired);
+        $this->assertEquals($conditionalRules, $param->conditionalRules);
+        $this->assertTrue($param->hasConditionalRules());
+    }
+
+    #[Test]
+    public function it_creates_from_array(): void
+    {
+        $data = [
+            'name' => 'username',
+            'in' => 'body',
+            'required' => true,
+            'type' => 'string',
+            'description' => 'Username for login',
+            'example' => 'john_doe',
+            'validation' => ['required', 'string', 'max:255'],
+            'format' => null,
+        ];
+
+        $param = ParameterDefinition::fromArray($data);
+
+        $this->assertEquals('username', $param->name);
+        $this->assertEquals('body', $param->in);
+        $this->assertTrue($param->required);
+        $this->assertEquals('string', $param->type);
+        $this->assertEquals('Username for login', $param->description);
+        $this->assertEquals('john_doe', $param->example);
+        $this->assertEquals(['required', 'string', 'max:255'], $param->validation);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_defaults(): void
+    {
+        $data = [
+            'name' => 'field',
+        ];
+
+        $param = ParameterDefinition::fromArray($data);
+
+        $this->assertEquals('field', $param->name);
+        $this->assertEquals('body', $param->in);
+        $this->assertFalse($param->required);
+        $this->assertEquals('string', $param->type);
+        $this->assertEquals('', $param->description);
+        $this->assertNull($param->example);
+        $this->assertEquals([], $param->validation);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_enum_info(): void
+    {
+        $enumInfo = new EnumInfo(
+            class: 'App\\Enums\\Priority',
+            values: [1, 2, 3],
+            backingType: EnumBackingType::INTEGER,
+        );
+
+        $data = [
+            'name' => 'priority',
+            'in' => 'body',
+            'required' => true,
+            'type' => 'integer',
+            'description' => 'Task priority',
+            'example' => 1,
+            'validation' => ['required'],
+            'enum' => $enumInfo,
+        ];
+
+        $param = ParameterDefinition::fromArray($data);
+
+        $this->assertSame($enumInfo, $param->enum);
+        $this->assertTrue($param->hasEnum());
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_file_info(): void
+    {
+        $fileInfo = new FileUploadInfo(isImage: true, maxSize: 2048);
+
+        $data = [
+            'name' => 'document',
+            'in' => 'body',
+            'required' => false,
+            'type' => 'file',
+            'description' => 'Upload document',
+            'example' => null,
+            'validation' => ['file'],
+            'format' => 'binary',
+            'file_info' => $fileInfo,
+        ];
+
+        $param = ParameterDefinition::fromArray($data);
+
+        $this->assertSame($fileInfo, $param->fileInfo);
+        $this->assertTrue($param->isFileUpload());
+    }
+
+    #[Test]
+    public function it_converts_to_array(): void
+    {
+        $param = new ParameterDefinition(
+            name: 'email',
+            in: 'body',
+            required: true,
+            type: 'string',
+            description: 'Email address',
+            example: 'test@example.com',
+            validation: ['required', 'email'],
+            format: 'email',
+        );
+
+        $array = $param->toArray();
+
+        $this->assertEquals([
+            'name' => 'email',
+            'in' => 'body',
+            'required' => true,
+            'type' => 'string',
+            'description' => 'Email address',
+            'example' => 'test@example.com',
+            'validation' => ['required', 'email'],
+            'format' => 'email',
+        ], $array);
+    }
+
+    #[Test]
+    public function it_converts_to_array_with_optional_fields(): void
+    {
+        $enumInfo = new EnumInfo(
+            class: 'App\\Enums\\Status',
+            values: ['active', 'inactive'],
+            backingType: EnumBackingType::STRING,
+        );
+
+        $param = new ParameterDefinition(
+            name: 'status',
+            in: 'body',
+            required: true,
+            type: 'string',
+            description: 'Status',
+            example: 'active',
+            validation: ['required'],
+            conditionalRequired: true,
+            conditionalRules: [['conditions' => [], 'rules' => ['required']]],
+            enum: $enumInfo,
+        );
+
+        $array = $param->toArray();
+
+        $this->assertArrayHasKey('conditional_required', $array);
+        $this->assertTrue($array['conditional_required']);
+        $this->assertArrayHasKey('conditional_rules', $array);
+        $this->assertArrayHasKey('enum', $array);
+        $this->assertSame($enumInfo, $array['enum']);
+    }
+
+    #[Test]
+    public function it_omits_null_optional_fields_in_to_array(): void
+    {
+        $param = new ParameterDefinition(
+            name: 'simple',
+            in: 'body',
+            required: false,
+            type: 'string',
+            description: 'Simple field',
+            example: null,
+            validation: [],
+        );
+
+        $array = $param->toArray();
+
+        $this->assertArrayNotHasKey('format', $array);
+        $this->assertArrayNotHasKey('conditional_required', $array);
+        $this->assertArrayNotHasKey('conditional_rules', $array);
+        $this->assertArrayNotHasKey('enum', $array);
+        $this->assertArrayNotHasKey('file_info', $array);
+    }
+
+    #[Test]
+    public function it_is_file_upload_returns_true_for_file_type(): void
+    {
+        $param = new ParameterDefinition(
+            name: 'upload',
+            in: 'body',
+            required: true,
+            type: 'file',
+            description: 'File upload',
+            example: null,
+            validation: ['required', 'file'],
+        );
+
+        $this->assertTrue($param->isFileUpload());
+    }
+
+    #[Test]
+    public function it_is_file_upload_returns_false_for_non_file_type(): void
+    {
+        $param = new ParameterDefinition(
+            name: 'name',
+            in: 'body',
+            required: true,
+            type: 'string',
+            description: 'Name field',
+            example: 'John',
+            validation: ['required', 'string'],
+        );
+
+        $this->assertFalse($param->isFileUpload());
+    }
+
+    #[Test]
+    public function it_has_conditional_rules_returns_true_when_present(): void
+    {
+        $param = new ParameterDefinition(
+            name: 'field',
+            in: 'body',
+            required: false,
+            type: 'string',
+            description: 'Field',
+            example: null,
+            validation: [],
+            conditionalRules: [['conditions' => [], 'rules' => ['required']]],
+        );
+
+        $this->assertTrue($param->hasConditionalRules());
+    }
+
+    #[Test]
+    public function it_has_conditional_rules_returns_false_when_null(): void
+    {
+        $param = new ParameterDefinition(
+            name: 'field',
+            in: 'body',
+            required: false,
+            type: 'string',
+            description: 'Field',
+            example: null,
+            validation: [],
+        );
+
+        $this->assertFalse($param->hasConditionalRules());
+    }
+
+    #[Test]
+    public function it_has_conditional_rules_returns_false_when_empty(): void
+    {
+        $param = new ParameterDefinition(
+            name: 'field',
+            in: 'body',
+            required: false,
+            type: 'string',
+            description: 'Field',
+            example: null,
+            validation: [],
+            conditionalRules: [],
+        );
+
+        $this->assertFalse($param->hasConditionalRules());
+    }
+
+    #[Test]
+    public function it_has_enum_returns_true_when_enum_info_present(): void
+    {
+        $enumInfo = new EnumInfo('App\\Enums\\A', ['a'], EnumBackingType::STRING);
+
+        $param = new ParameterDefinition(
+            name: 'field',
+            in: 'body',
+            required: false,
+            type: 'string',
+            description: 'Field',
+            example: null,
+            validation: [],
+            enum: $enumInfo,
+        );
+
+        $this->assertTrue($param->hasEnum());
+    }
+
+    #[Test]
+    public function it_has_enum_returns_false_when_null(): void
+    {
+        $param = new ParameterDefinition(
+            name: 'field',
+            in: 'body',
+            required: false,
+            type: 'string',
+            description: 'Field',
+            example: null,
+            validation: [],
+        );
+
+        $this->assertFalse($param->hasEnum());
+    }
+
+    #[Test]
+    public function it_survives_serialization_round_trip(): void
+    {
+        $original = new ParameterDefinition(
+            name: 'email',
+            in: 'body',
+            required: true,
+            type: 'string',
+            description: 'Email address',
+            example: 'test@example.com',
+            validation: ['required', 'email'],
+            format: 'email',
+        );
+
+        $restored = ParameterDefinition::fromArray($original->toArray());
+
+        $this->assertEquals($original->name, $restored->name);
+        $this->assertEquals($original->in, $restored->in);
+        $this->assertEquals($original->required, $restored->required);
+        $this->assertEquals($original->type, $restored->type);
+        $this->assertEquals($original->description, $restored->description);
+        $this->assertEquals($original->example, $restored->example);
+        $this->assertEquals($original->validation, $restored->validation);
+        $this->assertEquals($original->format, $restored->format);
+    }
+
+    #[Test]
+    public function it_handles_integer_type(): void
+    {
+        $param = new ParameterDefinition(
+            name: 'age',
+            in: 'body',
+            required: true,
+            type: 'integer',
+            description: 'User age',
+            example: 25,
+            validation: ['required', 'integer', 'min:0'],
+        );
+
+        $this->assertEquals('integer', $param->type);
+        $this->assertEquals(25, $param->example);
+    }
+
+    #[Test]
+    public function it_handles_boolean_type(): void
+    {
+        $param = new ParameterDefinition(
+            name: 'active',
+            in: 'body',
+            required: false,
+            type: 'boolean',
+            description: 'Is active flag',
+            example: true,
+            validation: ['boolean'],
+        );
+
+        $this->assertEquals('boolean', $param->type);
+        $this->assertTrue($param->example);
+    }
+
+    #[Test]
+    public function it_handles_array_type(): void
+    {
+        $param = new ParameterDefinition(
+            name: 'tags',
+            in: 'body',
+            required: false,
+            type: 'array',
+            description: 'List of tags',
+            example: ['tag1', 'tag2'],
+            validation: ['array'],
+        );
+
+        $this->assertEquals('array', $param->type);
+        $this->assertEquals(['tag1', 'tag2'], $param->example);
+    }
+}


### PR DESCRIPTION
# 概要

`ParameterBuilder`が返すパラメータ配列を型安全な`ParameterDefinition` DTOに変換するリファクタリングです。EnumInfo DTOと同様のパターンに従っています。

## 変更内容

### 新規作成
- `src/DTO/ParameterDefinition.php` - 12のプロパティを持つ新しいDTOクラス
  - `name`, `in`, `required`, `type`, `description`, `example`, `validation`
  - オプショナル: `format`, `conditionalRequired`, `conditionalRules`, `enum`, `fileInfo`
  - ヘルパーメソッド: `isFileUpload()`, `hasConditionalRules()`, `hasEnum()`
  - `fromArray()` / `toArray()` 変換メソッド
- `tests/Unit/DTO/ParameterDefinitionTest.php` - 22の包括的なテストケース

### 変更
- `src/Analyzers/Support/ParameterBuilder.php` - `array<ParameterDefinition>`を返すように更新
- `src/Analyzers/FormRequestAnalyzer.php` - 後方互換性のため`convertParametersToArrays()`を追加
- `src/Analyzers/Support/AnonymousClassAnalyzer.php` - 同様のパターンを適用
- `tests/Unit/Analyzers/Support/ParameterBuilderTest.php` - DTOプロパティアクセスに更新
- `tests/Unit/Analyzers/Support/AnonymousClassAnalyzerTest.php` - モックデータ形式を修正

### 設計上の決定
1. **後方互換性**: `toArray()`でDTOを配列に戻すことで、下流コード（SchemaGenerator, RequestBodyGenerator）は変更不要
2. **柔軟な変換**: `convertParametersToArrays()`はDTOとレガシー配列の両方を処理可能
3. **ネストしたDTO処理**: `EnumInfo`はDTOのまま保持（SchemaPropertyMapperが処理）、`FileUploadInfo`は配列に変換

## 関連情報

- 前のPR: #248 (EnumInfo DTO適用)
- DTOリファクタリングシリーズの一環