### PR TITLE
refactor: apply ControllerInfo DTO to generator classes

### DIFF
--- a/src/Generators/ParameterGenerator.php
+++ b/src/Generators/ParameterGenerator.php
@@ -2,6 +2,7 @@
 
 namespace LaravelSpectrum\Generators;
 
+use LaravelSpectrum\DTO\ControllerInfo;
 use LaravelSpectrum\DTO\OpenApiParameter;
 use LaravelSpectrum\DTO\OpenApiSchema;
 use LaravelSpectrum\DTO\QueryParameterInfo;
@@ -26,10 +27,10 @@ class ParameterGenerator
      * Generate parameters for an API operation.
      *
      * @param  array{parameters: array}  $route  Route information with parameters
-     * @param  array{enumParameters?: array, queryParameters?: array}  $controllerInfo  Controller analysis result
+     * @param  ControllerInfo  $controllerInfo  Controller analysis result
      * @return array<int, OpenApiParameter> OpenAPI parameter definitions
      */
-    public function generate(array $route, array $controllerInfo): array
+    public function generate(array $route, ControllerInfo $controllerInfo): array
     {
         // Convert route parameters to DTOs
         $parameters = array_map(
@@ -50,18 +51,19 @@ class ParameterGenerator
      * Add enum type parameters from controller analysis.
      *
      * @param  array<int, OpenApiParameter>  $parameters  Existing parameters
-     * @param  array  $controllerInfo  Controller analysis result
+     * @param  ControllerInfo  $controllerInfo  Controller analysis result
      * @return array<int, OpenApiParameter> Updated parameters
      */
-    protected function addEnumParameters(array $parameters, array $controllerInfo): array
+    protected function addEnumParameters(array $parameters, ControllerInfo $controllerInfo): array
     {
-        if (empty($controllerInfo['enumParameters'])) {
+        if (! $controllerInfo->hasEnumParameters()) {
             return $parameters;
         }
 
         $result = $parameters;
 
-        foreach ($controllerInfo['enumParameters'] as $enumParam) {
+        foreach ($controllerInfo->enumParameters as $enumParamDTO) {
+            $enumParam = $enumParamDTO->toArray();
             // Check if this is already a route parameter
             $matchIndex = null;
             foreach ($result as $index => $routeParam) {
@@ -107,16 +109,17 @@ class ParameterGenerator
      * Add query parameters from controller analysis.
      *
      * @param  array<int, OpenApiParameter>  $parameters  Existing parameters
-     * @param  array  $controllerInfo  Controller analysis result
+     * @param  ControllerInfo  $controllerInfo  Controller analysis result
      * @return array<int, OpenApiParameter> Updated parameters
      */
-    protected function addQueryParameters(array $parameters, array $controllerInfo): array
+    protected function addQueryParameters(array $parameters, ControllerInfo $controllerInfo): array
     {
-        if (empty($controllerInfo['queryParameters'])) {
+        if (! $controllerInfo->hasQueryParameters()) {
             return $parameters;
         }
 
-        foreach ($controllerInfo['queryParameters'] as $queryParam) {
+        foreach ($controllerInfo->queryParameters as $queryParamDTO) {
+            $queryParam = $queryParamDTO->toArray();
             $type = $queryParam['type'] ?? 'string';
 
             // Build schema

--- a/src/Generators/RequestBodyGenerator.php
+++ b/src/Generators/RequestBodyGenerator.php
@@ -4,6 +4,7 @@ namespace LaravelSpectrum\Generators;
 
 use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
 use LaravelSpectrum\Analyzers\InlineValidationAnalyzer;
+use LaravelSpectrum\DTO\ControllerInfo;
 use LaravelSpectrum\DTO\OpenApiRequestBody;
 
 /**
@@ -26,30 +27,30 @@ class RequestBodyGenerator
     /**
      * Generate request body for an API operation.
      *
-     * @param  array{formRequest?: string, inlineValidation?: array}  $controllerInfo  Controller analysis result
+     * @param  ControllerInfo  $controllerInfo  Controller analysis result
      * @param  array  $route  Route information
      * @return OpenApiRequestBody|null Request body DTO or null if no validation
      */
-    public function generate(array $controllerInfo, array $route): ?OpenApiRequestBody
+    public function generate(ControllerInfo $controllerInfo, array $route): ?OpenApiRequestBody
     {
         $parameters = [];
         $conditionalRules = null;
 
         // FormRequest validation
-        if (! empty($controllerInfo['formRequest'])) {
-            $analysisResult = $this->requestAnalyzer->analyzeWithConditionalRules($controllerInfo['formRequest']);
+        if ($controllerInfo->hasFormRequest()) {
+            $analysisResult = $this->requestAnalyzer->analyzeWithConditionalRules($controllerInfo->formRequest);
 
             if (! empty($analysisResult['conditional_rules']['rules_sets'])) {
                 $conditionalRules = $analysisResult['conditional_rules'];
                 $parameters = $analysisResult['parameters'] ?? [];
             } else {
-                $parameters = $this->requestAnalyzer->analyze($controllerInfo['formRequest']);
+                $parameters = $this->requestAnalyzer->analyze($controllerInfo->formRequest);
             }
         }
         // Inline validation
-        elseif (! empty($controllerInfo['inlineValidation'])) {
+        elseif ($controllerInfo->hasInlineValidation()) {
             $parameters = $this->inlineValidationAnalyzer->generateParameters(
-                $controllerInfo['inlineValidation']
+                $controllerInfo->inlineValidation->toArray()
             );
         }
 

--- a/tests/Feature/OpenApiGeneratorTest.php
+++ b/tests/Feature/OpenApiGeneratorTest.php
@@ -5,6 +5,7 @@ namespace LaravelSpectrum\Tests\Feature;
 use Illuminate\Support\Facades\Route;
 use LaravelSpectrum\Analyzers\RouteAnalyzer;
 use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\DTO\ControllerInfo;
 use LaravelSpectrum\Generators\OpenApiGenerator;
 use LaravelSpectrum\Tests\Fixtures\Controllers\ProfileController;
 use LaravelSpectrum\Tests\Fixtures\Controllers\UserController;
@@ -335,8 +336,8 @@ class OpenApiGeneratorTest extends TestCase
     protected function mockControllerAnalysis(string $method, array $result): void
     {
         $controllerAnalyzer = Mockery::mock('LaravelSpectrum\Analyzers\ControllerAnalyzer');
-        $controllerAnalyzer->shouldReceive('analyze')
-            ->andReturn($result);
+        $controllerAnalyzer->shouldReceive('analyzeToResult')
+            ->andReturn(ControllerInfo::fromArray($result));
 
         $this->app->instance('LaravelSpectrum\Analyzers\ControllerAnalyzer', $controllerAnalyzer);
     }

--- a/tests/Unit/Generators/OpenApiGeneratorTest.php
+++ b/tests/Unit/Generators/OpenApiGeneratorTest.php
@@ -11,6 +11,7 @@ use LaravelSpectrum\Converters\OpenApi31Converter;
 use LaravelSpectrum\DTO\AuthenticationResult;
 use LaravelSpectrum\DTO\AuthenticationScheme;
 use LaravelSpectrum\DTO\AuthenticationType;
+use LaravelSpectrum\DTO\ControllerInfo;
 use LaravelSpectrum\DTO\OpenApiParameter;
 use LaravelSpectrum\DTO\OpenApiRequestBody;
 use LaravelSpectrum\DTO\OpenApiResponse;
@@ -270,13 +271,13 @@ class OpenApiGeneratorTest extends TestCase
             ->once()
             ->andReturn([]);
 
-        $this->controllerAnalyzer->shouldReceive('analyze')
+        $this->controllerAnalyzer->shouldReceive('analyzeToResult')
             ->once()
-            ->andReturn([
+            ->andReturn(ControllerInfo::fromArray([
                 'method' => 'index',
                 'responseType' => 'json',
                 'hasValidation' => false,
-            ]);
+            ]));
 
         $this->metadataGenerator->shouldReceive('convertToOpenApiPath')
             ->once()
@@ -345,14 +346,14 @@ class OpenApiGeneratorTest extends TestCase
             ->once()
             ->andReturn([]);
 
-        $this->controllerAnalyzer->shouldReceive('analyze')
+        $this->controllerAnalyzer->shouldReceive('analyzeToResult')
             ->once()
-            ->andReturn([
+            ->andReturn(ControllerInfo::fromArray([
                 'method' => 'store',
                 'responseType' => 'json',
                 'hasValidation' => true,
                 'formRequest' => 'App\Http\Requests\StoreUserRequest',
-            ]);
+            ]));
 
         $this->metadataGenerator->shouldReceive('convertToOpenApiPath')
             ->once()
@@ -495,13 +496,13 @@ class OpenApiGeneratorTest extends TestCase
                 ['bearerAuth' => []],
             ]);
 
-        $this->controllerAnalyzer->shouldReceive('analyze')
+        $this->controllerAnalyzer->shouldReceive('analyzeToResult')
             ->once()
-            ->andReturn([
+            ->andReturn(ControllerInfo::fromArray([
                 'method' => 'show',
                 'responseType' => 'json',
                 'hasValidation' => false,
-            ]);
+            ]));
 
         $this->metadataGenerator->shouldReceive('convertToOpenApiPath')
             ->once()
@@ -590,13 +591,13 @@ class OpenApiGeneratorTest extends TestCase
             ->once()
             ->andReturn([]);
 
-        $this->controllerAnalyzer->shouldReceive('analyze')
+        $this->controllerAnalyzer->shouldReceive('analyzeToResult')
             ->once()
-            ->andReturn([
+            ->andReturn(ControllerInfo::fromArray([
                 'method' => 'show',
                 'responseType' => 'json',
                 'hasValidation' => false,
-            ]);
+            ]));
 
         $this->metadataGenerator->shouldReceive('convertToOpenApiPath')
             ->once()
@@ -854,15 +855,15 @@ class OpenApiGeneratorTest extends TestCase
         $this->authenticationAnalyzer->shouldReceive('analyze')->once()->andReturn(AuthenticationResult::empty());
         $this->securitySchemeGenerator->shouldReceive('generateSecuritySchemes')->once()->andReturn([]);
 
-        $this->controllerAnalyzer->shouldReceive('analyze')
+        $this->controllerAnalyzer->shouldReceive('analyzeToResult')
             ->once()
-            ->andReturn([
+            ->andReturn(ControllerInfo::fromArray([
                 'method' => 'index',
                 'responseType' => 'json',
                 'hasValidation' => false,
                 'resource' => 'App\Http\Resources\UserResource',
                 'returnsCollection' => true,
-            ]);
+            ]));
 
         $this->metadataGenerator->shouldReceive('convertToOpenApiPath')->once()->andReturn('/api/users');
         $this->metadataGenerator->shouldReceive('generateSummary')->once()->andReturn('List all User');
@@ -947,15 +948,15 @@ class OpenApiGeneratorTest extends TestCase
         $this->authenticationAnalyzer->shouldReceive('analyze')->once()->andReturn(AuthenticationResult::empty());
         $this->securitySchemeGenerator->shouldReceive('generateSecuritySchemes')->once()->andReturn([]);
 
-        $this->controllerAnalyzer->shouldReceive('analyze')
+        $this->controllerAnalyzer->shouldReceive('analyzeToResult')
             ->once()
-            ->andReturn([
+            ->andReturn(ControllerInfo::fromArray([
                 'method' => 'show',
                 'responseType' => 'json',
                 'hasValidation' => false,
                 'resource' => 'App\Http\Resources\UserResource',
                 'returnsCollection' => false,
-            ]);
+            ]));
 
         $this->metadataGenerator->shouldReceive('convertToOpenApiPath')->once()->andReturn('/api/users/{user}');
         $this->metadataGenerator->shouldReceive('generateSummary')->once()->andReturn('Get User by ID');
@@ -1019,15 +1020,15 @@ class OpenApiGeneratorTest extends TestCase
         $this->authenticationAnalyzer->shouldReceive('analyze')->once()->andReturn(AuthenticationResult::empty());
         $this->securitySchemeGenerator->shouldReceive('generateSecuritySchemes')->once()->andReturn([]);
 
-        $this->controllerAnalyzer->shouldReceive('analyze')
+        $this->controllerAnalyzer->shouldReceive('analyzeToResult')
             ->once()
-            ->andReturn([
+            ->andReturn(ControllerInfo::fromArray([
                 'method' => 'index',
                 'responseType' => 'json',
                 'hasValidation' => false,
                 'resource' => 'App\Http\Resources\PostResource',
                 'returnsCollection' => true,
-            ]);
+            ]));
 
         $this->metadataGenerator->shouldReceive('convertToOpenApiPath')->once()->andReturn('/api/posts');
         $this->metadataGenerator->shouldReceive('generateSummary')->once()->andReturn('List all Post');
@@ -1110,15 +1111,15 @@ class OpenApiGeneratorTest extends TestCase
         $this->authenticationAnalyzer->shouldReceive('analyze')->once()->andReturn(AuthenticationResult::empty());
         $this->securitySchemeGenerator->shouldReceive('generateSecuritySchemes')->once()->andReturn([]);
 
-        $this->controllerAnalyzer->shouldReceive('analyze')
+        $this->controllerAnalyzer->shouldReceive('analyzeToResult')
             ->twice()
-            ->andReturn([
+            ->andReturn(ControllerInfo::fromArray([
                 'method' => 'index',
                 'responseType' => 'json',
                 'hasValidation' => false,
                 'resource' => 'App\Http\Resources\UserResource',
                 'returnsCollection' => false,
-            ]);
+            ]));
 
         $this->metadataGenerator->shouldReceive('convertToOpenApiPath')
             ->twice()
@@ -1200,7 +1201,7 @@ class OpenApiGeneratorTest extends TestCase
 
         $this->parameterGenerator->shouldReceive('generate')->andReturn([]);
 
-        $this->controllerAnalyzer->shouldReceive('analyze')->andReturn([]);
+        $this->controllerAnalyzer->shouldReceive('analyzeToResult')->andReturn(ControllerInfo::empty());
 
         $this->errorResponseGenerator->shouldReceive('generateErrorResponses')->andReturn([]);
         // Verify that getDefaultErrorResponses is called with requiresAuth=true
@@ -1255,7 +1256,7 @@ class OpenApiGeneratorTest extends TestCase
 
         $this->parameterGenerator->shouldReceive('generate')->andReturn([]);
 
-        $this->controllerAnalyzer->shouldReceive('analyze')->andReturn([]);
+        $this->controllerAnalyzer->shouldReceive('analyzeToResult')->andReturn(ControllerInfo::empty());
 
         $this->errorResponseGenerator->shouldReceive('generateErrorResponses')->andReturn([]);
         // Verify that getDefaultErrorResponses is called with requiresAuth=false
@@ -1296,7 +1297,7 @@ class OpenApiGeneratorTest extends TestCase
 
         $this->parameterGenerator->shouldReceive('generate')->andReturn([]);
 
-        $this->controllerAnalyzer->shouldReceive('analyze')->andReturn([]);
+        $this->controllerAnalyzer->shouldReceive('analyzeToResult')->andReturn(ControllerInfo::empty());
 
         $this->errorResponseGenerator->shouldReceive('generateErrorResponses')->andReturn([]);
         // auth:api should be detected as requiring auth
@@ -1408,7 +1409,7 @@ class OpenApiGeneratorTest extends TestCase
 
         $this->parameterGenerator->shouldReceive('generate')->andReturn([]);
 
-        $this->controllerAnalyzer->shouldReceive('analyze')->andReturn([]);
+        $this->controllerAnalyzer->shouldReceive('analyzeToResult')->andReturn(ControllerInfo::empty());
 
         $this->errorResponseGenerator->shouldReceive('generateErrorResponses')->andReturn([]);
         $this->errorResponseGenerator->shouldReceive('getDefaultErrorResponses')->andReturn([]);
@@ -1481,7 +1482,7 @@ class OpenApiGeneratorTest extends TestCase
 
         $this->parameterGenerator->shouldReceive('generate')->andReturn([]);
 
-        $this->controllerAnalyzer->shouldReceive('analyze')->andReturn([]);
+        $this->controllerAnalyzer->shouldReceive('analyzeToResult')->andReturn(ControllerInfo::empty());
 
         $this->errorResponseGenerator->shouldReceive('generateErrorResponses')->andReturn([]);
         $this->errorResponseGenerator->shouldReceive('getDefaultErrorResponses')->andReturn([]);
@@ -1582,10 +1583,10 @@ class OpenApiGeneratorTest extends TestCase
 
         $this->parameterGenerator->shouldReceive('generate')->andReturn([]);
 
-        $this->controllerAnalyzer->shouldReceive('analyze')->andReturn([
+        $this->controllerAnalyzer->shouldReceive('analyzeToResult')->andReturn(ControllerInfo::fromArray([
             'resource' => 'App\Http\Resources\UserResource',
             'returnsCollection' => false,
-        ]);
+        ]));
 
         $this->resourceAnalyzer->shouldReceive('analyze')
             ->with('App\Http\Resources\UserResource')

--- a/tests/Unit/Generators/ParameterGeneratorTest.php
+++ b/tests/Unit/Generators/ParameterGeneratorTest.php
@@ -2,6 +2,7 @@
 
 namespace LaravelSpectrum\Tests\Unit\Generators;
 
+use LaravelSpectrum\DTO\ControllerInfo;
 use LaravelSpectrum\DTO\OpenApiParameter;
 use LaravelSpectrum\DTO\QueryParameterInfo;
 use LaravelSpectrum\Generators\ParameterGenerator;
@@ -44,7 +45,7 @@ class ParameterGeneratorTest extends TestCase
                 ['name' => 'id', 'in' => 'path', 'required' => true, 'schema' => ['type' => 'integer']],
             ],
         ];
-        $controllerInfo = [];
+        $controllerInfo = ControllerInfo::empty();
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -61,7 +62,7 @@ class ParameterGeneratorTest extends TestCase
                 ['name' => 'status', 'in' => 'path', 'required' => true, 'schema' => ['type' => 'string']],
             ],
         ];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'enumParameters' => [
                 [
                     'name' => 'status',
@@ -71,7 +72,7 @@ class ParameterGeneratorTest extends TestCase
                     'required' => true,
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -94,7 +95,7 @@ class ParameterGeneratorTest extends TestCase
                 ],
             ],
         ];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'enumParameters' => [
                 [
                     'name' => 'status',
@@ -104,7 +105,7 @@ class ParameterGeneratorTest extends TestCase
                     'required' => true,
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -119,7 +120,7 @@ class ParameterGeneratorTest extends TestCase
     public function it_adds_enum_as_query_parameter_when_not_in_route(): void
     {
         $route = ['parameters' => []];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'enumParameters' => [
                 [
                     'name' => 'sort',
@@ -129,7 +130,7 @@ class ParameterGeneratorTest extends TestCase
                     'required' => false,
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -144,7 +145,7 @@ class ParameterGeneratorTest extends TestCase
     public function it_adds_query_parameters(): void
     {
         $route = ['parameters' => []];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'queryParameters' => [
                 [
                     'name' => 'page',
@@ -153,7 +154,7 @@ class ParameterGeneratorTest extends TestCase
                     'default' => 1,
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -168,7 +169,7 @@ class ParameterGeneratorTest extends TestCase
     public function it_adds_query_parameter_with_description(): void
     {
         $route = ['parameters' => []];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'queryParameters' => [
                 [
                     'name' => 'search',
@@ -177,7 +178,7 @@ class ParameterGeneratorTest extends TestCase
                     'description' => 'Search term',
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -189,7 +190,7 @@ class ParameterGeneratorTest extends TestCase
     public function it_adds_query_parameter_with_enum(): void
     {
         $route = ['parameters' => []];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'queryParameters' => [
                 [
                     'name' => 'order',
@@ -198,7 +199,7 @@ class ParameterGeneratorTest extends TestCase
                     'enum' => ['name', 'date', 'price'],
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -210,7 +211,7 @@ class ParameterGeneratorTest extends TestCase
     public function it_adds_validation_constraints_to_query_parameter(): void
     {
         $route = ['parameters' => []];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'queryParameters' => [
                 [
                     'name' => 'limit',
@@ -219,7 +220,7 @@ class ParameterGeneratorTest extends TestCase
                     'validation_rules' => ['integer', 'min:1', 'max:100'],
                 ],
             ],
-        ];
+        ]);
 
         $this->mockTypeInference->shouldReceive('getConstraintsFromRules')
             ->once()
@@ -241,7 +242,7 @@ class ParameterGeneratorTest extends TestCase
                 ['name' => 'id', 'in' => 'path', 'required' => true, 'schema' => ['type' => 'integer']],
             ],
         ];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'enumParameters' => [
                 [
                     'name' => 'status',
@@ -258,7 +259,7 @@ class ParameterGeneratorTest extends TestCase
                     'required' => false,
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -281,7 +282,7 @@ class ParameterGeneratorTest extends TestCase
     public function it_handles_empty_parameters(): void
     {
         $route = ['parameters' => []];
-        $controllerInfo = [];
+        $controllerInfo = ControllerInfo::empty();
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -296,7 +297,7 @@ class ParameterGeneratorTest extends TestCase
                 ['name' => 'status', 'in' => 'path', 'required' => true, 'schema' => ['type' => 'string']],
             ],
         ];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'enumParameters' => [
                 [
                     'name' => 'status',
@@ -306,7 +307,7 @@ class ParameterGeneratorTest extends TestCase
                     'required' => true,
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -317,7 +318,7 @@ class ParameterGeneratorTest extends TestCase
     public function it_does_not_add_empty_description_to_enum_query_parameter(): void
     {
         $route = ['parameters' => []];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'enumParameters' => [
                 [
                     'name' => 'status',
@@ -327,7 +328,7 @@ class ParameterGeneratorTest extends TestCase
                     'required' => false,
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -338,7 +339,7 @@ class ParameterGeneratorTest extends TestCase
     public function it_handles_required_query_parameter(): void
     {
         $route = ['parameters' => []];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'queryParameters' => [
                 [
                     'name' => 'api_key',
@@ -346,7 +347,7 @@ class ParameterGeneratorTest extends TestCase
                     'required' => true,
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -357,7 +358,7 @@ class ParameterGeneratorTest extends TestCase
     public function it_adds_style_and_explode_to_array_query_parameters(): void
     {
         $route = ['parameters' => []];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'queryParameters' => [
                 [
                     'name' => 'ids',
@@ -365,7 +366,7 @@ class ParameterGeneratorTest extends TestCase
                     'required' => false,
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -379,7 +380,7 @@ class ParameterGeneratorTest extends TestCase
     public function it_adds_items_schema_to_array_parameters(): void
     {
         $route = ['parameters' => []];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'queryParameters' => [
                 [
                     'name' => 'tags',
@@ -387,7 +388,7 @@ class ParameterGeneratorTest extends TestCase
                     'required' => false,
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -401,7 +402,7 @@ class ParameterGeneratorTest extends TestCase
     public function it_does_not_add_style_for_simple_types(): void
     {
         $route = ['parameters' => []];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'queryParameters' => [
                 [
                     'name' => 'page',
@@ -409,7 +410,7 @@ class ParameterGeneratorTest extends TestCase
                     'required' => false,
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -424,7 +425,7 @@ class ParameterGeneratorTest extends TestCase
         config(['spectrum.parameters.include_style' => false]);
 
         $route = ['parameters' => []];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'queryParameters' => [
                 [
                     'name' => 'ids',
@@ -432,7 +433,7 @@ class ParameterGeneratorTest extends TestCase
                     'required' => false,
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -448,7 +449,7 @@ class ParameterGeneratorTest extends TestCase
         config(['spectrum.parameters.array_style' => 'spaceDelimited']);
 
         $route = ['parameters' => []];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'queryParameters' => [
                 [
                     'name' => 'ids',
@@ -456,7 +457,7 @@ class ParameterGeneratorTest extends TestCase
                     'required' => false,
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 
@@ -469,7 +470,7 @@ class ParameterGeneratorTest extends TestCase
         config(['spectrum.parameters.array_explode' => false]);
 
         $route = ['parameters' => []];
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'queryParameters' => [
                 [
                     'name' => 'ids',
@@ -477,7 +478,7 @@ class ParameterGeneratorTest extends TestCase
                     'required' => false,
                 ],
             ],
-        ];
+        ]);
 
         $parameters = $this->generator->generate($route, $controllerInfo);
 

--- a/tests/Unit/Generators/RequestBodyGeneratorTest.php
+++ b/tests/Unit/Generators/RequestBodyGeneratorTest.php
@@ -4,6 +4,7 @@ namespace LaravelSpectrum\Tests\Unit\Generators;
 
 use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
 use LaravelSpectrum\Analyzers\InlineValidationAnalyzer;
+use LaravelSpectrum\DTO\ControllerInfo;
 use LaravelSpectrum\DTO\OpenApiRequestBody;
 use LaravelSpectrum\Generators\RequestBodyGenerator;
 use LaravelSpectrum\Generators\SchemaGenerator;
@@ -44,7 +45,7 @@ class RequestBodyGeneratorTest extends TestCase
     #[Test]
     public function it_returns_null_when_no_validation(): void
     {
-        $controllerInfo = [];
+        $controllerInfo = ControllerInfo::empty();
         $route = ['uri' => 'api/users'];
 
         $result = $this->generator->generate($controllerInfo, $route);
@@ -55,7 +56,7 @@ class RequestBodyGeneratorTest extends TestCase
     #[Test]
     public function it_generates_request_body_from_form_request(): void
     {
-        $controllerInfo = ['formRequest' => 'App\Http\Requests\StoreUserRequest'];
+        $controllerInfo = ControllerInfo::fromArray(['formRequest' => 'App\Http\Requests\StoreUserRequest']);
         $route = ['uri' => 'api/users'];
 
         $this->mockRequestAnalyzer->shouldReceive('analyzeWithConditionalRules')
@@ -93,13 +94,13 @@ class RequestBodyGeneratorTest extends TestCase
     #[Test]
     public function it_generates_request_body_from_inline_validation(): void
     {
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'inlineValidation' => [
                 'rules' => [
                     'name' => ['required', 'string'],
                 ],
             ],
-        ];
+        ]);
         $route = ['uri' => 'api/users'];
 
         $this->mockInlineValidationAnalyzer->shouldReceive('generateParameters')
@@ -127,7 +128,7 @@ class RequestBodyGeneratorTest extends TestCase
     #[Test]
     public function it_generates_request_body_with_conditional_rules(): void
     {
-        $controllerInfo = ['formRequest' => 'App\Http\Requests\ConditionalRequest'];
+        $controllerInfo = ControllerInfo::fromArray(['formRequest' => 'App\Http\Requests\ConditionalRequest']);
         $route = ['uri' => 'api/users'];
 
         $conditionalRules = [
@@ -163,7 +164,7 @@ class RequestBodyGeneratorTest extends TestCase
     #[Test]
     public function it_generates_multipart_request_body_for_file_uploads(): void
     {
-        $controllerInfo = ['formRequest' => 'App\Http\Requests\UploadRequest'];
+        $controllerInfo = ControllerInfo::fromArray(['formRequest' => 'App\Http\Requests\UploadRequest']);
         $route = ['uri' => 'api/upload'];
 
         $this->mockRequestAnalyzer->shouldReceive('analyzeWithConditionalRules')
@@ -204,7 +205,7 @@ class RequestBodyGeneratorTest extends TestCase
     #[Test]
     public function it_includes_multiple_files_info_in_description(): void
     {
-        $controllerInfo = ['formRequest' => 'App\Http\Requests\MultiUploadRequest'];
+        $controllerInfo = ControllerInfo::fromArray(['formRequest' => 'App\Http\Requests\MultiUploadRequest']);
         $route = ['uri' => 'api/upload'];
 
         $this->mockRequestAnalyzer->shouldReceive('analyzeWithConditionalRules')
@@ -246,7 +247,7 @@ class RequestBodyGeneratorTest extends TestCase
     #[Test]
     public function it_handles_schema_with_existing_content_structure(): void
     {
-        $controllerInfo = ['formRequest' => 'App\Http\Requests\SpecialRequest'];
+        $controllerInfo = ControllerInfo::fromArray(['formRequest' => 'App\Http\Requests\SpecialRequest']);
         $route = ['uri' => 'api/special'];
 
         $this->mockRequestAnalyzer->shouldReceive('analyzeWithConditionalRules')
@@ -279,12 +280,12 @@ class RequestBodyGeneratorTest extends TestCase
     #[Test]
     public function it_prefers_form_request_over_inline_validation(): void
     {
-        $controllerInfo = [
+        $controllerInfo = ControllerInfo::fromArray([
             'formRequest' => 'App\Http\Requests\StoreUserRequest',
             'inlineValidation' => [
                 'rules' => ['ignored' => ['required']],
             ],
-        ];
+        ]);
         $route = ['uri' => 'api/users'];
 
         $this->mockRequestAnalyzer->shouldReceive('analyzeWithConditionalRules')
@@ -317,7 +318,7 @@ class RequestBodyGeneratorTest extends TestCase
     #[Test]
     public function it_returns_null_when_form_request_has_no_parameters(): void
     {
-        $controllerInfo = ['formRequest' => 'App\Http\Requests\EmptyRequest'];
+        $controllerInfo = ControllerInfo::fromArray(['formRequest' => 'App\Http\Requests\EmptyRequest']);
         $route = ['uri' => 'api/users'];
 
         $this->mockRequestAnalyzer->shouldReceive('analyzeWithConditionalRules')
@@ -336,7 +337,7 @@ class RequestBodyGeneratorTest extends TestCase
     #[Test]
     public function it_returns_null_when_file_upload_schema_has_no_content(): void
     {
-        $controllerInfo = ['formRequest' => 'App\Http\Requests\UploadRequest'];
+        $controllerInfo = ControllerInfo::fromArray(['formRequest' => 'App\Http\Requests\UploadRequest']);
         $route = ['uri' => 'api/upload'];
 
         $this->mockRequestAnalyzer->shouldReceive('analyzeWithConditionalRules')


### PR DESCRIPTION
## Summary

This PR applies the existing `ControllerInfo` DTO to the generator classes that previously consumed arrays from `ControllerAnalyzer::analyze()`. The generators now use type-safe DTO properties and helper methods.

## Changes

### OpenApiGenerator
- Updated to call `analyzeToResult()` instead of `analyze()`
- Updated `generateResponses()`, `generateErrorResponses()`, `generateSuccessResponse()` signatures to accept `ControllerInfo`
- Fixed ResponseType enum comparison using `isResource()` helper method instead of string comparison
- Uses DTO helper methods: `hasFormRequest()`, `hasResource()`, `hasPagination()`, etc.

### RequestBodyGenerator
- Updated `generate()` method signature from `array $controllerInfo` to `ControllerInfo $controllerInfo`
- Uses `hasFormRequest()`, `hasInlineValidation()` helper methods

### ParameterGenerator
- Updated `generate()`, `addEnumParameters()`, `addQueryParameters()` methods
- Uses `hasEnumParameters()`, `hasQueryParameters()` helper methods
- Converts DTO items to arrays via `toArray()` in loops

### Tests
- Updated `RequestBodyGeneratorTest` to use `ControllerInfo::fromArray()` and `ControllerInfo::empty()`
- Updated `ParameterGeneratorTest` to use `ControllerInfo` DTOs
- Updated `OpenApiGeneratorTest` to mock `analyzeToResult()` and return DTOs
- Updated Feature `OpenApiGeneratorTest` mock helper

## Bug Fix

Fixed a bug where `$controllerInfo->response->type !== 'resource'` was comparing a `ResponseType` enum to a string, which always returned true. Changed to use `! $controllerInfo->response->isResource()`.

## Test Plan

- [x] All 2675 tests pass
- [x] PHPStan analysis passes
- [x] Laravel Pint formatting passes