### PR TITLE
fix: increase memory limit for coverage generation in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Execute tests (with coverage)
         if: matrix.php == '8.2' && matrix.laravel == '12.*'
-        run: vendor/bin/phpunit --coverage-clover coverage.xml
+        run: php -d memory_limit=512M vendor/bin/phpunit --coverage-clover coverage.xml
 
       - name: Execute tests (without coverage)
         if: matrix.php != '8.2' || matrix.laravel != '12.*'


### PR DESCRIPTION
## Summary
- Fixes the flaky P8.2 - L12.* test job that was failing with memory exhaustion during code coverage generation
- Tests pass successfully (2812 tests, 8456 assertions), but coverage report generation exceeds the default 128MB memory limit
- Sets explicit memory_limit=512M when running PHPUnit with coverage

## Test plan
- [x] CI Tests workflow should pass for all PHP/Laravel combinations
- [x] Coverage reports should generate successfully
- [x] Codecov upload should complete without errors