### PR TITLE
refactor: add ConditionalRule DTO for type-safe conditional validation rules

### DIFF
--- a/src/DTO/ConditionalRule.php
+++ b/src/DTO/ConditionalRule.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\DTO;
+
+/**
+ * Represents a single conditional validation rule set with its conditions and rules.
+ *
+ * Used within ConditionalRuleSet to represent individual rule sets
+ * that apply under specific conditions (e.g., HTTP method, request field).
+ */
+final readonly class ConditionalRule
+{
+    /**
+     * @param  array<int, ConditionResult>  $conditions  The conditions under which rules apply
+     * @param  array<string, mixed>  $rules  Validation rules that apply when conditions are met
+     * @param  float  $probability  Probability that this rule set will be executed
+     */
+    public function __construct(
+        public array $conditions,
+        public array $rules,
+        public float $probability = 1.0,
+    ) {}
+
+    /**
+     * Create from an array.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $conditions = [];
+        foreach ($data['conditions'] ?? [] as $condition) {
+            $conditions[] = $condition instanceof ConditionResult
+                ? $condition
+                : ConditionResult::fromArray($condition);
+        }
+
+        return new self(
+            conditions: $conditions,
+            rules: $data['rules'] ?? [],
+            probability: $data['probability'] ?? 1.0,
+        );
+    }
+
+    /**
+     * Convert to array (preserves ConditionResult objects for backward compatibility).
+     *
+     * @return array{conditions: array<int, ConditionResult>, rules: array<string, mixed>, probability: float}
+     */
+    public function toArray(): array
+    {
+        return [
+            'conditions' => $this->conditions,
+            'rules' => $this->rules,
+            'probability' => $this->probability,
+        ];
+    }
+
+    /**
+     * Check if this rule has any rules defined.
+     */
+    public function hasRules(): bool
+    {
+        return count($this->rules) > 0;
+    }
+
+    /**
+     * Check if this rule has any conditions defined.
+     */
+    public function hasConditions(): bool
+    {
+        return count($this->conditions) > 0;
+    }
+
+    /**
+     * Check if this rule's first condition is an HTTP method condition.
+     */
+    public function isHttpMethodCondition(): bool
+    {
+        if (empty($this->conditions)) {
+            return false;
+        }
+
+        return $this->conditions[0]->isHttpMethod();
+    }
+
+    /**
+     * Get the HTTP method if this is an HTTP method condition.
+     */
+    public function getHttpMethod(): ?string
+    {
+        if (! $this->isHttpMethodCondition()) {
+            return null;
+        }
+
+        return $this->conditions[0]->method;
+    }
+
+    /**
+     * Get the number of rules in this conditional rule.
+     */
+    public function getRuleCount(): int
+    {
+        return count($this->rules);
+    }
+
+    /**
+     * Get the field names from the rules.
+     *
+     * @return array<int, string>
+     */
+    public function getFieldNames(): array
+    {
+        return array_keys($this->rules);
+    }
+}

--- a/tests/Unit/DTO/ConditionalRuleTest.php
+++ b/tests/Unit/DTO/ConditionalRuleTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\DTO;
+
+use LaravelSpectrum\DTO\ConditionalRule;
+use LaravelSpectrum\DTO\ConditionResult;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ConditionalRuleTest extends TestCase
+{
+    #[Test]
+    public function it_can_be_constructed(): void
+    {
+        $condition = ConditionResult::httpMethod('POST', 'isMethod("POST")');
+        $rule = new ConditionalRule(
+            conditions: [$condition],
+            rules: ['name' => 'required', 'email' => 'required|email'],
+            probability: 0.8,
+        );
+
+        $this->assertCount(1, $rule->conditions);
+        $this->assertInstanceOf(ConditionResult::class, $rule->conditions[0]);
+        $this->assertEquals(['name' => 'required', 'email' => 'required|email'], $rule->rules);
+        $this->assertEquals(0.8, $rule->probability);
+    }
+
+    #[Test]
+    public function it_creates_from_array(): void
+    {
+        $array = [
+            'conditions' => [
+                ['type' => 'http_method', 'expression' => 'isMethod("PUT")', 'method' => 'PUT'],
+            ],
+            'rules' => ['id' => 'required|integer'],
+            'probability' => 0.5,
+        ];
+
+        $rule = ConditionalRule::fromArray($array);
+
+        $this->assertCount(1, $rule->conditions);
+        $this->assertInstanceOf(ConditionResult::class, $rule->conditions[0]);
+        $this->assertTrue($rule->conditions[0]->isHttpMethod());
+        $this->assertEquals('PUT', $rule->conditions[0]->method);
+        $this->assertEquals(['id' => 'required|integer'], $rule->rules);
+        $this->assertEquals(0.5, $rule->probability);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_defaults(): void
+    {
+        $array = [];
+
+        $rule = ConditionalRule::fromArray($array);
+
+        $this->assertEquals([], $rule->conditions);
+        $this->assertEquals([], $rule->rules);
+        $this->assertEquals(1.0, $rule->probability);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_condition_result_objects(): void
+    {
+        $condition = ConditionResult::httpMethod('POST', 'isMethod("POST")');
+        $array = [
+            'conditions' => [$condition],
+            'rules' => ['name' => 'required'],
+        ];
+
+        $rule = ConditionalRule::fromArray($array);
+
+        $this->assertSame($condition, $rule->conditions[0]);
+    }
+
+    #[Test]
+    public function it_converts_to_array(): void
+    {
+        $condition = ConditionResult::httpMethod('POST', 'isMethod("POST")');
+        $rule = new ConditionalRule(
+            conditions: [$condition],
+            rules: ['role' => 'required', 'permissions' => 'array'],
+            probability: 0.75,
+        );
+
+        $array = $rule->toArray();
+
+        $this->assertArrayHasKey('conditions', $array);
+        $this->assertArrayHasKey('rules', $array);
+        $this->assertArrayHasKey('probability', $array);
+        // ConditionResult objects are preserved for backward compatibility
+        $this->assertInstanceOf(ConditionResult::class, $array['conditions'][0]);
+        $this->assertTrue($array['conditions'][0]->isHttpMethod());
+        $this->assertEquals('POST', $array['conditions'][0]->method);
+        $this->assertEquals(['role' => 'required', 'permissions' => 'array'], $array['rules']);
+        $this->assertEquals(0.75, $array['probability']);
+    }
+
+    #[Test]
+    public function it_checks_if_has_rules(): void
+    {
+        $withRules = new ConditionalRule(
+            conditions: [],
+            rules: ['field' => 'required'],
+        );
+        $withoutRules = new ConditionalRule(
+            conditions: [],
+            rules: [],
+        );
+
+        $this->assertTrue($withRules->hasRules());
+        $this->assertFalse($withoutRules->hasRules());
+    }
+
+    #[Test]
+    public function it_checks_if_has_conditions(): void
+    {
+        $withConditions = new ConditionalRule(
+            conditions: [ConditionResult::httpMethod('POST', 'isMethod("POST")')],
+            rules: [],
+        );
+        $withoutConditions = new ConditionalRule(
+            conditions: [],
+            rules: [],
+        );
+
+        $this->assertTrue($withConditions->hasConditions());
+        $this->assertFalse($withoutConditions->hasConditions());
+    }
+
+    #[Test]
+    public function it_checks_if_is_http_method_condition(): void
+    {
+        $httpMethodCondition = new ConditionalRule(
+            conditions: [ConditionResult::httpMethod('POST', 'isMethod("POST")')],
+            rules: ['name' => 'required'],
+        );
+        $userCheckCondition = new ConditionalRule(
+            conditions: [ConditionResult::userCheck('isAdmin()', 'isAdmin')],
+            rules: ['role' => 'required'],
+        );
+        $noCondition = new ConditionalRule(
+            conditions: [],
+            rules: ['field' => 'required'],
+        );
+
+        $this->assertTrue($httpMethodCondition->isHttpMethodCondition());
+        $this->assertFalse($userCheckCondition->isHttpMethodCondition());
+        $this->assertFalse($noCondition->isHttpMethodCondition());
+    }
+
+    #[Test]
+    public function it_gets_http_method(): void
+    {
+        $postCondition = new ConditionalRule(
+            conditions: [ConditionResult::httpMethod('POST', 'isMethod("POST")')],
+            rules: [],
+        );
+        $userCheckCondition = new ConditionalRule(
+            conditions: [ConditionResult::userCheck('isAdmin()', 'isAdmin')],
+            rules: [],
+        );
+
+        $this->assertEquals('POST', $postCondition->getHttpMethod());
+        $this->assertNull($userCheckCondition->getHttpMethod());
+    }
+
+    #[Test]
+    public function it_counts_rules(): void
+    {
+        $empty = new ConditionalRule(conditions: [], rules: []);
+        $withRules = new ConditionalRule(
+            conditions: [],
+            rules: ['a' => 'required', 'b' => 'string', 'c' => 'integer'],
+        );
+
+        $this->assertEquals(0, $empty->getRuleCount());
+        $this->assertEquals(3, $withRules->getRuleCount());
+    }
+
+    #[Test]
+    public function it_gets_rule_field_names(): void
+    {
+        $rule = new ConditionalRule(
+            conditions: [],
+            rules: ['name' => 'required', 'email' => 'required|email', 'age' => 'integer'],
+        );
+
+        $fieldNames = $rule->getFieldNames();
+
+        $this->assertCount(3, $fieldNames);
+        $this->assertContains('name', $fieldNames);
+        $this->assertContains('email', $fieldNames);
+        $this->assertContains('age', $fieldNames);
+    }
+
+    #[Test]
+    public function it_survives_serialization_round_trip(): void
+    {
+        $original = new ConditionalRule(
+            conditions: [ConditionResult::httpMethod('DELETE', 'isMethod("DELETE")')],
+            rules: ['id' => 'required|integer', 'confirm' => 'boolean'],
+            probability: 0.9,
+        );
+
+        $restored = ConditionalRule::fromArray($original->toArray());
+
+        $this->assertCount(1, $restored->conditions);
+        $this->assertInstanceOf(ConditionResult::class, $restored->conditions[0]);
+        $this->assertTrue($restored->conditions[0]->isHttpMethod());
+        $this->assertEquals('DELETE', $restored->conditions[0]->method);
+        $this->assertEquals($original->rules, $restored->rules);
+        $this->assertEquals($original->probability, $restored->probability);
+    }
+}


### PR DESCRIPTION
## Summary

- Create `ConditionalRule` DTO to replace raw arrays in `ConditionalRuleSet.ruleSets`
- Update `ConditionalRuleSet` to use `array<ConditionalRule>` instead of `array<array>`
- Preserve `ConditionResult` objects in `toArray()` for backward compatibility with existing code

## Changes

### New Files
- `src/DTO/ConditionalRule.php` - New DTO with `conditions`, `rules`, and `probability` properties
- `tests/Unit/DTO/ConditionalRuleTest.php` - Comprehensive tests for the new DTO

### Modified Files
- `src/DTO/ConditionalRuleSet.php` - Updated to use `ConditionalRule[]` type
- `tests/Unit/DTO/ConditionalRuleSetTest.php` - Updated to use DTOs
- `tests/Unit/DTO/ValidationAnalysisResultTest.php` - Updated to use DTOs

## ConditionalRule DTO Features

```php
final readonly class ConditionalRule
{
    public function __construct(
        public array $conditions,    // array<ConditionResult>
        public array $rules,         // array<string, mixed>
        public float $probability = 1.0,
    ) {}

    // Helper methods
    public function hasRules(): bool;
    public function hasConditions(): bool;
    public function isHttpMethodCondition(): bool;
    public function getHttpMethod(): ?string;
    public function getRuleCount(): int;
    public function getFieldNames(): array;
}
```

## Test Plan

- [x] All existing tests pass (2989 tests, 9146 assertions)
- [x] PHPStan analysis passes
- [x] Laravel Pint formatting passes
- [x] New DTO tests cover construction, fromArray, toArray, and helper methods