### PR TITLE
refactor: eliminate redundant DTO-to-array conversion in AnonymousClassAnalyzer

### DIFF
--- a/src/Analyzers/FormRequestAnalyzer.php
+++ b/src/Analyzers/FormRequestAnalyzer.php
@@ -173,13 +173,8 @@ class FormRequestAnalyzer implements ClassAnalyzer, HasErrors
             }
 
             if ($context->isAnonymous()) {
-                // AnonymousClassAnalyzer returns arrays, convert to DTOs
-                $arrays = $this->anonymousClassAnalyzer->analyze($context->reflection);
-
-                return array_map(
-                    fn (array $data) => ParameterDefinition::fromArray($data),
-                    $arrays
-                );
+                // AnonymousClassAnalyzer now returns ParameterDefinition[] directly
+                return $this->anonymousClassAnalyzer->analyze($context->reflection);
             }
 
             // Extract rules and attributes from AST


### PR DESCRIPTION
## Summary

- Update `AnonymousClassAnalyzer::analyze()` to return `ParameterDefinition[]` directly instead of converting to arrays
- Simplify `FormRequestAnalyzer::performAnalysisToResult()` to use DTOs directly without reconversion
- Keep `analyzeWithConditionalRules()` backward compatible with arrays for `ValidationAnalysisResult`

## Problem

The previous code had an inefficient pattern:
1. `ParameterBuilder::buildFromRules()` created `ParameterDefinition` DTOs
2. `AnonymousClassAnalyzer` immediately converted them to arrays via `convertParametersToArrays()`
3. `FormRequestAnalyzer` converted them back to DTOs via `ParameterDefinition::fromArray()`

## Solution

- `analyze()` now returns `ParameterDefinition[]` directly
- `tryAstBasedAnalysis()` and `extractParametersUsingReflection()` return DTOs directly
- `FormRequestAnalyzer` can use the DTOs without conversion
- `analyzeWithConditionalRules()` still converts to arrays at the boundary for backward compatibility with `ValidationAnalysisResult`

## Changes

| File | Changes |
|------|---------|
| `src/Analyzers/Support/AnonymousClassAnalyzer.php` | Return `ParameterDefinition[]` from `analyze()` |
| `src/Analyzers/FormRequestAnalyzer.php` | Simplify anonymous class handling |

## Test plan

- [x] All existing tests pass (2977 tests)
- [x] PHPStan analysis passes
- [x] Code formatting passes