### PR TITLE
refactor: add ErrorEntry DTO for type-safe error collection

### DIFF
--- a/src/DTO/ErrorEntry.php
+++ b/src/DTO/ErrorEntry.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\DTO;
+
+use LaravelSpectrum\Support\AnalyzerErrorType;
+
+/**
+ * Represents a single error or warning entry in error collection.
+ *
+ * Used by ErrorCollector to store structured error/warning information
+ * with context, metadata, and optional stack trace.
+ */
+final readonly class ErrorEntry
+{
+    private const TYPE_ERROR = 'error';
+
+    private const TYPE_WARNING = 'warning';
+
+    /**
+     * @param  string  $context  The context where the error occurred (e.g., analyzer name)
+     * @param  string  $message  The error/warning message
+     * @param  array<string, mixed>  $metadata  Additional metadata about the error
+     * @param  string  $type  The entry type ('error' or 'warning')
+     * @param  string  $timestamp  ISO 8601 timestamp when the entry was created
+     * @param  array<int, array<string, mixed>>|null  $trace  Stack trace (only for errors)
+     * @param  AnalyzerErrorType|null  $errorType  Categorized error type
+     */
+    private function __construct(
+        public string $context,
+        public string $message,
+        public array $metadata,
+        public string $type,
+        public string $timestamp,
+        public ?array $trace,
+        public ?AnalyzerErrorType $errorType,
+    ) {}
+
+    /**
+     * Create an error entry with stack trace.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    public static function error(
+        string $context,
+        string $message,
+        array $metadata = [],
+        ?AnalyzerErrorType $errorType = null,
+    ): self {
+        return new self(
+            context: $context,
+            message: $message,
+            metadata: $metadata,
+            type: self::TYPE_ERROR,
+            timestamp: now()->toIso8601String(),
+            trace: debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 5),
+            errorType: $errorType,
+        );
+    }
+
+    /**
+     * Create a warning entry without stack trace.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    public static function warning(
+        string $context,
+        string $message,
+        array $metadata = [],
+        ?AnalyzerErrorType $errorType = null,
+    ): self {
+        return new self(
+            context: $context,
+            message: $message,
+            metadata: $metadata,
+            type: self::TYPE_WARNING,
+            timestamp: now()->toIso8601String(),
+            trace: null,
+            errorType: $errorType,
+        );
+    }
+
+    /**
+     * Check if this entry is an error.
+     */
+    public function isError(): bool
+    {
+        return $this->type === self::TYPE_ERROR;
+    }
+
+    /**
+     * Check if this entry is a warning.
+     */
+    public function isWarning(): bool
+    {
+        return $this->type === self::TYPE_WARNING;
+    }
+
+    /**
+     * Create from an array.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $errorType = null;
+        if (isset($data['errorType']) && is_string($data['errorType'])) {
+            $errorType = AnalyzerErrorType::tryFrom($data['errorType']);
+        }
+
+        return new self(
+            context: $data['context'] ?? '',
+            message: $data['message'] ?? '',
+            metadata: $data['metadata'] ?? [],
+            type: $data['type'] ?? self::TYPE_ERROR,
+            timestamp: $data['timestamp'] ?? now()->toIso8601String(),
+            trace: $data['trace'] ?? null,
+            errorType: $errorType,
+        );
+    }
+
+    /**
+     * Convert to array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $result = [
+            'context' => $this->context,
+            'message' => $this->message,
+            'metadata' => $this->metadata,
+            'type' => $this->type,
+            'timestamp' => $this->timestamp,
+        ];
+
+        if ($this->trace !== null) {
+            $result['trace'] = $this->trace;
+        }
+
+        if ($this->errorType !== null) {
+            $result['errorType'] = $this->errorType->value;
+        }
+
+        return $result;
+    }
+}

--- a/src/Support/ErrorCollector.php
+++ b/src/Support/ErrorCollector.php
@@ -1,11 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Support;
+
+use LaravelSpectrum\DTO\ErrorEntry;
 
 class ErrorCollector
 {
+    /** @var array<int, ErrorEntry> */
     private array $errors = [];
 
+    /** @var array<int, ErrorEntry> */
     private array $warnings = [];
 
     private bool $failOnError = false;
@@ -15,29 +21,36 @@ class ErrorCollector
         $this->failOnError = $failOnError;
     }
 
+    /**
+     * Add an error entry.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
     public function addError(string $context, string $message, array $metadata = []): void
     {
-        $this->errors[] = [
-            'context' => $context,
-            'message' => $message,
-            'metadata' => $metadata,
-            'timestamp' => now()->toIso8601String(),
-            'trace' => debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 5),
-        ];
+        $this->errors[] = ErrorEntry::error(
+            context: $context,
+            message: $message,
+            metadata: $metadata,
+        );
 
         if ($this->failOnError) {
             throw new \RuntimeException("Error in {$context}: {$message}");
         }
     }
 
+    /**
+     * Add a warning entry.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
     public function addWarning(string $context, string $message, array $metadata = []): void
     {
-        $this->warnings[] = [
-            'context' => $context,
-            'message' => $message,
-            'metadata' => $metadata,
-            'timestamp' => now()->toIso8601String(),
-        ];
+        $this->warnings[] = ErrorEntry::warning(
+            context: $context,
+            message: $message,
+            metadata: $metadata,
+        );
     }
 
     public function hasErrors(): bool
@@ -45,16 +58,51 @@ class ErrorCollector
         return count($this->errors) > 0;
     }
 
+    /**
+     * Get all error entries.
+     *
+     * @return array<int, ErrorEntry>
+     */
     public function getErrors(): array
     {
         return $this->errors;
     }
 
+    /**
+     * Get all warning entries.
+     *
+     * @return array<int, ErrorEntry>
+     */
     public function getWarnings(): array
     {
         return $this->warnings;
     }
 
+    /**
+     * Get all errors as arrays (for backward compatibility).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getErrorsAsArray(): array
+    {
+        return array_map(fn (ErrorEntry $e) => $e->toArray(), $this->errors);
+    }
+
+    /**
+     * Get all warnings as arrays (for backward compatibility).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getWarningsAsArray(): array
+    {
+        return array_map(fn (ErrorEntry $e) => $e->toArray(), $this->warnings);
+    }
+
+    /**
+     * Generate a report with all errors and warnings.
+     *
+     * @return array{summary: array{total_errors: int, total_warnings: int, generated_at: string}, errors: array<int, array<string, mixed>>, warnings: array<int, array<string, mixed>>}
+     */
     public function generateReport(): array
     {
         return [
@@ -63,8 +111,8 @@ class ErrorCollector
                 'total_warnings' => count($this->warnings),
                 'generated_at' => now()->toIso8601String(),
             ],
-            'errors' => $this->errors,
-            'warnings' => $this->warnings,
+            'errors' => $this->getErrorsAsArray(),
+            'warnings' => $this->getWarningsAsArray(),
         ];
     }
 }

--- a/tests/Unit/Analyzers/FractalTransformerAnalyzerTest.php
+++ b/tests/Unit/Analyzers/FractalTransformerAnalyzerTest.php
@@ -177,8 +177,8 @@ class FractalTransformerAnalyzerTest extends TestCase
 
         $warnings = $errorCollector->getWarnings();
         $this->assertNotEmpty($warnings);
-        $this->assertEquals('class_not_found', $warnings[0]['metadata']['error_type']);
-        $this->assertStringContainsString('NonExistentTransformerClass', $warnings[0]['message']);
+        $this->assertEquals('class_not_found', $warnings[0]->metadata['error_type']);
+        $this->assertStringContainsString('NonExistentTransformerClass', $warnings[0]->message);
     }
 
     #[Test]
@@ -196,8 +196,8 @@ class FractalTransformerAnalyzerTest extends TestCase
 
         $warnings = $errorCollector->getWarnings();
         $this->assertNotEmpty($warnings);
-        $this->assertEquals('invalid_parent_class', $warnings[0]['metadata']['error_type']);
-        $this->assertStringContainsString('stdClass', $warnings[0]['message']);
+        $this->assertEquals('invalid_parent_class', $warnings[0]->metadata['error_type']);
+        $this->assertStringContainsString('stdClass', $warnings[0]->message);
     }
 
     // ========== Additional coverage tests ==========
@@ -298,7 +298,7 @@ class FractalTransformerAnalyzerTest extends TestCase
         $this->assertEmpty($result);
         $warnings = $errorCollector->getWarnings();
         $this->assertNotEmpty($warnings, 'Expected warning for class_node_not_found');
-        $this->assertEquals('class_node_not_found', $warnings[0]['metadata']['error_type']);
+        $this->assertEquals('class_node_not_found', $warnings[0]->metadata['error_type']);
     }
 
     #[Test]

--- a/tests/Unit/Analyzers/Support/AnonymousClassAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Support/AnonymousClassAnalyzerTest.php
@@ -248,8 +248,8 @@ class AnonymousClassAnalyzerTest extends TestCase
 
         $errors = $this->errorCollector->getErrors();
         $this->assertNotEmpty($errors);
-        $this->assertStringContainsString('Test error', $errors[0]['message']);
-        $this->assertEquals('Exception', $errors[0]['metadata']['exception_class']);
+        $this->assertStringContainsString('Test error', $errors[0]->message);
+        $this->assertEquals('Exception', $errors[0]->metadata['exception_class']);
     }
 
     #[Test]
@@ -264,8 +264,8 @@ class AnonymousClassAnalyzerTest extends TestCase
 
         $errors = $this->errorCollector->getErrors();
         $this->assertNotEmpty($errors);
-        $this->assertStringContainsString('Details extraction error', $errors[0]['message']);
-        $this->assertEquals('Exception', $errors[0]['metadata']['exception_class']);
+        $this->assertStringContainsString('Details extraction error', $errors[0]->message);
+        $this->assertEquals('Exception', $errors[0]->metadata['exception_class']);
     }
 
     // ========== Edge cases ==========
@@ -391,8 +391,8 @@ class AnonymousClassAnalyzerTest extends TestCase
 
         $warnings = $this->errorCollector->getWarnings();
         $this->assertNotEmpty($warnings);
-        $this->assertStringContainsString('Parser returned null AST', $warnings[0]['message']);
-        $this->assertEquals('anonymous_ast_null_result', $warnings[0]['metadata']['error_type']);
+        $this->assertStringContainsString('Parser returned null AST', $warnings[0]->message);
+        $this->assertEquals('anonymous_ast_null_result', $warnings[0]->metadata['error_type']);
 
         unlink($tempFile);
     }
@@ -433,8 +433,8 @@ class AnonymousClassAnalyzerTest extends TestCase
 
         $warnings = $this->errorCollector->getWarnings();
         $this->assertNotEmpty($warnings);
-        $this->assertStringContainsString('Anonymous class node not found', $warnings[0]['message']);
-        $this->assertEquals('anonymous_class_node_not_found', $warnings[0]['metadata']['error_type']);
+        $this->assertStringContainsString('Anonymous class node not found', $warnings[0]->message);
+        $this->assertEquals('anonymous_class_node_not_found', $warnings[0]->metadata['error_type']);
 
         unlink($tempFile);
     }
@@ -475,9 +475,9 @@ class AnonymousClassAnalyzerTest extends TestCase
 
         $warnings = $this->errorCollector->getWarnings();
         $this->assertNotEmpty($warnings);
-        $this->assertStringContainsString('Failed to parse anonymous class AST', $warnings[0]['message']);
-        $this->assertEquals('anonymous_ast_parse_error', $warnings[0]['metadata']['error_type']);
-        $this->assertEquals('PhpParser\\Error', $warnings[0]['metadata']['exception_class']);
+        $this->assertStringContainsString('Failed to parse anonymous class AST', $warnings[0]->message);
+        $this->assertEquals('anonymous_ast_parse_error', $warnings[0]->metadata['error_type']);
+        $this->assertEquals('PhpParser\\Error', $warnings[0]->metadata['exception_class']);
 
         unlink($tempFile);
     }
@@ -512,7 +512,7 @@ class AnonymousClassAnalyzerTest extends TestCase
         $errors = $this->errorCollector->getErrors();
         $this->assertNotEmpty($errors);
         // In PHP 8.x, file_get_contents on a directory throws, which is caught by outer handler
-        $this->assertStringContainsString('file_get_contents', $errors[0]['message']);
+        $this->assertStringContainsString('file_get_contents', $errors[0]->message);
 
         rmdir($tempDir);
     }
@@ -542,8 +542,8 @@ class AnonymousClassAnalyzerTest extends TestCase
 
         $warnings = $this->errorCollector->getWarnings();
         $this->assertNotEmpty($warnings);
-        $this->assertStringContainsString('Line information not available', $warnings[0]['message']);
-        $this->assertEquals('anonymous_line_info_unavailable', $warnings[0]['metadata']['error_type']);
+        $this->assertStringContainsString('Line information not available', $warnings[0]->message);
+        $this->assertEquals('anonymous_line_info_unavailable', $warnings[0]->metadata['error_type']);
 
         unlink($tempFile);
     }
@@ -619,7 +619,7 @@ class AnonymousClassAnalyzerTest extends TestCase
 
         // Should log a warning about fallback
         $warnings = $this->errorCollector->getWarnings();
-        $fallbackWarnings = array_filter($warnings, fn ($w) => isset($w['metadata']['error_type']) && $w['metadata']['error_type'] === 'anonymous_conditional_rules_fallback');
+        $fallbackWarnings = array_filter($warnings, fn ($w) => isset($w->metadata['error_type']) && $w->metadata['error_type'] === 'anonymous_conditional_rules_fallback');
         $this->assertNotEmpty($fallbackWarnings, 'Expected fallback warning to be logged');
 
         unlink($tempFile);
@@ -661,7 +661,7 @@ class AnonymousClassAnalyzerTest extends TestCase
         $analyzer->analyzeWithConditionalRules($reflection);
 
         $warnings = $this->errorCollector->getWarnings();
-        $astNullWarnings = array_filter($warnings, fn ($w) => str_contains($w['metadata']['error_type'], 'ast_null'));
+        $astNullWarnings = array_filter($warnings, fn ($w) => str_contains($w->metadata['error_type'], 'ast_null'));
         $this->assertNotEmpty($astNullWarnings);
 
         unlink($tempFile);
@@ -682,9 +682,9 @@ class AnonymousClassAnalyzerTest extends TestCase
 
         $errors = $this->errorCollector->getErrors();
         $this->assertNotEmpty($errors);
-        $this->assertStringContainsString('Conditional test error', $errors[0]['message']);
+        $this->assertStringContainsString('Conditional test error', $errors[0]->message);
         // Exception is caught by analyze() fallback, so error type is from analyze()
-        $this->assertEquals('anonymous_reflection_analysis_error', $errors[0]['metadata']['error_type']);
+        $this->assertEquals('anonymous_reflection_analysis_error', $errors[0]->metadata['error_type']);
     }
 
     // ========== invokeMethodSafely() tests ==========
@@ -709,9 +709,9 @@ class AnonymousClassAnalyzerTest extends TestCase
 
         $errors = $this->errorCollector->getErrors();
         $this->assertNotEmpty($errors);
-        $this->assertStringContainsString('Failed to invoke rules()', $errors[0]['message']);
-        $this->assertEquals('anonymous_method_invocation_error', $errors[0]['metadata']['error_type']);
-        $this->assertEquals('RuntimeException', $errors[0]['metadata']['exception_class']);
+        $this->assertStringContainsString('Failed to invoke rules()', $errors[0]->message);
+        $this->assertEquals('anonymous_method_invocation_error', $errors[0]->metadata['error_type']);
+        $this->assertEquals('RuntimeException', $errors[0]->metadata['exception_class']);
     }
 
     #[Test]
@@ -741,9 +741,9 @@ class AnonymousClassAnalyzerTest extends TestCase
 
         // Warning should be logged for non-critical method failure
         $warnings = $this->errorCollector->getWarnings();
-        $attributeWarnings = array_filter($warnings, fn ($w) => str_contains($w['message'], 'attributes'));
+        $attributeWarnings = array_filter($warnings, fn ($w) => str_contains($w->message, 'attributes'));
         $this->assertNotEmpty($attributeWarnings);
-        $this->assertEquals('anonymous_non_critical_method_failure', array_values($attributeWarnings)[0]['metadata']['error_type']);
+        $this->assertEquals('anonymous_non_critical_method_failure', array_values($attributeWarnings)[0]->metadata['error_type']);
     }
 
     // ========== Additional edge case tests ==========
@@ -797,7 +797,7 @@ class AnonymousClassAnalyzerTest extends TestCase
         $analyzer->analyzeWithConditionalRules($reflection);
 
         $warnings = $this->errorCollector->getWarnings();
-        $parseErrorWarnings = array_filter($warnings, fn ($w) => $w['metadata']['error_type'] === 'anonymous_conditional_ast_parse_error');
+        $parseErrorWarnings = array_filter($warnings, fn ($w) => $w->metadata['error_type'] === 'anonymous_conditional_ast_parse_error');
         $this->assertNotEmpty($parseErrorWarnings, 'Expected conditional AST parse error warning');
 
         unlink($tempFile);
@@ -835,7 +835,7 @@ class AnonymousClassAnalyzerTest extends TestCase
         $analyzer->analyzeWithConditionalRules($reflection);
 
         $warnings = $this->errorCollector->getWarnings();
-        $nodeNotFoundWarnings = array_filter($warnings, fn ($w) => $w['metadata']['error_type'] === 'anonymous_conditional_class_node_not_found');
+        $nodeNotFoundWarnings = array_filter($warnings, fn ($w) => $w->metadata['error_type'] === 'anonymous_conditional_class_node_not_found');
         $this->assertNotEmpty($nodeNotFoundWarnings, 'Expected conditional class node not found warning');
 
         unlink($tempFile);

--- a/tests/Unit/Analyzers/Support/AstHelperTest.php
+++ b/tests/Unit/Analyzers/Support/AstHelperTest.php
@@ -50,7 +50,7 @@ class AstHelperTest extends TestCase
 
         $warnings = $this->errorCollector->getWarnings();
         $this->assertNotEmpty($warnings);
-        $this->assertEquals('file_not_found', $warnings[0]['metadata']['error_type']);
+        $this->assertEquals('file_not_found', $warnings[0]->metadata['error_type']);
     }
 
     #[Test]
@@ -66,8 +66,8 @@ class AstHelperTest extends TestCase
 
             $errors = $this->errorCollector->getErrors();
             $this->assertNotEmpty($errors);
-            $this->assertEquals('parse_error', $errors[0]['metadata']['error_type']);
-            $this->assertStringContainsString($tempFile, $errors[0]['metadata']['file_path']);
+            $this->assertEquals('parse_error', $errors[0]->metadata['error_type']);
+            $this->assertStringContainsString($tempFile, $errors[0]->metadata['file_path']);
         } finally {
             unlink($tempFile);
         }
@@ -108,7 +108,7 @@ PHP;
 
         $errors = $this->errorCollector->getErrors();
         $this->assertNotEmpty($errors);
-        $this->assertEquals('parse_error', $errors[0]['metadata']['error_type']);
+        $this->assertEquals('parse_error', $errors[0]->metadata['error_type']);
     }
 
     #[Test]
@@ -122,7 +122,7 @@ PHP;
 
         $errors = $this->errorCollector->getErrors();
         $this->assertNotEmpty($errors);
-        $this->assertEquals('test/file.php', $errors[0]['metadata']['file_path']);
+        $this->assertEquals('test/file.php', $errors[0]->metadata['file_path']);
     }
 
     #[Test]

--- a/tests/Unit/Analyzers/Support/FormRequestAstExtractorTest.php
+++ b/tests/Unit/Analyzers/Support/FormRequestAstExtractorTest.php
@@ -126,7 +126,7 @@ PHP;
 
         $errors = $this->errorCollector->getErrors();
         $this->assertNotEmpty($errors);
-        $this->assertEquals('parse_error', $errors[0]['metadata']['error_type']);
+        $this->assertEquals('parse_error', $errors[0]->metadata['error_type']);
     }
 
     #[Test]
@@ -143,8 +143,8 @@ PHP;
 
             $errors = $this->errorCollector->getErrors();
             $this->assertNotEmpty($errors);
-            $this->assertEquals('parse_error', $errors[0]['metadata']['error_type']);
-            $this->assertStringContainsString($tempFile, $errors[0]['metadata']['file_path']);
+            $this->assertEquals('parse_error', $errors[0]->metadata['error_type']);
+            $this->assertStringContainsString($tempFile, $errors[0]->metadata['file_path']);
         } finally {
             unlink($tempFile);
         }
@@ -159,7 +159,7 @@ PHP;
 
         $warnings = $this->errorCollector->getWarnings();
         $this->assertNotEmpty($warnings);
-        $this->assertEquals('file_not_found', $warnings[0]['metadata']['error_type']);
+        $this->assertEquals('file_not_found', $warnings[0]->metadata['error_type']);
     }
 
     // ========== Empty file/code handling tests ==========

--- a/tests/Unit/DTO/ErrorEntryTest.php
+++ b/tests/Unit/DTO/ErrorEntryTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\DTO;
+
+use LaravelSpectrum\DTO\ErrorEntry;
+use LaravelSpectrum\Support\AnalyzerErrorType;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ErrorEntryTest extends TestCase
+{
+    #[Test]
+    public function it_creates_error_entry(): void
+    {
+        $entry = ErrorEntry::error(
+            context: 'TestAnalyzer',
+            message: 'Something went wrong',
+            metadata: ['file' => 'test.php'],
+        );
+
+        $this->assertEquals('TestAnalyzer', $entry->context);
+        $this->assertEquals('Something went wrong', $entry->message);
+        $this->assertEquals(['file' => 'test.php'], $entry->metadata);
+        $this->assertTrue($entry->isError());
+        $this->assertFalse($entry->isWarning());
+        $this->assertNotNull($entry->timestamp);
+        $this->assertNotNull($entry->trace);
+    }
+
+    #[Test]
+    public function it_creates_warning_entry(): void
+    {
+        $entry = ErrorEntry::warning(
+            context: 'TestAnalyzer',
+            message: 'Something might be wrong',
+            metadata: ['line' => 42],
+        );
+
+        $this->assertEquals('TestAnalyzer', $entry->context);
+        $this->assertEquals('Something might be wrong', $entry->message);
+        $this->assertEquals(['line' => 42], $entry->metadata);
+        $this->assertFalse($entry->isError());
+        $this->assertTrue($entry->isWarning());
+        $this->assertNotNull($entry->timestamp);
+        $this->assertNull($entry->trace);
+    }
+
+    #[Test]
+    public function it_creates_entry_with_empty_metadata(): void
+    {
+        $entry = ErrorEntry::error(
+            context: 'TestAnalyzer',
+            message: 'Error without metadata',
+        );
+
+        $this->assertEquals([], $entry->metadata);
+    }
+
+    #[Test]
+    public function it_creates_entry_with_error_type(): void
+    {
+        $entry = ErrorEntry::error(
+            context: 'FormRequestAnalyzer',
+            message: 'Failed to analyze',
+            metadata: [],
+            errorType: AnalyzerErrorType::AnalysisError,
+        );
+
+        $this->assertEquals(AnalyzerErrorType::AnalysisError, $entry->errorType);
+    }
+
+    #[Test]
+    public function it_converts_to_array(): void
+    {
+        $entry = ErrorEntry::error(
+            context: 'TestAnalyzer',
+            message: 'Test error',
+            metadata: ['key' => 'value'],
+        );
+
+        $array = $entry->toArray();
+
+        $this->assertEquals('TestAnalyzer', $array['context']);
+        $this->assertEquals('Test error', $array['message']);
+        $this->assertEquals(['key' => 'value'], $array['metadata']);
+        $this->assertEquals('error', $array['type']);
+        $this->assertArrayHasKey('timestamp', $array);
+        $this->assertArrayHasKey('trace', $array);
+    }
+
+    #[Test]
+    public function it_converts_warning_to_array_without_trace(): void
+    {
+        $entry = ErrorEntry::warning(
+            context: 'TestAnalyzer',
+            message: 'Test warning',
+        );
+
+        $array = $entry->toArray();
+
+        $this->assertEquals('warning', $array['type']);
+        $this->assertArrayNotHasKey('trace', $array);
+    }
+
+    #[Test]
+    public function it_creates_from_array(): void
+    {
+        $data = [
+            'context' => 'TestAnalyzer',
+            'message' => 'Restored error',
+            'metadata' => ['restored' => true],
+            'type' => 'error',
+            'timestamp' => '2024-01-01T00:00:00+00:00',
+            'trace' => [['file' => 'test.php', 'line' => 10]],
+        ];
+
+        $entry = ErrorEntry::fromArray($data);
+
+        $this->assertEquals('TestAnalyzer', $entry->context);
+        $this->assertEquals('Restored error', $entry->message);
+        $this->assertEquals(['restored' => true], $entry->metadata);
+        $this->assertTrue($entry->isError());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $entry->timestamp);
+        $this->assertEquals([['file' => 'test.php', 'line' => 10]], $entry->trace);
+    }
+
+    #[Test]
+    public function it_creates_warning_from_array(): void
+    {
+        $data = [
+            'context' => 'TestAnalyzer',
+            'message' => 'Restored warning',
+            'type' => 'warning',
+            'timestamp' => '2024-01-01T00:00:00+00:00',
+        ];
+
+        $entry = ErrorEntry::fromArray($data);
+
+        $this->assertTrue($entry->isWarning());
+        $this->assertNull($entry->trace);
+    }
+
+    #[Test]
+    public function it_survives_serialization_round_trip(): void
+    {
+        $original = ErrorEntry::error(
+            context: 'TestAnalyzer',
+            message: 'Round trip test',
+            metadata: ['test' => 'data'],
+        );
+
+        $restored = ErrorEntry::fromArray($original->toArray());
+
+        $this->assertEquals($original->context, $restored->context);
+        $this->assertEquals($original->message, $restored->message);
+        $this->assertEquals($original->metadata, $restored->metadata);
+        $this->assertEquals($original->isError(), $restored->isError());
+        $this->assertEquals($original->timestamp, $restored->timestamp);
+    }
+
+    #[Test]
+    public function it_includes_error_type_in_array_when_present(): void
+    {
+        $entry = ErrorEntry::error(
+            context: 'TestAnalyzer',
+            message: 'Typed error',
+            errorType: AnalyzerErrorType::UnsupportedFeature,
+        );
+
+        $array = $entry->toArray();
+
+        $this->assertEquals('unsupported_feature', $array['errorType']);
+    }
+
+    #[Test]
+    public function it_restores_error_type_from_array(): void
+    {
+        $data = [
+            'context' => 'TestAnalyzer',
+            'message' => 'Typed error',
+            'type' => 'error',
+            'timestamp' => '2024-01-01T00:00:00+00:00',
+            'errorType' => 'analysis_error',
+        ];
+
+        $entry = ErrorEntry::fromArray($data);
+
+        $this->assertEquals(AnalyzerErrorType::AnalysisError, $entry->errorType);
+    }
+}

--- a/tests/Unit/FormRequestAnalyzerTest.php
+++ b/tests/Unit/FormRequestAnalyzerTest.php
@@ -981,7 +981,7 @@ class FormRequestAnalyzerTest extends TestCase
         // Check that the warning was logged with correct type
         $warnings = $analyzer->getErrorCollector()->getWarnings();
         $this->assertTrue(
-            collect($warnings)->contains(fn ($warning) => str_contains($warning['message'], 'Class node not found'))
+            collect($warnings)->contains(fn ($warning) => str_contains($warning->message, 'Class node not found'))
         );
     }
 

--- a/tests/Unit/RouteAnalyzerAdvancedTest.php
+++ b/tests/Unit/RouteAnalyzerAdvancedTest.php
@@ -190,8 +190,8 @@ PHP;
         // Assert
         $errors = $this->errorCollector->getErrors();
         $this->assertCount(1, $errors);
-        $this->assertStringContainsString('Failed to load route file', $errors[0]['message']);
-        $this->assertStringContainsString('Route loading error', $errors[0]['message']);
+        $this->assertStringContainsString('Failed to load route file', $errors[0]->message);
+        $this->assertStringContainsString('Route loading error', $errors[0]->message);
 
         // Cleanup
         unlink($tempFile);

--- a/tests/Unit/Support/ErrorCollectorTest.php
+++ b/tests/Unit/Support/ErrorCollectorTest.php
@@ -1,13 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Tests\Unit\Support;
 
+use LaravelSpectrum\DTO\ErrorEntry;
 use LaravelSpectrum\Support\ErrorCollector;
 use LaravelSpectrum\Tests\TestCase;
 
 class ErrorCollectorTest extends TestCase
 {
-    public function test_collects_errors_without_throwing()
+    public function test_collects_errors_without_throwing(): void
     {
         $collector = new ErrorCollector(failOnError: false);
 
@@ -17,14 +20,15 @@ class ErrorCollectorTest extends TestCase
         $this->assertCount(1, $collector->getErrors());
 
         $errors = $collector->getErrors();
-        $this->assertEquals('TestContext', $errors[0]['context']);
-        $this->assertEquals('Test error message', $errors[0]['message']);
-        $this->assertEquals(['key' => 'value'], $errors[0]['metadata']);
-        $this->assertArrayHasKey('timestamp', $errors[0]);
-        $this->assertArrayHasKey('trace', $errors[0]);
+        $this->assertInstanceOf(ErrorEntry::class, $errors[0]);
+        $this->assertEquals('TestContext', $errors[0]->context);
+        $this->assertEquals('Test error message', $errors[0]->message);
+        $this->assertEquals(['key' => 'value'], $errors[0]->metadata);
+        $this->assertNotEmpty($errors[0]->timestamp);
+        $this->assertNotNull($errors[0]->trace);
     }
 
-    public function test_throws_on_error_when_configured()
+    public function test_throws_on_error_when_configured(): void
     {
         $collector = new ErrorCollector(failOnError: true);
 
@@ -34,7 +38,7 @@ class ErrorCollectorTest extends TestCase
         $collector->addError('TestContext', 'Test error message');
     }
 
-    public function test_collects_warnings()
+    public function test_collects_warnings(): void
     {
         $collector = new ErrorCollector;
 
@@ -44,12 +48,14 @@ class ErrorCollectorTest extends TestCase
         $this->assertCount(1, $collector->getWarnings());
 
         $warnings = $collector->getWarnings();
-        $this->assertEquals('WarningContext', $warnings[0]['context']);
-        $this->assertEquals('Warning message', $warnings[0]['message']);
-        $this->assertEquals(['severity' => 'low'], $warnings[0]['metadata']);
+        $this->assertInstanceOf(ErrorEntry::class, $warnings[0]);
+        $this->assertEquals('WarningContext', $warnings[0]->context);
+        $this->assertEquals('Warning message', $warnings[0]->message);
+        $this->assertEquals(['severity' => 'low'], $warnings[0]->metadata);
+        $this->assertNull($warnings[0]->trace);
     }
 
-    public function test_generates_comprehensive_report()
+    public function test_generates_comprehensive_report(): void
     {
         $collector = new ErrorCollector;
 
@@ -65,9 +71,13 @@ class ErrorCollectorTest extends TestCase
 
         $this->assertCount(2, $report['errors']);
         $this->assertCount(1, $report['warnings']);
+
+        // Report should contain arrays (converted from DTOs)
+        $this->assertIsArray($report['errors'][0]);
+        $this->assertEquals('Context1', $report['errors'][0]['context']);
     }
 
-    public function test_empty_collector_report()
+    public function test_empty_collector_report(): void
     {
         $collector = new ErrorCollector;
 
@@ -79,16 +89,34 @@ class ErrorCollectorTest extends TestCase
         $this->assertEmpty($report['warnings']);
     }
 
-    public function test_error_trace_limited_to_5_frames()
+    public function test_error_trace_limited_to_5_frames(): void
     {
         $collector = new ErrorCollector;
 
         $collector->addError('TestContext', 'Test error');
 
         $errors = $collector->getErrors();
-        $trace = $errors[0]['trace'];
+        $this->assertInstanceOf(ErrorEntry::class, $errors[0]);
+        $trace = $errors[0]->trace;
 
         $this->assertIsArray($trace);
         $this->assertLessThanOrEqual(5, count($trace));
+    }
+
+    public function test_error_entry_is_error_type(): void
+    {
+        $collector = new ErrorCollector;
+
+        $collector->addError('TestContext', 'Test error');
+        $collector->addWarning('TestContext', 'Test warning');
+
+        $errors = $collector->getErrors();
+        $warnings = $collector->getWarnings();
+
+        $this->assertTrue($errors[0]->isError());
+        $this->assertFalse($errors[0]->isWarning());
+
+        $this->assertFalse($warnings[0]->isError());
+        $this->assertTrue($warnings[0]->isWarning());
     }
 }

--- a/tests/Unit/Support/HasErrorCollectionTest.php
+++ b/tests/Unit/Support/HasErrorCollectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaravelSpectrum\Tests\Unit\Support;
 
+use LaravelSpectrum\DTO\ErrorEntry;
 use LaravelSpectrum\Support\AnalyzerErrorType;
 use LaravelSpectrum\Support\ErrorCollector;
 use LaravelSpectrum\Support\HasErrorCollection;
@@ -100,10 +101,11 @@ class HasErrorCollectionTest extends TestCase
         $this->assertCount(1, $errors);
 
         $error = $errors[0];
-        $this->assertEquals(TestClassWithErrorCollection::class, $error['context']);
-        $this->assertEquals('Test error message', $error['message']);
-        $this->assertEquals(AnalyzerErrorType::ParseError->value, $error['metadata']['error_type']);
-        $this->assertEquals('TestClass', $error['metadata']['class']);
+        $this->assertInstanceOf(ErrorEntry::class, $error);
+        $this->assertEquals(TestClassWithErrorCollection::class, $error->context);
+        $this->assertEquals('Test error message', $error->message);
+        $this->assertEquals(AnalyzerErrorType::ParseError->value, $error->metadata['error_type']);
+        $this->assertEquals('TestClass', $error->metadata['class']);
     }
 
     #[Test]
@@ -123,10 +125,11 @@ class HasErrorCollectionTest extends TestCase
         $this->assertCount(1, $warnings);
 
         $warning = $warnings[0];
-        $this->assertEquals(TestClassWithErrorCollection::class, $warning['context']);
-        $this->assertEquals('Test warning message', $warning['message']);
-        $this->assertEquals(AnalyzerErrorType::UnsupportedFeature->value, $warning['metadata']['error_type']);
-        $this->assertEquals('advanced', $warning['metadata']['feature']);
+        $this->assertInstanceOf(ErrorEntry::class, $warning);
+        $this->assertEquals(TestClassWithErrorCollection::class, $warning->context);
+        $this->assertEquals('Test warning message', $warning->message);
+        $this->assertEquals(AnalyzerErrorType::UnsupportedFeature->value, $warning->metadata['error_type']);
+        $this->assertEquals('advanced', $warning->metadata['feature']);
     }
 
     #[Test]
@@ -148,14 +151,15 @@ class HasErrorCollectionTest extends TestCase
         $this->assertCount(1, $errors);
 
         $error = $errors[0];
-        $this->assertEquals(TestClassWithErrorCollection::class, $error['context']);
-        $this->assertEquals('Something went wrong', $error['message']);
-        $this->assertEquals(AnalyzerErrorType::AnalysisError->value, $error['metadata']['error_type']);
-        $this->assertEquals(\RuntimeException::class, $error['metadata']['exception_class']);
-        $this->assertArrayHasKey('file', $error['metadata']);
-        $this->assertArrayHasKey('line', $error['metadata']);
-        $this->assertArrayHasKey('trace', $error['metadata']);
-        $this->assertEquals('processing', $error['metadata']['action']);
+        $this->assertInstanceOf(ErrorEntry::class, $error);
+        $this->assertEquals(TestClassWithErrorCollection::class, $error->context);
+        $this->assertEquals('Something went wrong', $error->message);
+        $this->assertEquals(AnalyzerErrorType::AnalysisError->value, $error->metadata['error_type']);
+        $this->assertEquals(\RuntimeException::class, $error->metadata['exception_class']);
+        $this->assertArrayHasKey('file', $error->metadata);
+        $this->assertArrayHasKey('line', $error->metadata);
+        $this->assertArrayHasKey('trace', $error->metadata);
+        $this->assertEquals('processing', $error->metadata['action']);
     }
 
     #[Test]
@@ -194,7 +198,8 @@ class HasErrorCollectionTest extends TestCase
         $this->assertCount(count($errorTypes), $errors);
 
         foreach ($errors as $index => $error) {
-            $this->assertEquals($errorTypes[$index]->value, $error['metadata']['error_type']);
+            $this->assertInstanceOf(ErrorEntry::class, $error);
+            $this->assertEquals($errorTypes[$index]->value, $error->metadata['error_type']);
         }
     }
 


### PR DESCRIPTION
## Summary

- Create `ErrorEntry` DTO with factory methods (`error`, `warning`)
- Add `isError()` and `isWarning()` type check methods
- Support `AnalyzerErrorType` enum for categorization
- Add `fromArray`/`toArray` methods for serialization
- Update `ErrorCollector` to use `ErrorEntry` internally
- Add `getErrorsAsArray`/`getWarningsAsArray` for backward compatibility
- Update all tests to use DTO properties instead of array access

## Changes

### New Files
- `src/DTO/ErrorEntry.php` - New DTO class
- `tests/Unit/DTO/ErrorEntryTest.php` - Comprehensive tests

### Modified Files
- `src/Support/ErrorCollector.php` - Use ErrorEntry internally
- Multiple test files - Updated to use DTO properties

## Design

The `ErrorEntry` DTO encapsulates error/warning entries with:

| Property | Type | Description |
|----------|------|-------------|
| `context` | `string` | Where the error occurred (e.g., analyzer name) |
| `message` | `string` | Error/warning message |
| `metadata` | `array` | Additional metadata |
| `type` | `string` | 'error' or 'warning' |
| `timestamp` | `string` | ISO 8601 timestamp |
| `trace` | `?array` | Stack trace (errors only) |
| `errorType` | `?AnalyzerErrorType` | Categorized error type |

### Factory Methods (Private Constructor)
```php
ErrorEntry::error('Context', 'Message', $metadata);   // Error with trace
ErrorEntry::warning('Context', 'Message', $metadata); // Warning without trace
```

### Backward Compatibility
- `generateReport()` returns arrays (unchanged API)
- `getErrorsAsArray()` / `getWarningsAsArray()` for legacy code
- `getErrors()` / `getWarnings()` return `ErrorEntry[]` for type-safe access

## Test plan

- [x] All existing tests pass (2871 tests)
- [x] New DTO tests added (11 test cases)
- [x] PHPStan passes
- [x] Laravel Pint passes