### PR TITLE
refactor: use ParameterDefinition[] in ValidationAnalysisResult

### DIFF
--- a/src/Analyzers/FormRequestAnalyzer.php
+++ b/src/Analyzers/FormRequestAnalyzer.php
@@ -262,7 +262,7 @@ class FormRequestAnalyzer implements ClassAnalyzer, HasErrors
                 );
 
                 return new ValidationAnalysisResult(
-                    parameters: $this->convertParametersToArrays($parameters),
+                    parameters: $parameters,
                     conditionalRules: ConditionalRuleSet::fromArray($conditionalRulesArray),
                     attributes: $attributes,
                     messages: $messages,
@@ -279,7 +279,7 @@ class FormRequestAnalyzer implements ClassAnalyzer, HasErrors
             );
 
             return new ValidationAnalysisResult(
-                parameters: $this->convertParametersToArrays($parameters),
+                parameters: $parameters,
                 conditionalRules: ConditionalRuleSet::empty(),
                 attributes: $attributes,
                 messages: $messages,

--- a/tests/Unit/FormRequestAnalyzerTest.php
+++ b/tests/Unit/FormRequestAnalyzerTest.php
@@ -9,6 +9,7 @@ use LaravelSpectrum\Analyzers\Support\AnonymousClassAnalyzer;
 use LaravelSpectrum\Analyzers\Support\FormRequestAstExtractor;
 use LaravelSpectrum\Analyzers\Support\ParameterBuilder;
 use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\DTO\ParameterDefinition;
 use LaravelSpectrum\Tests\Fixtures\StoreUserRequest;
 use LaravelSpectrum\Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
@@ -728,7 +729,15 @@ class FormRequestAnalyzerTest extends TestCase
 
         $mockParameterBuilder = $this->createMock(ParameterBuilder::class);
         $mockParameterBuilder->method('buildFromRules')->willReturn([
-            ['name' => 'name', 'type' => 'string', 'required' => true, 'validation' => ['required', 'string']],
+            new ParameterDefinition(
+                name: 'name',
+                in: 'body',
+                required: true,
+                type: 'string',
+                description: '',
+                example: null,
+                validation: ['required', 'string'],
+            ),
         ]);
 
         $analyzer = new FormRequestAnalyzer(


### PR DESCRIPTION
## Summary
- Update `ValidationAnalysisResult` to use type-safe `ParameterDefinition[]` instead of `array<int, array<string, mixed>>` for the `$parameters` property
- Eliminate redundant array-to-DTO conversions in `FormRequestAnalyzer::performConditionalAnalysis()`
- Maintain backward compatibility via `toArray()` method

## Changes
- **`src/DTO/ValidationAnalysisResult.php`**
  - Update `$parameters` type annotation to `array<ParameterDefinition>`
  - Update `fromArray()` to convert parameter arrays to `ParameterDefinition` DTOs
  - Update `toArray()` to convert DTOs back to arrays
  - Update `getParameterByName()` return type to `?ParameterDefinition`
  - Update `getRequiredParameters()` return type to `array<ParameterDefinition>`
  - Update `getParameterNames()` to use DTO property access

- **`src/Analyzers/FormRequestAnalyzer.php`**
  - Remove `convertParametersToArrays()` calls in `performConditionalAnalysis()`
  - Pass `ParameterDefinition[]` directly to `ValidationAnalysisResult` constructor

- **`tests/Unit/DTO/ValidationAnalysisResultTest.php`**
  - Update all tests to use `ParameterDefinition` DTOs instead of raw arrays
  - Add helper method `createParameter()` for cleaner test setup

- **`tests/Unit/FormRequestAnalyzerTest.php`**
  - Update mock `ParameterBuilder` to return `ParameterDefinition` objects

## Test plan
- [x] All existing tests pass (2977 tests, 9082 assertions)
- [x] PHPStan passes
- [x] Laravel Pint formatting passes