### PR TITLE
refactor: introduce ResourceFieldInfo DTO for API Resource field type info

### DIFF
--- a/src/Analyzers/AST/Visitors/ResourceStructureVisitor.php
+++ b/src/Analyzers/AST/Visitors/ResourceStructureVisitor.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Analyzers\AST\Visitors;
 
+use LaravelSpectrum\DTO\ResourceFieldInfo;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\PrettyPrinter;
@@ -17,10 +20,13 @@ use PhpParser\PrettyPrinter;
  */
 class ResourceStructureVisitor extends NodeVisitorAbstract
 {
+    /** @var array<string, ResourceFieldInfo> */
     private array $structure = [];
 
+    /** @var list<string> */
     private array $conditionalFields = [];
 
+    /** @var list<string> */
     private array $nestedResources = [];
 
     private PrettyPrinter\Standard $printer;
@@ -47,11 +53,13 @@ class ResourceStructureVisitor extends NodeVisitorAbstract
             }
             // array_merge()などの関数呼び出し
             elseif ($node->expr instanceof Node\Expr\FuncCall) {
-                $this->structure = $this->analyzeFunctionCall($node->expr);
+                $this->structure = $this->analyzeTopLevelFunctionCall($node->expr);
             }
             // 変数を返す場合
             elseif ($node->expr instanceof Node\Expr\Variable) {
-                $this->structure = ['_notice' => 'Dynamic structure detected - manual review required'];
+                $this->structure = [
+                    '_notice' => ResourceFieldInfo::withExpression('Dynamic structure detected - manual review required'),
+                ];
             }
         }
 
@@ -70,6 +78,8 @@ class ResourceStructureVisitor extends NodeVisitorAbstract
 
     /**
      * 配列構造を解析
+     *
+     * @return array<string, ResourceFieldInfo>
      */
     private function analyzeArrayStructure(Node\Expr\Array_ $array): array
     {
@@ -103,289 +113,291 @@ class ResourceStructureVisitor extends NodeVisitorAbstract
     /**
      * 値の型と構造を解析
      */
-    private function analyzeValue(Node $expr): array
+    private function analyzeValue(Node $expr): ResourceFieldInfo
     {
-        $info = [
-            'type' => 'mixed',
-            'nullable' => false,
-            'source' => null,
-            'example' => null,
-        ];
-
         // スカラー値
         if ($expr instanceof Node\Scalar\String_) {
-            $info['type'] = 'string';
-            $info['example'] = $expr->value;
-        } elseif ($expr instanceof Node\Scalar\LNumber) {
-            $info['type'] = 'integer';
-            $info['example'] = $expr->value;
-        } elseif ($expr instanceof Node\Scalar\DNumber) {
-            $info['type'] = 'number';
-            $info['example'] = $expr->value;
+            return ResourceFieldInfo::string()->withExample($expr->value);
+        }
+        if ($expr instanceof Node\Scalar\LNumber) {
+            return ResourceFieldInfo::integer()->withExample($expr->value);
+        }
+        if ($expr instanceof Node\Scalar\DNumber) {
+            return ResourceFieldInfo::number()->withExample($expr->value);
         }
 
         // $this->property
-        elseif ($expr instanceof Node\Expr\PropertyFetch &&
-                $expr->var instanceof Node\Expr\Variable &&
-                $expr->var->name === 'this') {
+        if ($expr instanceof Node\Expr\PropertyFetch &&
+            $expr->var instanceof Node\Expr\Variable &&
+            $expr->var->name === 'this') {
             $propertyName = $expr->name->toString();
-            $info = $this->analyzePropertyAccess($propertyName);
+
+            return $this->analyzePropertyAccess($propertyName);
         }
 
         // $this->property->method() (プロパティのメソッドチェーン)
-        elseif ($expr instanceof Node\Expr\MethodCall &&
-                $expr->var instanceof Node\Expr\PropertyFetch &&
-                $expr->var->var instanceof Node\Expr\Variable &&
-                $expr->var->var->name === 'this') {
+        if ($expr instanceof Node\Expr\MethodCall &&
+            $expr->var instanceof Node\Expr\PropertyFetch &&
+            $expr->var->var instanceof Node\Expr\Variable &&
+            $expr->var->var->name === 'this') {
             // プロパティに対するメソッド呼び出し
             $methodName = $expr->name->toString();
             if ($methodName === 'pluck') {
-                $info = ['type' => 'array'];
-            } else {
-                $info = $this->analyzeMethodChain($expr);
+                return ResourceFieldInfo::array();
             }
+
+            return $this->analyzeMethodChain($expr);
         }
 
         // $this->when()
-        elseif ($expr instanceof Node\Expr\MethodCall &&
-                $expr->var instanceof Node\Expr\Variable &&
-                $expr->var->name === 'this' &&
-                $expr->name->toString() === 'when') {
-            $info = $this->analyzeWhenMethod($expr);
+        if ($expr instanceof Node\Expr\MethodCall &&
+            $expr->var instanceof Node\Expr\Variable &&
+            $expr->var->name === 'this' &&
+            $expr->name->toString() === 'when') {
+            return $this->analyzeWhenMethod($expr);
         }
 
         // $this->whenLoaded()
-        elseif ($expr instanceof Node\Expr\MethodCall &&
-                $expr->var instanceof Node\Expr\Variable &&
-                $expr->var->name === 'this' &&
-                $expr->name->toString() === 'whenLoaded') {
-            $info = $this->analyzeWhenLoadedMethod($expr);
+        if ($expr instanceof Node\Expr\MethodCall &&
+            $expr->var instanceof Node\Expr\Variable &&
+            $expr->var->name === 'this' &&
+            $expr->name->toString() === 'whenLoaded') {
+            return $this->analyzeWhenLoadedMethod($expr);
         }
 
         // Resource::collection()
-        elseif ($expr instanceof Node\Expr\StaticCall) {
-            $info = $this->analyzeStaticCall($expr);
+        if ($expr instanceof Node\Expr\StaticCall) {
+            return $this->analyzeStaticCall($expr);
         }
 
         // new Resource()
-        elseif ($expr instanceof Node\Expr\New_) {
-            $info = $this->analyzeNewResource($expr);
+        if ($expr instanceof Node\Expr\New_) {
+            return $this->analyzeNewResource($expr);
         }
 
         // プロパティのメソッド/プロパティアクセス (例: $this->status->value)
-        elseif ($expr instanceof Node\Expr\PropertyFetch &&
-                $expr->var instanceof Node\Expr\PropertyFetch &&
-                $expr->var->var instanceof Node\Expr\Variable &&
-                $expr->var->var->name === 'this') {
+        if ($expr instanceof Node\Expr\PropertyFetch &&
+            $expr->var instanceof Node\Expr\PropertyFetch &&
+            $expr->var->var instanceof Node\Expr\Variable &&
+            $expr->var->var->name === 'this') {
             // $this->property->value のようなパターン
             $propertyName = $expr->name->toString();
             if ($propertyName === 'value') {
                 // Enumのvalueアクセス
-                $info = [
-                    'type' => 'string',
-                    'source' => 'enum',
-                ];
-            } else {
-                $info = ['type' => 'mixed'];
+                return ResourceFieldInfo::enum();
             }
+
+            return ResourceFieldInfo::mixed();
         }
 
         // Null-safe プロパティアクセス (例: $this->status?->value)
-        elseif ($expr instanceof Node\Expr\NullsafePropertyFetch) {
-            $info = $this->analyzeNullsafePropertyFetch($expr);
+        if ($expr instanceof Node\Expr\NullsafePropertyFetch) {
+            return $this->analyzeNullsafePropertyFetch($expr);
         }
 
         // Null-safe メソッド呼び出し (例: $this->created_at?->toDateTimeString())
-        elseif ($expr instanceof Node\Expr\NullsafeMethodCall) {
-            $info = $this->analyzeNullsafeMethodCall($expr);
+        if ($expr instanceof Node\Expr\NullsafeMethodCall) {
+            return $this->analyzeNullsafeMethodCall($expr);
         }
 
         // メソッドチェーン (例: $this->created_at->format())
-        elseif ($expr instanceof Node\Expr\MethodCall) {
-            $info = $this->analyzeMethodChain($expr);
+        if ($expr instanceof Node\Expr\MethodCall) {
+            return $this->analyzeMethodChain($expr);
         }
 
         // キャスト (例: (bool) $this->value)
-        elseif ($expr instanceof Node\Expr\Cast) {
-            $info = $this->analyzeCast($expr);
+        if ($expr instanceof Node\Expr\Cast) {
+            return $this->analyzeCast($expr);
         }
 
         // 配列
-        elseif ($expr instanceof Node\Expr\Array_) {
-            $info['type'] = 'object';
-            $info['properties'] = $this->analyzeArrayStructure($expr);
+        if ($expr instanceof Node\Expr\Array_) {
+            $properties = $this->convertToArrayFormat($this->analyzeArrayStructure($expr));
+
+            return ResourceFieldInfo::object()->withProperties($properties);
         }
 
         // 関数呼び出し (例: number_format())
-        elseif ($expr instanceof Node\Expr\FuncCall) {
-            $info = $this->analyzeFunctionCall($expr);
+        if ($expr instanceof Node\Expr\FuncCall) {
+            return $this->analyzeFunctionCall($expr);
         }
 
         // 文字列連結
-        elseif ($expr instanceof Node\Expr\BinaryOp\Concat) {
-            $info['type'] = 'string';
+        if ($expr instanceof Node\Expr\BinaryOp\Concat) {
+            return ResourceFieldInfo::string();
         }
 
         // その他の複雑な式
-        elseif ($expr instanceof Node\Expr) {
-            $info['expression'] = $this->printer->prettyPrintExpr($expr);
+        if ($expr instanceof Node\Expr) {
+            return ResourceFieldInfo::withExpression($this->printer->prettyPrintExpr($expr));
         }
 
-        return $info;
+        return ResourceFieldInfo::mixed();
     }
 
     /**
      * プロパティアクセスを解析
      */
-    private function analyzePropertyAccess(string $property): array
+    private function analyzePropertyAccess(string $property): ResourceFieldInfo
     {
-        $info = ['source' => 'property', 'property' => $property];
+        $type = $this->inferTypeFromPropertyName($property);
+        $example = $this->generateExampleFromProperty($property);
 
-        // プロパティ名から型を推論
-        $info['type'] = $this->inferTypeFromPropertyName($property);
-        $info['example'] = $this->generateExampleFromProperty($property);
-
-        return $info;
+        return ResourceFieldInfo::property($property, $type, $example);
     }
 
     /**
      * when()メソッドを解析
      */
-    private function analyzeWhenMethod(Node\Expr\MethodCall $call): array
+    private function analyzeWhenMethod(Node\Expr\MethodCall $call): ResourceFieldInfo
     {
-        $info = [
-            'type' => 'mixed',
-            'conditional' => true,
-            'condition' => 'when',
-        ];
+        $type = 'mixed';
 
         // 第2引数が値の場合
         if (isset($call->args[1])) {
             $valueNode = $call->args[1]->value;
 
-            // クロージャの場合
-            if ($valueNode instanceof Node\Expr\Closure) {
-                $info['type'] = 'mixed'; // クロージャの戻り値は解析が複雑
-            }
-            // 直接値の場合
-            else {
+            // クロージャでない場合は値を解析
+            if (! ($valueNode instanceof Node\Expr\Closure)) {
                 $valueInfo = $this->analyzeValue($valueNode);
-                $info = array_merge($info, $valueInfo);
+                $type = $valueInfo->type;
             }
         }
 
         $this->conditionalFields[] = $this->printer->prettyPrintExpr($call);
 
-        return $info;
+        return ResourceFieldInfo::conditional('when', $type);
     }
 
     /**
      * whenLoaded()メソッドを解析
      */
-    private function analyzeWhenLoadedMethod(Node\Expr\MethodCall $call): array
+    private function analyzeWhenLoadedMethod(Node\Expr\MethodCall $call): ResourceFieldInfo
     {
-        $info = [
-            'type' => 'mixed',
-            'conditional' => true,
-            'condition' => 'whenLoaded',
-        ];
+        $relation = null;
+        $type = 'mixed';
 
         if (isset($call->args[0])) {
-            $relation = $call->args[0]->value;
-            if ($relation instanceof Node\Scalar\String_) {
-                $info['relation'] = $relation->value;
+            $relationArg = $call->args[0]->value;
+            if ($relationArg instanceof Node\Scalar\String_) {
+                $relation = $relationArg->value;
 
                 // リレーション名から型を推論
-                if (str_ends_with($relation->value, 's')) {
-                    $info['type'] = 'array';
-                } else {
-                    $info['type'] = 'object';
-                }
+                $type = str_ends_with($relationArg->value, 's') ? 'array' : 'object';
             }
         }
 
         // 第2引数（クロージャ）がある場合
-        if (isset($call->args[1])) {
-            $info['hasTransformation'] = true;
-        }
+        $hasTransformation = isset($call->args[1]);
 
         $this->conditionalFields[] = $this->printer->prettyPrintExpr($call);
 
-        return $info;
+        if ($relation !== null) {
+            return ResourceFieldInfo::whenLoaded($relation, $type, $hasTransformation);
+        }
+
+        return ResourceFieldInfo::conditional('whenLoaded', $type);
     }
 
     /**
      * 静的メソッド呼び出しを解析（Resource::collection()など）
      */
-    private function analyzeStaticCall(Node\Expr\StaticCall $call): array
+    private function analyzeStaticCall(Node\Expr\StaticCall $call): ResourceFieldInfo
     {
-        $info = ['type' => 'mixed'];
-
         if ($call->class instanceof Node\Name) {
             $className = $call->class->toString();
 
             // ResourceクラスのCollection
             if (str_ends_with($className, 'Resource') &&
                 $call->name->toString() === 'collection') {
-                $info['type'] = 'array';
-                $info['items'] = [
-                    'type' => 'object',
-                    'resource' => $className,
-                ];
+                $items = ['type' => 'object', 'resource' => $className];
 
                 // 引数がwhenLoaded()の場合は条件付きフィールドとして扱う
                 if (isset($call->args[0]) &&
                     $call->args[0]->value instanceof Node\Expr\MethodCall &&
                     $call->args[0]->value->name->toString() === 'whenLoaded') {
-                    $whenLoadedInfo = $this->analyzeWhenLoadedMethod($call->args[0]->value);
-                    $info = array_merge($info, $whenLoadedInfo);
+                    $whenLoadedCall = $call->args[0]->value;
+                    $relation = null;
+                    $hasTransformation = isset($whenLoadedCall->args[1]);
+
+                    if (isset($whenLoadedCall->args[0]) &&
+                        $whenLoadedCall->args[0]->value instanceof Node\Scalar\String_) {
+                        $relation = $whenLoadedCall->args[0]->value->value;
+                    }
+
+                    $this->conditionalFields[] = $this->printer->prettyPrintExpr($whenLoadedCall);
+                    $this->nestedResources[] = $className;
+
+                    if ($relation !== null) {
+                        return ResourceFieldInfo::conditionalResourceCollection(
+                            $className,
+                            $relation,
+                            $items,
+                            $hasTransformation,
+                        );
+                    }
                 }
 
                 $this->nestedResources[] = $className;
+
+                return ResourceFieldInfo::resourceCollection($className, $items);
             }
         }
 
-        return $info;
+        return ResourceFieldInfo::mixed();
     }
 
     /**
      * new Resource()を解析
      */
-    private function analyzeNewResource(Node\Expr\New_ $new): array
+    private function analyzeNewResource(Node\Expr\New_ $new): ResourceFieldInfo
     {
-        $info = ['type' => 'object'];
-
         if ($new->class instanceof Node\Name) {
             $className = $new->class->toString();
 
             if (str_ends_with($className, 'Resource')) {
-                $info['resource'] = $className;
-
                 // 引数がwhenLoaded()の場合は条件付きフィールドとして扱う
                 if (isset($new->args[0]) &&
                     $new->args[0]->value instanceof Node\Expr\MethodCall &&
                     $new->args[0]->value->name->toString() === 'whenLoaded') {
-                    $whenLoadedInfo = $this->analyzeWhenLoadedMethod($new->args[0]->value);
-                    $info = array_merge($info, $whenLoadedInfo);
+                    $whenLoadedCall = $new->args[0]->value;
+                    $relation = null;
+                    $hasTransformation = isset($whenLoadedCall->args[1]);
+
+                    if (isset($whenLoadedCall->args[0]) &&
+                        $whenLoadedCall->args[0]->value instanceof Node\Scalar\String_) {
+                        $relation = $whenLoadedCall->args[0]->value->value;
+                    }
+
+                    $this->conditionalFields[] = $this->printer->prettyPrintExpr($whenLoadedCall);
+                    $this->nestedResources[] = $className;
+
+                    if ($relation !== null) {
+                        return ResourceFieldInfo::conditionalNestedResource(
+                            $className,
+                            $relation,
+                            $hasTransformation,
+                        );
+                    }
                 }
 
                 $this->nestedResources[] = $className;
+
+                return ResourceFieldInfo::nestedResource($className);
             }
         }
 
-        return $info;
+        return ResourceFieldInfo::object();
     }
 
     /**
      * Null-safe プロパティアクセスを解析 (例: $this->status?->value)
-     *
-     * @return array<string, mixed>
      */
-    private function analyzeNullsafePropertyFetch(Node\Expr\NullsafePropertyFetch $expr): array
+    private function analyzeNullsafePropertyFetch(Node\Expr\NullsafePropertyFetch $expr): ResourceFieldInfo
     {
         // 動的プロパティ名（$this->obj?->$dynamicProperty）は静的解析不可
         if (! ($expr->name instanceof Node\Identifier)) {
-            return ['type' => 'mixed', 'nullable' => true];
+            return ResourceFieldInfo::mixed()->withNullable();
         }
 
         $propertyName = $expr->name->toString();
@@ -394,55 +406,41 @@ class ResourceStructureVisitor extends NodeVisitorAbstract
         if ($propertyName === 'value') {
             // var が NullsafePropertyFetch または PropertyFetch で $this-> から始まる場合
             if ($this->isThisPropertyAccess($expr->var)) {
-                return [
-                    'type' => 'string',
-                    'source' => 'enum',
-                    'nullable' => true,
-                ];
+                return ResourceFieldInfo::enum(nullable: true);
             }
         }
 
         // $this->relation?->property パターン
         if ($this->isThisPropertyAccess($expr->var)) {
-            $info = $this->analyzePropertyAccess($propertyName);
-            $info['nullable'] = true;
-
-            return $info;
+            return $this->analyzePropertyAccess($propertyName)->withNullable();
         }
 
-        return ['type' => 'mixed', 'nullable' => true];
+        return ResourceFieldInfo::mixed()->withNullable();
     }
 
     /**
      * Null-safe メソッド呼び出しを解析 (例: $this->created_at?->toDateTimeString())
-     *
-     * @return array<string, mixed>
      */
-    private function analyzeNullsafeMethodCall(Node\Expr\NullsafeMethodCall $call): array
+    private function analyzeNullsafeMethodCall(Node\Expr\NullsafeMethodCall $call): ResourceFieldInfo
     {
         // 動的メソッド名（$this->obj?->$dynamicMethod()）は静的解析不可
         if (! ($call->name instanceof Node\Identifier)) {
-            return ['type' => 'mixed', 'nullable' => true];
+            return ResourceFieldInfo::mixed()->withNullable();
         }
 
         $methodName = $call->name->toString();
 
         // 日付フォーマットメソッド
         if ($this->isDateFormattingMethod($methodName)) {
-            return [
-                'type' => 'string',
-                'format' => 'date-time',
-                'example' => date('Y-m-d H:i:s'),
-                'nullable' => true,
-            ];
+            return ResourceFieldInfo::dateTime(date('Y-m-d H:i:s'))->withNullable();
         }
 
         // has*, is* メソッド (boolean を返すメソッド)
         if (str_starts_with($methodName, 'has') || str_starts_with($methodName, 'is')) {
-            return ['type' => 'boolean', 'nullable' => true];
+            return ResourceFieldInfo::boolean()->withNullable();
         }
 
-        return ['type' => 'mixed', 'nullable' => true];
+        return ResourceFieldInfo::mixed()->withNullable();
     }
 
     /**
@@ -500,40 +498,33 @@ class ResourceStructureVisitor extends NodeVisitorAbstract
     /**
      * メソッドチェーンを解析
      */
-    private function analyzeMethodChain(Node\Expr\MethodCall $call): array
+    private function analyzeMethodChain(Node\Expr\MethodCall $call): ResourceFieldInfo
     {
         $methodName = $call->name->toString();
 
         // 日付フォーマット
         if ($this->isDateFormattingMethod($methodName)) {
-            return [
-                'type' => 'string',
-                'format' => 'date-time',
-                'example' => date('Y-m-d H:i:s'),
-            ];
+            return ResourceFieldInfo::dateTime(date('Y-m-d H:i:s'));
         }
 
         // Enumのvalue
         if ($methodName === 'value' && $call->var instanceof Node\Expr\PropertyFetch) {
-            return [
-                'type' => 'string',
-                'source' => 'enum',
-            ];
+            return ResourceFieldInfo::enum();
         }
 
         // count() メソッド
         if ($methodName === 'count') {
-            return ['type' => 'integer'];
+            return ResourceFieldInfo::integer();
         }
 
         // pluck() メソッド
         if ($methodName === 'pluck') {
-            return ['type' => 'array'];
+            return ResourceFieldInfo::array();
         }
 
         // has*, is* メソッド (boolean を返すメソッド)
         if (str_starts_with($methodName, 'has') || str_starts_with($methodName, 'is')) {
-            return ['type' => 'boolean'];
+            return ResourceFieldInfo::boolean();
         }
 
         // $this->relation()->method() パターン
@@ -542,60 +533,88 @@ class ResourceStructureVisitor extends NodeVisitorAbstract
             $call->var->var->name === 'this') {
             // リレーションのメソッドチェーン
             if ($methodName === 'count') {
-                return ['type' => 'integer'];
+                return ResourceFieldInfo::integer();
             }
         }
 
-        return ['type' => 'mixed'];
+        return ResourceFieldInfo::mixed();
     }
 
     /**
      * キャストを解析
      */
-    private function analyzeCast(Node\Expr\Cast $cast): array
+    private function analyzeCast(Node\Expr\Cast $cast): ResourceFieldInfo
     {
         if ($cast instanceof Node\Expr\Cast\Bool_) {
-            return ['type' => 'boolean'];
-        } elseif ($cast instanceof Node\Expr\Cast\Int_) {
-            return ['type' => 'integer'];
-        } elseif ($cast instanceof Node\Expr\Cast\Double) {
-            return ['type' => 'number'];
-        } elseif ($cast instanceof Node\Expr\Cast\String_) {
-            return ['type' => 'string'];
-        } elseif ($cast instanceof Node\Expr\Cast\Array_) {
-            return ['type' => 'array'];
-        } elseif ($cast instanceof Node\Expr\Cast\Object_) {
-            return ['type' => 'object'];
+            return ResourceFieldInfo::boolean();
+        }
+        if ($cast instanceof Node\Expr\Cast\Int_) {
+            return ResourceFieldInfo::integer();
+        }
+        if ($cast instanceof Node\Expr\Cast\Double) {
+            return ResourceFieldInfo::number();
+        }
+        if ($cast instanceof Node\Expr\Cast\String_) {
+            return ResourceFieldInfo::string();
+        }
+        if ($cast instanceof Node\Expr\Cast\Array_) {
+            return ResourceFieldInfo::array();
+        }
+        if ($cast instanceof Node\Expr\Cast\Object_) {
+            return ResourceFieldInfo::object();
         }
 
-        return ['type' => 'mixed'];
+        return ResourceFieldInfo::mixed();
     }
 
     /**
-     * 関数呼び出しを解析
+     * 関数呼び出しを解析 (値として使用される場合)
      */
-    private function analyzeFunctionCall(Node\Expr\FuncCall $call): array
+    private function analyzeFunctionCall(Node\Expr\FuncCall $call): ResourceFieldInfo
     {
         if ($call->name instanceof Node\Name) {
             $functionName = $call->name->toString();
 
             // 数値フォーマット関数
             if (in_array($functionName, ['number_format', 'round', 'floor', 'ceil'])) {
-                return ['type' => 'number'];
+                return ResourceFieldInfo::number();
             }
 
             // 文字列関数
             if (in_array($functionName, ['strtoupper', 'strtolower', 'ucfirst', 'trim', 'str_replace', 'substr', 'strlen'])) {
-                return ['type' => 'string'];
+                return ResourceFieldInfo::string();
             }
 
-            // array_merge
+            // array_merge - returns object with merged flag via properties
             if ($functionName === 'array_merge') {
-                return ['type' => 'object', 'merged' => true];
+                return ResourceFieldInfo::object()->withProperties(['merged' => true]);
             }
         }
 
-        return ['type' => 'mixed'];
+        return ResourceFieldInfo::mixed();
+    }
+
+    /**
+     * トップレベルの関数呼び出しを解析 (return array_merge(...) など)
+     *
+     * @return array<string, ResourceFieldInfo>
+     */
+    private function analyzeTopLevelFunctionCall(Node\Expr\FuncCall $call): array
+    {
+        if ($call->name instanceof Node\Name && $call->name->toString() === 'array_merge') {
+            // array_merge の各引数を解析してマージ
+            $merged = [];
+            foreach ($call->args as $arg) {
+                if ($arg->value instanceof Node\Expr\Array_) {
+                    $merged = array_merge($merged, $this->analyzeArrayStructure($arg->value));
+                }
+            }
+
+            return $merged;
+        }
+
+        // その他の関数呼び出しは単一の結果として返す
+        return ['_result' => $this->analyzeFunctionCall($call)];
     }
 
     /**
@@ -677,7 +696,41 @@ class ResourceStructureVisitor extends NodeVisitorAbstract
     }
 
     /**
-     * 解析結果の構造を取得
+     * Convert ResourceFieldInfo array to legacy array format.
+     *
+     * @param  array<string, ResourceFieldInfo>  $structure
+     * @return array<string, array<string, mixed>>
+     */
+    private function convertToArrayFormat(array $structure): array
+    {
+        $result = [];
+        foreach ($structure as $key => $fieldInfo) {
+            $result[$key] = $fieldInfo->toArray();
+        }
+
+        return $result;
+    }
+
+    /**
+     * 解析結果の構造を取得 (DTOとして)
+     *
+     * @return array{
+     *     properties: array<string, ResourceFieldInfo>,
+     *     conditionalFields: list<string>,
+     *     nestedResources: list<string>
+     * }
+     */
+    public function getStructureAsDto(): array
+    {
+        return [
+            'properties' => $this->structure,
+            'conditionalFields' => array_unique($this->conditionalFields),
+            'nestedResources' => array_unique($this->nestedResources),
+        ];
+    }
+
+    /**
+     * 解析結果の構造を取得 (後方互換性のため配列として)
      *
      * @return array{
      *     properties: array<string, array<string, mixed>>,
@@ -688,7 +741,7 @@ class ResourceStructureVisitor extends NodeVisitorAbstract
     public function getStructure(): array
     {
         return [
-            'properties' => $this->structure,
+            'properties' => $this->convertToArrayFormat($this->structure),
             'conditionalFields' => array_unique($this->conditionalFields),
             'nestedResources' => array_unique($this->nestedResources),
         ];

--- a/src/DTO/ResourceFieldInfo.php
+++ b/src/DTO/ResourceFieldInfo.php
@@ -1,0 +1,540 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\DTO;
+
+/**
+ * Represents type information for a field in an API Resource.
+ *
+ * This DTO encapsulates the type, nullability, source, and other metadata
+ * extracted from API Resource classes by ResourceStructureVisitor.
+ * It supports conditional fields (when/whenLoaded), nested resources,
+ * and resource collections.
+ */
+final readonly class ResourceFieldInfo
+{
+    /**
+     * @param  string  $type  The OpenAPI type (mixed, string, integer, number, boolean, array, object)
+     * @param  bool  $nullable  Whether the field can be null
+     * @param  string|null  $source  Source of the value (property, enum)
+     * @param  string|null  $property  Property name when source is 'property'
+     * @param  mixed  $example  Example value
+     * @param  string|null  $format  Format hint (date-time, etc.)
+     * @param  bool  $conditional  Whether this is a conditional field
+     * @param  string|null  $condition  Condition type (when, whenLoaded)
+     * @param  string|null  $relation  Relation name for whenLoaded
+     * @param  bool  $hasTransformation  Whether whenLoaded has transformation closure
+     * @param  array<string, mixed>|null  $properties  Nested properties for object types
+     * @param  array<string, mixed>|null  $items  Item definition for array types
+     * @param  string|null  $resource  Referenced resource class name
+     * @param  string|null  $expression  Expression string for complex values
+     */
+    private function __construct(
+        public string $type,
+        public bool $nullable = false,
+        public ?string $source = null,
+        public ?string $property = null,
+        public mixed $example = null,
+        public ?string $format = null,
+        public bool $conditional = false,
+        public ?string $condition = null,
+        public ?string $relation = null,
+        public bool $hasTransformation = false,
+        public ?array $properties = null,
+        public ?array $items = null,
+        public ?string $resource = null,
+        public ?string $expression = null,
+    ) {}
+
+    /**
+     * Create a basic field info with just the type.
+     */
+    public static function basic(string $type): self
+    {
+        return new self(type: $type);
+    }
+
+    /**
+     * Create a mixed type field.
+     */
+    public static function mixed(): self
+    {
+        return new self(type: 'mixed');
+    }
+
+    /**
+     * Create a string type field.
+     */
+    public static function string(): self
+    {
+        return new self(type: 'string');
+    }
+
+    /**
+     * Create an integer type field.
+     */
+    public static function integer(): self
+    {
+        return new self(type: 'integer');
+    }
+
+    /**
+     * Create a number type field.
+     */
+    public static function number(): self
+    {
+        return new self(type: 'number');
+    }
+
+    /**
+     * Create a boolean type field.
+     */
+    public static function boolean(): self
+    {
+        return new self(type: 'boolean');
+    }
+
+    /**
+     * Create an array type field.
+     */
+    public static function array(): self
+    {
+        return new self(type: 'array');
+    }
+
+    /**
+     * Create an object type field.
+     */
+    public static function object(): self
+    {
+        return new self(type: 'object');
+    }
+
+    /**
+     * Create a property-sourced field.
+     */
+    public static function property(string $propertyName, string $type, mixed $example = null): self
+    {
+        return new self(
+            type: $type,
+            source: 'property',
+            property: $propertyName,
+            example: $example,
+        );
+    }
+
+    /**
+     * Create an enum-sourced field.
+     */
+    public static function enum(bool $nullable = false): self
+    {
+        return new self(
+            type: 'string',
+            nullable: $nullable,
+            source: 'enum',
+        );
+    }
+
+    /**
+     * Create a conditional field.
+     */
+    public static function conditional(string $condition, string $type): self
+    {
+        return new self(
+            type: $type,
+            conditional: true,
+            condition: $condition,
+        );
+    }
+
+    /**
+     * Create a whenLoaded conditional field.
+     */
+    public static function whenLoaded(string $relation, string $type, bool $hasTransformation = false): self
+    {
+        return new self(
+            type: $type,
+            conditional: true,
+            condition: 'whenLoaded',
+            relation: $relation,
+            hasTransformation: $hasTransformation,
+        );
+    }
+
+    /**
+     * Create a resource collection field.
+     *
+     * @param  array<string, mixed>|null  $items
+     */
+    public static function resourceCollection(string $resourceClass, ?array $items = null): self
+    {
+        return new self(
+            type: 'array',
+            items: $items,
+            resource: $resourceClass,
+        );
+    }
+
+    /**
+     * Create a nested resource field.
+     */
+    public static function nestedResource(string $resourceClass): self
+    {
+        return new self(
+            type: 'object',
+            resource: $resourceClass,
+        );
+    }
+
+    /**
+     * Create a nested resource field with whenLoaded condition.
+     */
+    public static function conditionalNestedResource(
+        string $resourceClass,
+        string $relation,
+        bool $hasTransformation = false,
+    ): self {
+        return new self(
+            type: 'object',
+            conditional: true,
+            condition: 'whenLoaded',
+            relation: $relation,
+            hasTransformation: $hasTransformation,
+            resource: $resourceClass,
+        );
+    }
+
+    /**
+     * Create a resource collection with whenLoaded condition.
+     *
+     * @param  array<string, mixed>|null  $items
+     */
+    public static function conditionalResourceCollection(
+        string $resourceClass,
+        string $relation,
+        ?array $items = null,
+        bool $hasTransformation = false,
+    ): self {
+        return new self(
+            type: 'array',
+            conditional: true,
+            condition: 'whenLoaded',
+            relation: $relation,
+            hasTransformation: $hasTransformation,
+            items: $items,
+            resource: $resourceClass,
+        );
+    }
+
+    /**
+     * Create a date-time field.
+     */
+    public static function dateTime(?string $example = null): self
+    {
+        return new self(
+            type: 'string',
+            example: $example,
+            format: 'date-time',
+        );
+    }
+
+    /**
+     * Create a field with an expression.
+     */
+    public static function withExpression(string $expression): self
+    {
+        return new self(
+            type: 'mixed',
+            expression: $expression,
+        );
+    }
+
+    /**
+     * Create a copy with nullable set to true.
+     */
+    public function withNullable(): self
+    {
+        return new self(
+            type: $this->type,
+            nullable: true,
+            source: $this->source,
+            property: $this->property,
+            example: $this->example,
+            format: $this->format,
+            conditional: $this->conditional,
+            condition: $this->condition,
+            relation: $this->relation,
+            hasTransformation: $this->hasTransformation,
+            properties: $this->properties,
+            items: $this->items,
+            resource: $this->resource,
+            expression: $this->expression,
+        );
+    }
+
+    /**
+     * Create a copy with properties.
+     *
+     * @param  array<string, mixed>  $properties
+     */
+    public function withProperties(array $properties): self
+    {
+        return new self(
+            type: $this->type,
+            nullable: $this->nullable,
+            source: $this->source,
+            property: $this->property,
+            example: $this->example,
+            format: $this->format,
+            conditional: $this->conditional,
+            condition: $this->condition,
+            relation: $this->relation,
+            hasTransformation: $this->hasTransformation,
+            properties: $properties,
+            items: $this->items,
+            resource: $this->resource,
+            expression: $this->expression,
+        );
+    }
+
+    /**
+     * Create a copy with items.
+     *
+     * @param  array<string, mixed>  $items
+     */
+    public function withItems(array $items): self
+    {
+        return new self(
+            type: $this->type,
+            nullable: $this->nullable,
+            source: $this->source,
+            property: $this->property,
+            example: $this->example,
+            format: $this->format,
+            conditional: $this->conditional,
+            condition: $this->condition,
+            relation: $this->relation,
+            hasTransformation: $this->hasTransformation,
+            properties: $this->properties,
+            items: $items,
+            resource: $this->resource,
+            expression: $this->expression,
+        );
+    }
+
+    /**
+     * Create a copy with an example.
+     */
+    public function withExample(mixed $example): self
+    {
+        return new self(
+            type: $this->type,
+            nullable: $this->nullable,
+            source: $this->source,
+            property: $this->property,
+            example: $example,
+            format: $this->format,
+            conditional: $this->conditional,
+            condition: $this->condition,
+            relation: $this->relation,
+            hasTransformation: $this->hasTransformation,
+            properties: $this->properties,
+            items: $this->items,
+            resource: $this->resource,
+            expression: $this->expression,
+        );
+    }
+
+    /**
+     * Check if this is a mixed type.
+     */
+    public function isMixed(): bool
+    {
+        return $this->type === 'mixed';
+    }
+
+    /**
+     * Check if this is a string type.
+     */
+    public function isString(): bool
+    {
+        return $this->type === 'string';
+    }
+
+    /**
+     * Check if this is an integer type.
+     */
+    public function isInteger(): bool
+    {
+        return $this->type === 'integer';
+    }
+
+    /**
+     * Check if this is a number type.
+     */
+    public function isNumber(): bool
+    {
+        return $this->type === 'number';
+    }
+
+    /**
+     * Check if this is a boolean type.
+     */
+    public function isBoolean(): bool
+    {
+        return $this->type === 'boolean';
+    }
+
+    /**
+     * Check if this is an array type.
+     */
+    public function isArray(): bool
+    {
+        return $this->type === 'array';
+    }
+
+    /**
+     * Check if this is an object type.
+     */
+    public function isObject(): bool
+    {
+        return $this->type === 'object';
+    }
+
+    /**
+     * Check if this is a scalar type (string, integer, number, boolean).
+     */
+    public function isScalar(): bool
+    {
+        return in_array($this->type, ['string', 'integer', 'number', 'boolean'], true);
+    }
+
+    /**
+     * Check if this field is nullable.
+     */
+    public function isNullable(): bool
+    {
+        return $this->nullable;
+    }
+
+    /**
+     * Check if this is a conditional field.
+     */
+    public function isConditional(): bool
+    {
+        return $this->conditional;
+    }
+
+    /**
+     * Check if this field references another resource.
+     */
+    public function isResourceReference(): bool
+    {
+        return $this->resource !== null;
+    }
+
+    /**
+     * Check if this field has a format.
+     */
+    public function hasFormat(): bool
+    {
+        return $this->format !== null;
+    }
+
+    /**
+     * Check if this field has properties (for object types).
+     */
+    public function hasProperties(): bool
+    {
+        return $this->properties !== null && count($this->properties) > 0;
+    }
+
+    /**
+     * Convert to array format.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $result = [
+            'type' => $this->type,
+            'nullable' => $this->nullable,
+        ];
+
+        if ($this->source !== null) {
+            $result['source'] = $this->source;
+        }
+
+        if ($this->property !== null) {
+            $result['property'] = $this->property;
+        }
+
+        if ($this->example !== null) {
+            $result['example'] = $this->example;
+        }
+
+        if ($this->format !== null) {
+            $result['format'] = $this->format;
+        }
+
+        if ($this->conditional) {
+            $result['conditional'] = $this->conditional;
+        }
+
+        if ($this->condition !== null) {
+            $result['condition'] = $this->condition;
+        }
+
+        if ($this->relation !== null) {
+            $result['relation'] = $this->relation;
+        }
+
+        if ($this->hasTransformation) {
+            $result['hasTransformation'] = $this->hasTransformation;
+        }
+
+        if ($this->properties !== null) {
+            $result['properties'] = $this->properties;
+        }
+
+        if ($this->items !== null) {
+            $result['items'] = $this->items;
+        }
+
+        if ($this->resource !== null) {
+            $result['resource'] = $this->resource;
+        }
+
+        if ($this->expression !== null) {
+            $result['expression'] = $this->expression;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Create from array representation.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            type: $data['type'] ?? 'mixed',
+            nullable: $data['nullable'] ?? false,
+            source: $data['source'] ?? null,
+            property: $data['property'] ?? null,
+            example: $data['example'] ?? null,
+            format: $data['format'] ?? null,
+            conditional: $data['conditional'] ?? false,
+            condition: $data['condition'] ?? null,
+            relation: $data['relation'] ?? null,
+            hasTransformation: $data['hasTransformation'] ?? false,
+            properties: $data['properties'] ?? null,
+            items: $data['items'] ?? null,
+            resource: $data['resource'] ?? null,
+            expression: $data['expression'] ?? null,
+        );
+    }
+}

--- a/tests/Unit/Analyzers/AST/Visitors/ResourceStructureVisitorTest.php
+++ b/tests/Unit/Analyzers/AST/Visitors/ResourceStructureVisitorTest.php
@@ -314,8 +314,15 @@ class ResourceStructureVisitorTest extends TestCase
 
         $structure = $visitor->getStructure();
 
-        $this->assertEquals('object', $structure['properties']['type']);
-        $this->assertTrue($structure['properties']['merged']);
+        // array_merge is now properly parsed - all properties should be extracted
+        $this->assertArrayHasKey('id', $structure['properties']);
+        $this->assertArrayHasKey('name', $structure['properties']);
+        $this->assertArrayHasKey('email', $structure['properties']);
+        $this->assertArrayHasKey('phone', $structure['properties']);
+        $this->assertEquals('integer', $structure['properties']['id']['type']);
+        $this->assertEquals('string', $structure['properties']['name']['type']);
+        $this->assertEquals('string', $structure['properties']['email']['type']);
+        $this->assertEquals('string', $structure['properties']['phone']['type']);
     }
 
     #[Test]
@@ -417,8 +424,10 @@ class ResourceStructureVisitorTest extends TestCase
 
         $structure = $visitor->getStructure();
 
+        // Dynamic structures are flagged with a notice in the expression field
         $this->assertArrayHasKey('_notice', $structure['properties']);
-        $this->assertStringContainsString('Dynamic structure detected', $structure['properties']['_notice']);
+        $this->assertArrayHasKey('expression', $structure['properties']['_notice']);
+        $this->assertStringContainsString('Dynamic structure detected', $structure['properties']['_notice']['expression']);
     }
 
     #[Test]

--- a/tests/Unit/DTO/ResourceFieldInfoTest.php
+++ b/tests/Unit/DTO/ResourceFieldInfoTest.php
@@ -1,0 +1,440 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\DTO;
+
+use LaravelSpectrum\DTO\ResourceFieldInfo;
+use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class ResourceFieldInfoTest extends TestCase
+{
+    #[Test]
+    public function it_creates_basic_field_info(): void
+    {
+        $info = ResourceFieldInfo::basic('string');
+
+        $this->assertEquals('string', $info->type);
+        $this->assertFalse($info->nullable);
+        $this->assertNull($info->source);
+        $this->assertNull($info->property);
+        $this->assertNull($info->example);
+        $this->assertNull($info->format);
+        $this->assertFalse($info->conditional);
+        $this->assertNull($info->condition);
+        $this->assertNull($info->relation);
+        $this->assertFalse($info->hasTransformation);
+        $this->assertNull($info->properties);
+        $this->assertNull($info->items);
+        $this->assertNull($info->resource);
+        $this->assertNull($info->expression);
+    }
+
+    #[Test]
+    public function it_creates_mixed_type(): void
+    {
+        $info = ResourceFieldInfo::mixed();
+
+        $this->assertEquals('mixed', $info->type);
+        $this->assertFalse($info->nullable);
+    }
+
+    #[Test]
+    public function it_creates_string_type(): void
+    {
+        $info = ResourceFieldInfo::string();
+
+        $this->assertEquals('string', $info->type);
+        $this->assertFalse($info->nullable);
+    }
+
+    #[Test]
+    public function it_creates_integer_type(): void
+    {
+        $info = ResourceFieldInfo::integer();
+
+        $this->assertEquals('integer', $info->type);
+        $this->assertFalse($info->nullable);
+    }
+
+    #[Test]
+    public function it_creates_number_type(): void
+    {
+        $info = ResourceFieldInfo::number();
+
+        $this->assertEquals('number', $info->type);
+        $this->assertFalse($info->nullable);
+    }
+
+    #[Test]
+    public function it_creates_boolean_type(): void
+    {
+        $info = ResourceFieldInfo::boolean();
+
+        $this->assertEquals('boolean', $info->type);
+        $this->assertFalse($info->nullable);
+    }
+
+    #[Test]
+    public function it_creates_array_type(): void
+    {
+        $info = ResourceFieldInfo::array();
+
+        $this->assertEquals('array', $info->type);
+        $this->assertFalse($info->nullable);
+    }
+
+    #[Test]
+    public function it_creates_object_type(): void
+    {
+        $info = ResourceFieldInfo::object();
+
+        $this->assertEquals('object', $info->type);
+        $this->assertFalse($info->nullable);
+    }
+
+    #[Test]
+    public function it_creates_property_field_info(): void
+    {
+        $info = ResourceFieldInfo::property('email', 'string', 'user@example.com');
+
+        $this->assertEquals('string', $info->type);
+        $this->assertEquals('property', $info->source);
+        $this->assertEquals('email', $info->property);
+        $this->assertEquals('user@example.com', $info->example);
+        $this->assertFalse($info->nullable);
+    }
+
+    #[Test]
+    public function it_creates_enum_field_info(): void
+    {
+        $info = ResourceFieldInfo::enum();
+
+        $this->assertEquals('string', $info->type);
+        $this->assertEquals('enum', $info->source);
+    }
+
+    #[Test]
+    public function it_creates_nullable_enum_field_info(): void
+    {
+        $info = ResourceFieldInfo::enum(nullable: true);
+
+        $this->assertEquals('string', $info->type);
+        $this->assertEquals('enum', $info->source);
+        $this->assertTrue($info->nullable);
+    }
+
+    #[Test]
+    public function it_creates_conditional_field_info(): void
+    {
+        $info = ResourceFieldInfo::conditional('when', 'string');
+
+        $this->assertEquals('string', $info->type);
+        $this->assertTrue($info->conditional);
+        $this->assertEquals('when', $info->condition);
+    }
+
+    #[Test]
+    public function it_creates_when_loaded_field_info(): void
+    {
+        $info = ResourceFieldInfo::whenLoaded('comments', 'array', true);
+
+        $this->assertEquals('array', $info->type);
+        $this->assertTrue($info->conditional);
+        $this->assertEquals('whenLoaded', $info->condition);
+        $this->assertEquals('comments', $info->relation);
+        $this->assertTrue($info->hasTransformation);
+    }
+
+    #[Test]
+    public function it_creates_resource_collection_field_info(): void
+    {
+        $items = ['type' => 'object', 'resource' => 'UserResource'];
+        $info = ResourceFieldInfo::resourceCollection('UserResource', $items);
+
+        $this->assertEquals('array', $info->type);
+        $this->assertEquals('UserResource', $info->resource);
+        $this->assertEquals($items, $info->items);
+    }
+
+    #[Test]
+    public function it_creates_nested_resource_field_info(): void
+    {
+        $info = ResourceFieldInfo::nestedResource('ProfileResource');
+
+        $this->assertEquals('object', $info->type);
+        $this->assertEquals('ProfileResource', $info->resource);
+    }
+
+    #[Test]
+    public function it_creates_date_time_field_info(): void
+    {
+        $example = date('Y-m-d H:i:s');
+        $info = ResourceFieldInfo::dateTime($example);
+
+        $this->assertEquals('string', $info->type);
+        $this->assertEquals('date-time', $info->format);
+        $this->assertEquals($example, $info->example);
+    }
+
+    #[Test]
+    public function it_creates_with_expression(): void
+    {
+        $info = ResourceFieldInfo::withExpression('$this->foo ? $this->bar : null');
+
+        $this->assertEquals('mixed', $info->type);
+        $this->assertEquals('$this->foo ? $this->bar : null', $info->expression);
+    }
+
+    #[Test]
+    public function it_creates_with_nullable(): void
+    {
+        $info = ResourceFieldInfo::mixed()->withNullable();
+
+        $this->assertEquals('mixed', $info->type);
+        $this->assertTrue($info->nullable);
+    }
+
+    #[Test]
+    public function it_identifies_type_checks_correctly(): void
+    {
+        $this->assertTrue(ResourceFieldInfo::mixed()->isMixed());
+        $this->assertTrue(ResourceFieldInfo::string()->isString());
+        $this->assertTrue(ResourceFieldInfo::integer()->isInteger());
+        $this->assertTrue(ResourceFieldInfo::number()->isNumber());
+        $this->assertTrue(ResourceFieldInfo::boolean()->isBoolean());
+        $this->assertTrue(ResourceFieldInfo::array()->isArray());
+        $this->assertTrue(ResourceFieldInfo::object()->isObject());
+    }
+
+    #[Test]
+    public function it_identifies_scalar_types(): void
+    {
+        $this->assertTrue(ResourceFieldInfo::string()->isScalar());
+        $this->assertTrue(ResourceFieldInfo::integer()->isScalar());
+        $this->assertTrue(ResourceFieldInfo::number()->isScalar());
+        $this->assertTrue(ResourceFieldInfo::boolean()->isScalar());
+
+        $this->assertFalse(ResourceFieldInfo::array()->isScalar());
+        $this->assertFalse(ResourceFieldInfo::object()->isScalar());
+        $this->assertFalse(ResourceFieldInfo::mixed()->isScalar());
+    }
+
+    #[Test]
+    public function it_identifies_nullable_fields(): void
+    {
+        $nullable = ResourceFieldInfo::mixed()->withNullable();
+        $nonNullable = ResourceFieldInfo::string();
+
+        $this->assertTrue($nullable->isNullable());
+        $this->assertFalse($nonNullable->isNullable());
+    }
+
+    #[Test]
+    public function it_identifies_conditional_fields(): void
+    {
+        $conditional = ResourceFieldInfo::conditional('when', 'string');
+        $nonConditional = ResourceFieldInfo::string();
+
+        $this->assertTrue($conditional->isConditional());
+        $this->assertFalse($nonConditional->isConditional());
+    }
+
+    #[Test]
+    public function it_identifies_resource_reference(): void
+    {
+        $withResource = ResourceFieldInfo::nestedResource('UserResource');
+        $withoutResource = ResourceFieldInfo::object();
+
+        $this->assertTrue($withResource->isResourceReference());
+        $this->assertFalse($withoutResource->isResourceReference());
+    }
+
+    #[Test]
+    public function it_identifies_fields_with_format(): void
+    {
+        $withFormat = ResourceFieldInfo::dateTime();
+        $withoutFormat = ResourceFieldInfo::string();
+
+        $this->assertTrue($withFormat->hasFormat());
+        $this->assertFalse($withoutFormat->hasFormat());
+    }
+
+    #[Test]
+    public function it_identifies_fields_with_properties(): void
+    {
+        $withProperties = ResourceFieldInfo::object()->withProperties(['id' => ['type' => 'integer']]);
+        $withoutProperties = ResourceFieldInfo::object();
+
+        $this->assertTrue($withProperties->hasProperties());
+        $this->assertFalse($withoutProperties->hasProperties());
+    }
+
+    #[Test]
+    public function it_converts_to_array(): void
+    {
+        $info = ResourceFieldInfo::property('name', 'string', 'John Doe');
+        $array = $info->toArray();
+
+        $this->assertEquals('string', $array['type']);
+        $this->assertFalse($array['nullable']);
+        $this->assertEquals('property', $array['source']);
+        $this->assertEquals('name', $array['property']);
+        $this->assertEquals('John Doe', $array['example']);
+    }
+
+    #[Test]
+    public function it_converts_conditional_to_array(): void
+    {
+        $info = ResourceFieldInfo::whenLoaded('comments', 'array', true);
+        $array = $info->toArray();
+
+        $this->assertEquals('array', $array['type']);
+        $this->assertTrue($array['conditional']);
+        $this->assertEquals('whenLoaded', $array['condition']);
+        $this->assertEquals('comments', $array['relation']);
+        $this->assertTrue($array['hasTransformation']);
+    }
+
+    #[Test]
+    public function it_omits_null_values_in_array(): void
+    {
+        $info = ResourceFieldInfo::string();
+        $array = $info->toArray();
+
+        $this->assertArrayNotHasKey('source', $array);
+        $this->assertArrayNotHasKey('property', $array);
+        $this->assertArrayNotHasKey('example', $array);
+        $this->assertArrayNotHasKey('format', $array);
+        $this->assertArrayNotHasKey('condition', $array);
+        $this->assertArrayNotHasKey('relation', $array);
+        $this->assertArrayNotHasKey('properties', $array);
+        $this->assertArrayNotHasKey('items', $array);
+        $this->assertArrayNotHasKey('resource', $array);
+        $this->assertArrayNotHasKey('expression', $array);
+    }
+
+    #[Test]
+    public function it_creates_from_array(): void
+    {
+        $data = [
+            'type' => 'string',
+            'nullable' => true,
+            'source' => 'property',
+            'property' => 'email',
+            'example' => 'user@example.com',
+        ];
+
+        $info = ResourceFieldInfo::fromArray($data);
+
+        $this->assertEquals('string', $info->type);
+        $this->assertTrue($info->nullable);
+        $this->assertEquals('property', $info->source);
+        $this->assertEquals('email', $info->property);
+        $this->assertEquals('user@example.com', $info->example);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_conditional(): void
+    {
+        $data = [
+            'type' => 'array',
+            'conditional' => true,
+            'condition' => 'whenLoaded',
+            'relation' => 'comments',
+            'hasTransformation' => true,
+        ];
+
+        $info = ResourceFieldInfo::fromArray($data);
+
+        $this->assertEquals('array', $info->type);
+        $this->assertTrue($info->conditional);
+        $this->assertEquals('whenLoaded', $info->condition);
+        $this->assertEquals('comments', $info->relation);
+        $this->assertTrue($info->hasTransformation);
+    }
+
+    #[Test]
+    public function it_creates_from_minimal_array(): void
+    {
+        $data = ['type' => 'integer'];
+
+        $info = ResourceFieldInfo::fromArray($data);
+
+        $this->assertEquals('integer', $info->type);
+        $this->assertFalse($info->nullable);
+        $this->assertNull($info->source);
+    }
+
+    #[Test]
+    public function it_creates_from_empty_array_with_defaults(): void
+    {
+        $info = ResourceFieldInfo::fromArray([]);
+
+        $this->assertEquals('mixed', $info->type);
+        $this->assertFalse($info->nullable);
+    }
+
+    #[Test]
+    public function it_performs_roundtrip_conversion(): void
+    {
+        $original = ResourceFieldInfo::whenLoaded('users', 'array', true);
+        $array = $original->toArray();
+        $restored = ResourceFieldInfo::fromArray($array);
+
+        $this->assertEquals($original->type, $restored->type);
+        $this->assertEquals($original->nullable, $restored->nullable);
+        $this->assertEquals($original->conditional, $restored->conditional);
+        $this->assertEquals($original->condition, $restored->condition);
+        $this->assertEquals($original->relation, $restored->relation);
+        $this->assertEquals($original->hasTransformation, $restored->hasTransformation);
+    }
+
+    #[Test]
+    public function it_performs_roundtrip_for_resource_collection(): void
+    {
+        $items = ['type' => 'object', 'resource' => 'CommentResource'];
+        $original = ResourceFieldInfo::resourceCollection('CommentResource', $items);
+        $array = $original->toArray();
+        $restored = ResourceFieldInfo::fromArray($array);
+
+        $this->assertEquals($original->type, $restored->type);
+        $this->assertEquals($original->resource, $restored->resource);
+        $this->assertEquals($original->items, $restored->items);
+    }
+
+    #[Test]
+    public function it_creates_with_properties(): void
+    {
+        $properties = [
+            'id' => ['type' => 'integer'],
+            'name' => ['type' => 'string'],
+        ];
+
+        $info = ResourceFieldInfo::object()->withProperties($properties);
+
+        $this->assertEquals('object', $info->type);
+        $this->assertEquals($properties, $info->properties);
+    }
+
+    #[Test]
+    public function it_creates_with_items(): void
+    {
+        $items = ['type' => 'string'];
+
+        $info = ResourceFieldInfo::array()->withItems($items);
+
+        $this->assertEquals('array', $info->type);
+        $this->assertEquals($items, $info->items);
+    }
+
+    #[Test]
+    public function it_creates_with_example(): void
+    {
+        $info = ResourceFieldInfo::string()->withExample('Test value');
+
+        $this->assertEquals('string', $info->type);
+        $this->assertEquals('Test value', $info->example);
+    }
+}


### PR DESCRIPTION
## Summary

- Create `ResourceFieldInfo` DTO to replace array returns in `ResourceStructureVisitor`
- Provides type-safe factory methods for common field types (string, integer, object, etc.)
- Adds specialized methods for conditional fields (`whenLoaded`, `when`)
- Adds methods for resource references (`nestedResource`, `resourceCollection`, `conditionalNestedResource`, `conditionalResourceCollection`)

## Changes

### New Files
- `src/DTO/ResourceFieldInfo.php` - New DTO with private constructor and factory methods
- `tests/Unit/DTO/ResourceFieldInfoTest.php` - 37 comprehensive tests

### Modified Files
- `src/Analyzers/AST/Visitors/ResourceStructureVisitor.php`
  - Use `ResourceFieldInfo` DTOs internally
  - Add `getStructureAsDto()` method for DTO access
  - Keep `getStructure()` for backward compatibility via `toArray()`
  - Improved `array_merge` handling to properly parse merged arrays

### Test Updates
- `tests/Unit/Analyzers/AST/Visitors/ResourceStructureVisitorTest.php`
  - Updated tests to match improved `array_merge` behavior
  - Updated dynamic structure detection test

## Design Decisions

- **Private constructor**: Enforces invariant safety through factory methods
- **Immutable (readonly)**: All fields are readonly for immutability
- **With* methods**: Return new instances for mutation (e.g., `withNullable()`, `withExample()`)
- **Backward compatibility**: `toArray()` converts DTO to legacy array format

## Test plan

- [x] All 37 new DTO tests pass
- [x] All 19 ResourceStructureVisitor tests pass
- [x] PHPStan analysis passes
- [x] Code formatting passes
- [x] Full test suite passes (2977 tests)