### PR TITLE
refactor: add ResourceDetectionResult DTO for type-safe resource detection

### DIFF
--- a/src/DTO/ResourceDetectionResult.php
+++ b/src/DTO/ResourceDetectionResult.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\DTO;
+
+/**
+ * Represents the result of detecting a Laravel API Resource from controller code.
+ *
+ * Used by ControllerAnalyzer to communicate whether a resource class was found
+ * and whether it represents a single item or a collection.
+ */
+final readonly class ResourceDetectionResult
+{
+    /**
+     * @param  string|null  $resourceClass  The fully qualified resource class name, or null if not found
+     * @param  bool  $isCollection  Whether the resource is used as a collection
+     */
+    public function __construct(
+        public ?string $resourceClass,
+        public bool $isCollection,
+    ) {}
+
+    /**
+     * Check if a resource class was detected.
+     */
+    public function hasResource(): bool
+    {
+        return $this->resourceClass !== null;
+    }
+
+    /**
+     * Create a result indicating no resource was found.
+     */
+    public static function notFound(): self
+    {
+        return new self(
+            resourceClass: null,
+            isCollection: false,
+        );
+    }
+
+    /**
+     * Create a result for a single resource.
+     */
+    public static function single(string $resourceClass): self
+    {
+        return new self(
+            resourceClass: $resourceClass,
+            isCollection: false,
+        );
+    }
+
+    /**
+     * Create a result for a resource collection.
+     */
+    public static function collection(string $resourceClass): self
+    {
+        return new self(
+            resourceClass: $resourceClass,
+            isCollection: true,
+        );
+    }
+
+    /**
+     * Create from an array.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            resourceClass: $data['resourceClass'] ?? null,
+            isCollection: $data['isCollection'] ?? false,
+        );
+    }
+
+    /**
+     * Convert to array.
+     *
+     * @return array{resourceClass: string|null, isCollection: bool}
+     */
+    public function toArray(): array
+    {
+        return [
+            'resourceClass' => $this->resourceClass,
+            'isCollection' => $this->isCollection,
+        ];
+    }
+}

--- a/tests/Unit/DTO/ResourceDetectionResultTest.php
+++ b/tests/Unit/DTO/ResourceDetectionResultTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\DTO;
+
+use LaravelSpectrum\DTO\ResourceDetectionResult;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ResourceDetectionResultTest extends TestCase
+{
+    #[Test]
+    public function it_can_create_with_resource_class(): void
+    {
+        $result = new ResourceDetectionResult(
+            resourceClass: 'App\Http\Resources\UserResource',
+            isCollection: false,
+        );
+
+        $this->assertEquals('App\Http\Resources\UserResource', $result->resourceClass);
+        $this->assertFalse($result->isCollection);
+    }
+
+    #[Test]
+    public function it_can_create_collection_resource(): void
+    {
+        $result = new ResourceDetectionResult(
+            resourceClass: 'App\Http\Resources\UserResource',
+            isCollection: true,
+        );
+
+        $this->assertEquals('App\Http\Resources\UserResource', $result->resourceClass);
+        $this->assertTrue($result->isCollection);
+    }
+
+    #[Test]
+    public function it_can_create_with_null_resource(): void
+    {
+        $result = new ResourceDetectionResult(
+            resourceClass: null,
+            isCollection: false,
+        );
+
+        $this->assertNull($result->resourceClass);
+        $this->assertFalse($result->isCollection);
+    }
+
+    #[Test]
+    public function it_checks_if_resource_was_found(): void
+    {
+        $withResource = new ResourceDetectionResult(
+            resourceClass: 'App\Http\Resources\UserResource',
+            isCollection: false,
+        );
+
+        $withoutResource = new ResourceDetectionResult(
+            resourceClass: null,
+            isCollection: false,
+        );
+
+        $this->assertTrue($withResource->hasResource());
+        $this->assertFalse($withoutResource->hasResource());
+    }
+
+    #[Test]
+    public function it_creates_empty_result(): void
+    {
+        $result = ResourceDetectionResult::notFound();
+
+        $this->assertNull($result->resourceClass);
+        $this->assertFalse($result->isCollection);
+        $this->assertFalse($result->hasResource());
+    }
+
+    #[Test]
+    public function it_creates_single_resource_result(): void
+    {
+        $result = ResourceDetectionResult::single('App\Http\Resources\UserResource');
+
+        $this->assertEquals('App\Http\Resources\UserResource', $result->resourceClass);
+        $this->assertFalse($result->isCollection);
+        $this->assertTrue($result->hasResource());
+    }
+
+    #[Test]
+    public function it_creates_collection_resource_result(): void
+    {
+        $result = ResourceDetectionResult::collection('App\Http\Resources\UserResource');
+
+        $this->assertEquals('App\Http\Resources\UserResource', $result->resourceClass);
+        $this->assertTrue($result->isCollection);
+        $this->assertTrue($result->hasResource());
+    }
+
+    #[Test]
+    public function it_converts_to_array(): void
+    {
+        $result = new ResourceDetectionResult(
+            resourceClass: 'App\Http\Resources\UserResource',
+            isCollection: true,
+        );
+
+        $array = $result->toArray();
+
+        $this->assertEquals([
+            'resourceClass' => 'App\Http\Resources\UserResource',
+            'isCollection' => true,
+        ], $array);
+    }
+
+    #[Test]
+    public function it_converts_to_array_with_null_resource(): void
+    {
+        $result = ResourceDetectionResult::notFound();
+
+        $array = $result->toArray();
+
+        $this->assertEquals([
+            'resourceClass' => null,
+            'isCollection' => false,
+        ], $array);
+    }
+
+    #[Test]
+    public function it_creates_from_array(): void
+    {
+        $data = [
+            'resourceClass' => 'App\Http\Resources\PostResource',
+            'isCollection' => true,
+        ];
+
+        $result = ResourceDetectionResult::fromArray($data);
+
+        $this->assertEquals('App\Http\Resources\PostResource', $result->resourceClass);
+        $this->assertTrue($result->isCollection);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_defaults(): void
+    {
+        $result = ResourceDetectionResult::fromArray([]);
+
+        $this->assertNull($result->resourceClass);
+        $this->assertFalse($result->isCollection);
+    }
+
+    #[Test]
+    public function it_survives_serialization_round_trip(): void
+    {
+        $original = ResourceDetectionResult::collection('App\Http\Resources\UserResource');
+
+        $restored = ResourceDetectionResult::fromArray($original->toArray());
+
+        $this->assertEquals($original->resourceClass, $restored->resourceClass);
+        $this->assertEquals($original->isCollection, $restored->isCollection);
+    }
+}


### PR DESCRIPTION
## Summary
- Create `ResourceDetectionResult` DTO with factory methods (`notFound`, `single`, `collection`)
- Add `fromArray`/`toArray` methods for serialization
- Update `ControllerAnalyzer.detectResource()` to return DTO instead of tuple array
- Update `analyzeToResult()` to use DTO properties

## Changes
This follows the established DTO pattern for improving type safety and code readability. The `ResourceDetectionResult` DTO encapsulates the resource detection result that was previously returned as a tuple array `array{0: string|null, 1: bool}`.

### Before
```php
[$resource, $returnsCollection] = $this->detectResource($source, $reflection);
```

### After
```php
$resourceDetection = $this->detectResource($source, $reflection);
// Access via typed properties
$resourceDetection->resourceClass
$resourceDetection->isCollection
```

## Test plan
- [x] All existing tests pass
- [x] New DTO tests added (12 test cases)
- [x] PHPStan passes
- [x] Laravel Pint passes