### PR TITLE
fix: make ResourceDetectionResult constructor private for invariant safety

### DIFF
--- a/src/DTO/ResourceDetectionResult.php
+++ b/src/DTO/ResourceDetectionResult.php
@@ -16,7 +16,7 @@ final readonly class ResourceDetectionResult
      * @param  string|null  $resourceClass  The fully qualified resource class name, or null if not found
      * @param  bool  $isCollection  Whether the resource is used as a collection
      */
-    public function __construct(
+    private function __construct(
         public ?string $resourceClass,
         public bool $isCollection,
     ) {}
@@ -69,10 +69,16 @@ final readonly class ResourceDetectionResult
      */
     public static function fromArray(array $data): self
     {
-        return new self(
-            resourceClass: $data['resourceClass'] ?? null,
-            isCollection: $data['isCollection'] ?? false,
-        );
+        $resourceClass = $data['resourceClass'] ?? null;
+        $isCollection = $data['isCollection'] ?? false;
+
+        if ($resourceClass === null) {
+            return self::notFound();
+        }
+
+        return $isCollection
+            ? self::collection($resourceClass)
+            : self::single($resourceClass);
     }
 
     /**

--- a/tests/Unit/DTO/ResourceDetectionResultTest.php
+++ b/tests/Unit/DTO/ResourceDetectionResultTest.php
@@ -11,12 +11,9 @@ use PHPUnit\Framework\TestCase;
 class ResourceDetectionResultTest extends TestCase
 {
     #[Test]
-    public function it_can_create_with_resource_class(): void
+    public function it_can_create_single_resource(): void
     {
-        $result = new ResourceDetectionResult(
-            resourceClass: 'App\Http\Resources\UserResource',
-            isCollection: false,
-        );
+        $result = ResourceDetectionResult::single('App\Http\Resources\UserResource');
 
         $this->assertEquals('App\Http\Resources\UserResource', $result->resourceClass);
         $this->assertFalse($result->isCollection);
@@ -25,22 +22,16 @@ class ResourceDetectionResultTest extends TestCase
     #[Test]
     public function it_can_create_collection_resource(): void
     {
-        $result = new ResourceDetectionResult(
-            resourceClass: 'App\Http\Resources\UserResource',
-            isCollection: true,
-        );
+        $result = ResourceDetectionResult::collection('App\Http\Resources\UserResource');
 
         $this->assertEquals('App\Http\Resources\UserResource', $result->resourceClass);
         $this->assertTrue($result->isCollection);
     }
 
     #[Test]
-    public function it_can_create_with_null_resource(): void
+    public function it_can_create_not_found_result(): void
     {
-        $result = new ResourceDetectionResult(
-            resourceClass: null,
-            isCollection: false,
-        );
+        $result = ResourceDetectionResult::notFound();
 
         $this->assertNull($result->resourceClass);
         $this->assertFalse($result->isCollection);
@@ -49,15 +40,8 @@ class ResourceDetectionResultTest extends TestCase
     #[Test]
     public function it_checks_if_resource_was_found(): void
     {
-        $withResource = new ResourceDetectionResult(
-            resourceClass: 'App\Http\Resources\UserResource',
-            isCollection: false,
-        );
-
-        $withoutResource = new ResourceDetectionResult(
-            resourceClass: null,
-            isCollection: false,
-        );
+        $withResource = ResourceDetectionResult::single('App\Http\Resources\UserResource');
+        $withoutResource = ResourceDetectionResult::notFound();
 
         $this->assertTrue($withResource->hasResource());
         $this->assertFalse($withoutResource->hasResource());
@@ -96,10 +80,7 @@ class ResourceDetectionResultTest extends TestCase
     #[Test]
     public function it_converts_to_array(): void
     {
-        $result = new ResourceDetectionResult(
-            resourceClass: 'App\Http\Resources\UserResource',
-            isCollection: true,
-        );
+        $result = ResourceDetectionResult::collection('App\Http\Resources\UserResource');
 
         $array = $result->toArray();
 


### PR DESCRIPTION
## Summary

Follow-up to PR #261 based on type-design-analyzer feedback.

## Changes

- Make constructor `private` to prevent invalid states like `new ResourceDetectionResult(null, true)`
- Update `fromArray()` to use factory methods for validation
- Update tests to use factory methods instead of constructor

## Why

This ensures only valid states can be created through the well-designed factory methods:

| Method | resourceClass | isCollection |
|--------|---------------|--------------|
| `notFound()` | `null` | `false` |
| `single($class)` | non-null | `false` |
| `collection($class)` | non-null | `true` |

Previously, the public constructor allowed semantically invalid states like `(null, true)` which would represent "no resource found but it's a collection" - a nonsensical state.

## Test plan

- [x] All existing tests pass
- [x] Tests updated to use factory methods
- [x] PHPStan passes
- [x] Laravel Pint passes