### PR TITLE
refactor: apply AuthenticationResult DTO to AuthenticationAnalyzer

### DIFF
--- a/src/DTO/AuthenticationResult.php
+++ b/src/DTO/AuthenticationResult.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\DTO;
+
+/**
+ * Represents the result of authentication analysis across all routes.
+ *
+ * This DTO encapsulates the collection of authentication schemes used
+ * and the per-route authentication information.
+ */
+final readonly class AuthenticationResult
+{
+    /**
+     * @param  array<string, AuthenticationScheme>  $schemes  Map of scheme name to scheme definition
+     * @param  array<int, RouteAuthentication>  $routes  Map of route index to route authentication
+     */
+    public function __construct(
+        public array $schemes,
+        public array $routes,
+    ) {}
+
+    /**
+     * Create an empty result.
+     */
+    public static function empty(): self
+    {
+        return new self(schemes: [], routes: []);
+    }
+
+    /**
+     * Create from an array.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $schemes = [];
+        foreach ($data['schemes'] ?? [] as $name => $scheme) {
+            $schemes[$name] = $scheme instanceof AuthenticationScheme
+                ? $scheme
+                : AuthenticationScheme::fromArray($scheme);
+        }
+
+        $routes = [];
+        foreach ($data['routes'] ?? [] as $index => $route) {
+            $routes[$index] = $route instanceof RouteAuthentication
+                ? $route
+                : RouteAuthentication::fromArray($route);
+        }
+
+        return new self(
+            schemes: $schemes,
+            routes: $routes,
+        );
+    }
+
+    /**
+     * Convert to array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $schemes = [];
+        foreach ($this->schemes as $name => $scheme) {
+            $schemes[$name] = $scheme->toArray();
+        }
+
+        $routes = [];
+        foreach ($this->routes as $index => $route) {
+            $routes[$index] = $route->toArray();
+        }
+
+        return [
+            'schemes' => $schemes,
+            'routes' => $routes,
+        ];
+    }
+
+    /**
+     * Check if this result is empty (no schemes and no routes).
+     */
+    public function isEmpty(): bool
+    {
+        return empty($this->schemes) && empty($this->routes);
+    }
+
+    /**
+     * Check if there are any authentication schemes.
+     */
+    public function hasSchemes(): bool
+    {
+        return ! empty($this->schemes);
+    }
+
+    /**
+     * Get a scheme by name.
+     */
+    public function getScheme(string $name): ?AuthenticationScheme
+    {
+        return $this->schemes[$name] ?? null;
+    }
+
+    /**
+     * Get route authentication by route index.
+     */
+    public function getRouteAuthentication(int $index): ?RouteAuthentication
+    {
+        return $this->routes[$index] ?? null;
+    }
+
+    /**
+     * Check if a route has authentication.
+     */
+    public function hasRouteAuthentication(int $index): bool
+    {
+        return isset($this->routes[$index]);
+    }
+
+    /**
+     * Count the number of authentication schemes.
+     */
+    public function countSchemes(): int
+    {
+        return count($this->schemes);
+    }
+
+    /**
+     * Count the number of authenticated routes.
+     */
+    public function countAuthenticatedRoutes(): int
+    {
+        return count($this->routes);
+    }
+
+    /**
+     * Get all scheme names.
+     *
+     * @return array<string>
+     */
+    public function getSchemeNames(): array
+    {
+        return array_keys($this->schemes);
+    }
+}

--- a/src/DTO/RouteAuthentication.php
+++ b/src/DTO/RouteAuthentication.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\DTO;
+
+/**
+ * Represents authentication information for a specific route.
+ *
+ * This DTO encapsulates the authentication scheme, middleware, and
+ * requirement status for a single API route.
+ */
+final readonly class RouteAuthentication
+{
+    /**
+     * @param  AuthenticationScheme  $scheme  The authentication scheme for this route
+     * @param  array<string>  $middleware  Middleware applied to this route
+     * @param  bool  $required  Whether authentication is required (default: true)
+     */
+    public function __construct(
+        public AuthenticationScheme $scheme,
+        public array $middleware,
+        public bool $required = true,
+    ) {}
+
+    /**
+     * Create from an array.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $scheme = $data['scheme'] ?? [];
+
+        return new self(
+            scheme: $scheme instanceof AuthenticationScheme
+                ? $scheme
+                : AuthenticationScheme::fromArray($scheme),
+            middleware: $data['middleware'] ?? [],
+            required: $data['required'] ?? true,
+        );
+    }
+
+    /**
+     * Convert to array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'scheme' => $this->scheme->toArray(),
+            'middleware' => $this->middleware,
+            'required' => $this->required,
+        ];
+    }
+
+    /**
+     * Check if authentication is required for this route.
+     */
+    public function isRequired(): bool
+    {
+        return $this->required;
+    }
+
+    /**
+     * Get the scheme name.
+     */
+    public function getSchemeName(): string
+    {
+        return $this->scheme->name;
+    }
+
+    /**
+     * Check if this route has a specific middleware.
+     */
+    public function hasMiddleware(string $middleware): bool
+    {
+        return in_array($middleware, $this->middleware, true);
+    }
+}

--- a/tests/Unit/Analyzers/AuthenticationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/AuthenticationAnalyzerTest.php
@@ -3,6 +3,8 @@
 namespace LaravelSpectrum\Tests\Unit\Analyzers;
 
 use LaravelSpectrum\Analyzers\AuthenticationAnalyzer;
+use LaravelSpectrum\DTO\AuthenticationResult;
+use LaravelSpectrum\DTO\RouteAuthentication;
 use LaravelSpectrum\Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -36,16 +38,15 @@ class AuthenticationAnalyzerTest extends TestCase
 
         $result = $this->analyzer->analyze($routes);
 
-        $this->assertArrayHasKey('schemes', $result);
-        $this->assertArrayHasKey('routes', $result);
+        $this->assertInstanceOf(AuthenticationResult::class, $result);
 
         // Sanctum認証スキームが検出される
-        $this->assertArrayHasKey('sanctumAuth', $result['schemes']);
+        $this->assertArrayHasKey('sanctumAuth', $result->schemes);
 
         // ルート0と2に認証情報がある
-        $this->assertArrayHasKey(0, $result['routes']);
-        $this->assertArrayHasKey(2, $result['routes']);
-        $this->assertArrayNotHasKey(1, $result['routes']); // publicルートには認証なし
+        $this->assertTrue($result->hasRouteAuthentication(0));
+        $this->assertTrue($result->hasRouteAuthentication(2));
+        $this->assertFalse($result->hasRouteAuthentication(1)); // publicルートには認証なし
     }
 
     #[Test]
@@ -58,9 +59,9 @@ class AuthenticationAnalyzerTest extends TestCase
 
         $auth = $this->analyzer->analyzeRoute($route);
 
-        $this->assertNotNull($auth);
-        $this->assertEquals('apiAuth', $auth['scheme']['name']);
-        $this->assertTrue($auth['required']);
+        $this->assertInstanceOf(RouteAuthentication::class, $auth);
+        $this->assertEquals('apiAuth', $auth->getSchemeName());
+        $this->assertTrue($auth->isRequired());
     }
 
     #[Test]
@@ -98,8 +99,8 @@ class AuthenticationAnalyzerTest extends TestCase
 
         $auth = $this->analyzer->analyzeRoute($route);
 
-        $this->assertNotNull($auth);
-        $this->assertEquals('jwtAuth', $auth['scheme']['name']);
+        $this->assertInstanceOf(RouteAuthentication::class, $auth);
+        $this->assertEquals('jwtAuth', $auth->getSchemeName());
     }
 
     #[Test]

--- a/tests/Unit/DTO/AuthenticationResultTest.php
+++ b/tests/Unit/DTO/AuthenticationResultTest.php
@@ -1,0 +1,332 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\DTO;
+
+use LaravelSpectrum\DTO\AuthenticationResult;
+use LaravelSpectrum\DTO\AuthenticationScheme;
+use LaravelSpectrum\DTO\AuthenticationType;
+use LaravelSpectrum\DTO\RouteAuthentication;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class AuthenticationResultTest extends TestCase
+{
+    private AuthenticationScheme $sanctumScheme;
+
+    private AuthenticationScheme $basicScheme;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sanctumScheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'sanctumAuth',
+            scheme: 'bearer',
+            bearerFormat: 'JWT',
+            description: 'Laravel Sanctum authentication',
+        );
+
+        $this->basicScheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'basicAuth',
+            scheme: 'basic',
+            description: 'Basic HTTP authentication',
+        );
+    }
+
+    #[Test]
+    public function it_can_create_authentication_result(): void
+    {
+        $schemes = [
+            'sanctumAuth' => $this->sanctumScheme,
+        ];
+
+        $route0Auth = new RouteAuthentication(
+            scheme: $this->sanctumScheme,
+            middleware: ['auth:sanctum'],
+            required: true,
+        );
+
+        $routes = [
+            0 => $route0Auth,
+        ];
+
+        $result = new AuthenticationResult(
+            schemes: $schemes,
+            routes: $routes,
+        );
+
+        $this->assertCount(1, $result->schemes);
+        $this->assertCount(1, $result->routes);
+        $this->assertSame($this->sanctumScheme, $result->schemes['sanctumAuth']);
+        $this->assertSame($route0Auth, $result->routes[0]);
+    }
+
+    #[Test]
+    public function it_can_create_empty_result(): void
+    {
+        $result = AuthenticationResult::empty();
+
+        $this->assertEmpty($result->schemes);
+        $this->assertEmpty($result->routes);
+        $this->assertTrue($result->isEmpty());
+    }
+
+    #[Test]
+    public function it_creates_from_array(): void
+    {
+        $data = [
+            'schemes' => [
+                'sanctumAuth' => [
+                    'type' => 'http',
+                    'name' => 'sanctumAuth',
+                    'scheme' => 'bearer',
+                    'bearerFormat' => 'JWT',
+                ],
+            ],
+            'routes' => [
+                0 => [
+                    'scheme' => [
+                        'type' => 'http',
+                        'name' => 'sanctumAuth',
+                        'scheme' => 'bearer',
+                    ],
+                    'middleware' => ['auth:sanctum'],
+                    'required' => true,
+                ],
+            ],
+        ];
+
+        $result = AuthenticationResult::fromArray($data);
+
+        $this->assertCount(1, $result->schemes);
+        $this->assertEquals('sanctumAuth', $result->schemes['sanctumAuth']->name);
+        $this->assertCount(1, $result->routes);
+        $this->assertTrue($result->routes[0]->required);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_dto_objects(): void
+    {
+        $data = [
+            'schemes' => [
+                'sanctumAuth' => $this->sanctumScheme,
+            ],
+            'routes' => [
+                0 => new RouteAuthentication(
+                    scheme: $this->sanctumScheme,
+                    middleware: ['auth:sanctum'],
+                ),
+            ],
+        ];
+
+        $result = AuthenticationResult::fromArray($data);
+
+        $this->assertSame($this->sanctumScheme, $result->schemes['sanctumAuth']);
+        $this->assertInstanceOf(RouteAuthentication::class, $result->routes[0]);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_defaults(): void
+    {
+        $result = AuthenticationResult::fromArray([]);
+
+        $this->assertEmpty($result->schemes);
+        $this->assertEmpty($result->routes);
+    }
+
+    #[Test]
+    public function it_converts_to_array(): void
+    {
+        $route0Auth = new RouteAuthentication(
+            scheme: $this->sanctumScheme,
+            middleware: ['auth:sanctum'],
+            required: true,
+        );
+
+        $result = new AuthenticationResult(
+            schemes: ['sanctumAuth' => $this->sanctumScheme],
+            routes: [0 => $route0Auth],
+        );
+
+        $array = $result->toArray();
+
+        $this->assertArrayHasKey('schemes', $array);
+        $this->assertArrayHasKey('routes', $array);
+        $this->assertArrayHasKey('sanctumAuth', $array['schemes']);
+        $this->assertEquals('sanctumAuth', $array['schemes']['sanctumAuth']['name']);
+        $this->assertArrayHasKey(0, $array['routes']);
+        $this->assertTrue($array['routes'][0]['required']);
+    }
+
+    #[Test]
+    public function it_survives_serialization_round_trip(): void
+    {
+        $route0Auth = new RouteAuthentication(
+            scheme: $this->sanctumScheme,
+            middleware: ['auth:sanctum'],
+            required: true,
+        );
+
+        $original = new AuthenticationResult(
+            schemes: ['sanctumAuth' => $this->sanctumScheme],
+            routes: [0 => $route0Auth],
+        );
+
+        $restored = AuthenticationResult::fromArray($original->toArray());
+
+        $this->assertCount(count($original->schemes), $restored->schemes);
+        $this->assertCount(count($original->routes), $restored->routes);
+        $this->assertEquals(
+            $original->schemes['sanctumAuth']->name,
+            $restored->schemes['sanctumAuth']->name
+        );
+    }
+
+    #[Test]
+    public function it_checks_if_empty(): void
+    {
+        $empty = new AuthenticationResult(schemes: [], routes: []);
+        $this->assertTrue($empty->isEmpty());
+
+        $withSchemes = new AuthenticationResult(
+            schemes: ['test' => $this->sanctumScheme],
+            routes: [],
+        );
+        $this->assertFalse($withSchemes->isEmpty());
+
+        $withRoutes = new AuthenticationResult(
+            schemes: [],
+            routes: [0 => new RouteAuthentication(
+                scheme: $this->sanctumScheme,
+                middleware: ['auth'],
+            )],
+        );
+        $this->assertFalse($withRoutes->isEmpty());
+    }
+
+    #[Test]
+    public function it_checks_if_has_schemes(): void
+    {
+        $empty = AuthenticationResult::empty();
+        $this->assertFalse($empty->hasSchemes());
+
+        $withScheme = new AuthenticationResult(
+            schemes: ['sanctumAuth' => $this->sanctumScheme],
+            routes: [],
+        );
+        $this->assertTrue($withScheme->hasSchemes());
+    }
+
+    #[Test]
+    public function it_gets_scheme_by_name(): void
+    {
+        $result = new AuthenticationResult(
+            schemes: [
+                'sanctumAuth' => $this->sanctumScheme,
+                'basicAuth' => $this->basicScheme,
+            ],
+            routes: [],
+        );
+
+        $this->assertSame($this->sanctumScheme, $result->getScheme('sanctumAuth'));
+        $this->assertSame($this->basicScheme, $result->getScheme('basicAuth'));
+        $this->assertNull($result->getScheme('nonexistent'));
+    }
+
+    #[Test]
+    public function it_gets_route_authentication_by_index(): void
+    {
+        $route0Auth = new RouteAuthentication(
+            scheme: $this->sanctumScheme,
+            middleware: ['auth:sanctum'],
+        );
+
+        $route1Auth = new RouteAuthentication(
+            scheme: $this->basicScheme,
+            middleware: ['auth.basic'],
+        );
+
+        $result = new AuthenticationResult(
+            schemes: [],
+            routes: [0 => $route0Auth, 1 => $route1Auth],
+        );
+
+        $this->assertSame($route0Auth, $result->getRouteAuthentication(0));
+        $this->assertSame($route1Auth, $result->getRouteAuthentication(1));
+        $this->assertNull($result->getRouteAuthentication(99));
+    }
+
+    #[Test]
+    public function it_has_route_authentication(): void
+    {
+        $result = new AuthenticationResult(
+            schemes: [],
+            routes: [
+                0 => new RouteAuthentication(
+                    scheme: $this->sanctumScheme,
+                    middleware: ['auth:sanctum'],
+                ),
+            ],
+        );
+
+        $this->assertTrue($result->hasRouteAuthentication(0));
+        $this->assertFalse($result->hasRouteAuthentication(1));
+        $this->assertFalse($result->hasRouteAuthentication(99));
+    }
+
+    #[Test]
+    public function it_counts_schemes(): void
+    {
+        $result = new AuthenticationResult(
+            schemes: [
+                'sanctumAuth' => $this->sanctumScheme,
+                'basicAuth' => $this->basicScheme,
+            ],
+            routes: [],
+        );
+
+        $this->assertEquals(2, $result->countSchemes());
+    }
+
+    #[Test]
+    public function it_counts_authenticated_routes(): void
+    {
+        $result = new AuthenticationResult(
+            schemes: [],
+            routes: [
+                0 => new RouteAuthentication(
+                    scheme: $this->sanctumScheme,
+                    middleware: ['auth:sanctum'],
+                ),
+                5 => new RouteAuthentication(
+                    scheme: $this->basicScheme,
+                    middleware: ['auth.basic'],
+                ),
+            ],
+        );
+
+        $this->assertEquals(2, $result->countAuthenticatedRoutes());
+    }
+
+    #[Test]
+    public function it_gets_all_scheme_names(): void
+    {
+        $result = new AuthenticationResult(
+            schemes: [
+                'sanctumAuth' => $this->sanctumScheme,
+                'basicAuth' => $this->basicScheme,
+            ],
+            routes: [],
+        );
+
+        $names = $result->getSchemeNames();
+
+        $this->assertCount(2, $names);
+        $this->assertContains('sanctumAuth', $names);
+        $this->assertContains('basicAuth', $names);
+    }
+}

--- a/tests/Unit/DTO/RouteAuthenticationTest.php
+++ b/tests/Unit/DTO/RouteAuthenticationTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\DTO;
+
+use LaravelSpectrum\DTO\AuthenticationScheme;
+use LaravelSpectrum\DTO\AuthenticationType;
+use LaravelSpectrum\DTO\RouteAuthentication;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class RouteAuthenticationTest extends TestCase
+{
+    #[Test]
+    public function it_can_create_route_authentication(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'bearerAuth',
+            scheme: 'bearer',
+            bearerFormat: 'JWT',
+            description: 'Bearer token authentication',
+        );
+
+        $routeAuth = new RouteAuthentication(
+            scheme: $scheme,
+            middleware: ['auth:sanctum'],
+            required: true,
+        );
+
+        $this->assertSame($scheme, $routeAuth->scheme);
+        $this->assertEquals(['auth:sanctum'], $routeAuth->middleware);
+        $this->assertTrue($routeAuth->required);
+    }
+
+    #[Test]
+    public function it_can_create_route_authentication_with_defaults(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'basicAuth',
+            scheme: 'basic',
+        );
+
+        $routeAuth = new RouteAuthentication(
+            scheme: $scheme,
+            middleware: ['auth.basic'],
+        );
+
+        $this->assertSame($scheme, $routeAuth->scheme);
+        $this->assertEquals(['auth.basic'], $routeAuth->middleware);
+        $this->assertTrue($routeAuth->required); // Default is true
+    }
+
+    #[Test]
+    public function it_creates_from_array(): void
+    {
+        $data = [
+            'scheme' => [
+                'type' => 'http',
+                'name' => 'sanctumAuth',
+                'scheme' => 'bearer',
+                'bearerFormat' => 'JWT',
+                'description' => 'Sanctum authentication',
+            ],
+            'middleware' => ['auth:sanctum', 'verified'],
+            'required' => true,
+        ];
+
+        $routeAuth = RouteAuthentication::fromArray($data);
+
+        $this->assertEquals('sanctumAuth', $routeAuth->scheme->name);
+        $this->assertEquals('bearer', $routeAuth->scheme->scheme);
+        $this->assertEquals(['auth:sanctum', 'verified'], $routeAuth->middleware);
+        $this->assertTrue($routeAuth->required);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_authentication_scheme_object(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'bearerAuth',
+            scheme: 'bearer',
+        );
+
+        $data = [
+            'scheme' => $scheme,
+            'middleware' => ['auth'],
+            'required' => false,
+        ];
+
+        $routeAuth = RouteAuthentication::fromArray($data);
+
+        $this->assertSame($scheme, $routeAuth->scheme);
+        $this->assertEquals(['auth'], $routeAuth->middleware);
+        $this->assertFalse($routeAuth->required);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_defaults(): void
+    {
+        $data = [
+            'scheme' => [
+                'type' => 'http',
+                'name' => 'basicAuth',
+                'scheme' => 'basic',
+            ],
+            'middleware' => ['auth.basic'],
+        ];
+
+        $routeAuth = RouteAuthentication::fromArray($data);
+
+        $this->assertTrue($routeAuth->required); // Default
+    }
+
+    #[Test]
+    public function it_converts_to_array(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'bearerAuth',
+            scheme: 'bearer',
+            bearerFormat: 'JWT',
+            description: 'Bearer authentication',
+        );
+
+        $routeAuth = new RouteAuthentication(
+            scheme: $scheme,
+            middleware: ['auth:sanctum'],
+            required: true,
+        );
+
+        $array = $routeAuth->toArray();
+
+        $this->assertArrayHasKey('scheme', $array);
+        $this->assertArrayHasKey('middleware', $array);
+        $this->assertArrayHasKey('required', $array);
+        $this->assertEquals('bearerAuth', $array['scheme']['name']);
+        $this->assertEquals(['auth:sanctum'], $array['middleware']);
+        $this->assertTrue($array['required']);
+    }
+
+    #[Test]
+    public function it_survives_serialization_round_trip(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'apiAuth',
+            scheme: 'bearer',
+            bearerFormat: 'API Token',
+        );
+
+        $original = new RouteAuthentication(
+            scheme: $scheme,
+            middleware: ['auth:api', 'throttle:60,1'],
+            required: true,
+        );
+
+        $restored = RouteAuthentication::fromArray($original->toArray());
+
+        $this->assertEquals($original->scheme->name, $restored->scheme->name);
+        $this->assertEquals($original->scheme->scheme, $restored->scheme->scheme);
+        $this->assertEquals($original->middleware, $restored->middleware);
+        $this->assertEquals($original->required, $restored->required);
+    }
+
+    #[Test]
+    public function it_has_is_required_helper(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'bearerAuth',
+            scheme: 'bearer',
+        );
+
+        $required = new RouteAuthentication(
+            scheme: $scheme,
+            middleware: ['auth'],
+            required: true,
+        );
+
+        $optional = new RouteAuthentication(
+            scheme: $scheme,
+            middleware: ['auth'],
+            required: false,
+        );
+
+        $this->assertTrue($required->isRequired());
+        $this->assertFalse($optional->isRequired());
+    }
+
+    #[Test]
+    public function it_gets_scheme_name(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'sanctumAuth',
+            scheme: 'bearer',
+        );
+
+        $routeAuth = new RouteAuthentication(
+            scheme: $scheme,
+            middleware: ['auth:sanctum'],
+        );
+
+        $this->assertEquals('sanctumAuth', $routeAuth->getSchemeName());
+    }
+
+    #[Test]
+    public function it_checks_if_has_middleware(): void
+    {
+        $scheme = new AuthenticationScheme(
+            type: AuthenticationType::HTTP,
+            name: 'bearerAuth',
+            scheme: 'bearer',
+        );
+
+        $routeAuth = new RouteAuthentication(
+            scheme: $scheme,
+            middleware: ['auth:sanctum', 'verified', 'throttle:60,1'],
+        );
+
+        $this->assertTrue($routeAuth->hasMiddleware('auth:sanctum'));
+        $this->assertTrue($routeAuth->hasMiddleware('verified'));
+        $this->assertFalse($routeAuth->hasMiddleware('admin'));
+    }
+}


### PR DESCRIPTION
## Summary

- Create `RouteAuthentication` DTO for per-route authentication info
- Create `AuthenticationResult` DTO for `analyze()` return value
- Update `AuthenticationAnalyzer` to return DTOs instead of arrays
- Update `OpenApiGenerator` for backward compatibility using `toArray()`

## Changes

### New DTOs

**RouteAuthentication** (`src/DTO/RouteAuthentication.php`)
- Represents authentication information for a single route
- Properties: `scheme` (AuthenticationScheme), `middleware` (array), `required` (bool)
- Helper methods: `isRequired()`, `getSchemeName()`, `hasMiddleware()`

**AuthenticationResult** (`src/DTO/AuthenticationResult.php`)
- Represents the result of authentication analysis across all routes
- Properties: `schemes` (array<string, AuthenticationScheme>), `routes` (array<int, RouteAuthentication>)
- Helper methods: `isEmpty()`, `hasSchemes()`, `getScheme()`, `getRouteAuthentication()`, `hasRouteAuthentication()`, etc.

### Updated Files
- `AuthenticationAnalyzer.php` - Returns DTOs instead of arrays
- `OpenApiGenerator.php` - Uses DTO methods, converts to arrays at integration boundaries

## Test Plan

- [x] All new DTOs have comprehensive unit tests (25 test cases)
- [x] Updated existing tests to use DTO assertions
- [x] `composer format:fix` passes
- [x] `composer analyze` passes (PHPStan Level 6)
- [x] `composer test` passes (2656 tests)
- [x] Demo app generates documentation successfully