### PR TITLE
refactor: introduce ConditionalRuleDetail DTO for type-safe conditional rules

### DIFF
--- a/src/Analyzers/Support/RuleRequirementAnalyzer.php
+++ b/src/Analyzers/Support/RuleRequirementAnalyzer.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Analyzers\Support;
+
+use LaravelSpectrum\DTO\ConditionalRuleDetail;
 
 /**
  * Analyzes validation rules for requirement conditions.
@@ -84,7 +88,8 @@ class RuleRequirementAnalyzer
     /**
      * Extract details of conditional rules.
      *
-     * @param  string|array  $rules
+     * @param  string|array<mixed>  $rules
+     * @return array<int, ConditionalRuleDetail>
      */
     public function extractConditionalRuleDetails($rules): array
     {
@@ -107,11 +112,11 @@ class RuleRequirementAnalyzer
             );
 
             if (in_array($ruleName, $allConditionalRules)) {
-                $conditionalRules[] = [
-                    'type' => $ruleName,
-                    'parameters' => $ruleParams,
-                    'full_rule' => $rule,
-                ];
+                $conditionalRules[] = new ConditionalRuleDetail(
+                    type: $ruleName,
+                    parameters: $ruleParams,
+                    fullRule: $rule,
+                );
             }
         }
 

--- a/src/DTO/ConditionalRuleDetail.php
+++ b/src/DTO/ConditionalRuleDetail.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\DTO;
+
+/**
+ * Represents details of a conditional validation rule.
+ *
+ * Used to encapsulate information about conditional rules like required_if,
+ * prohibited_unless, exclude_with, etc.
+ */
+final readonly class ConditionalRuleDetail
+{
+    /**
+     * Conditional required rule names.
+     */
+    private const REQUIRED_RULES = [
+        'required_if',
+        'required_unless',
+        'required_with',
+        'required_without',
+        'required_with_all',
+        'required_without_all',
+    ];
+
+    /**
+     * Prohibited rule names.
+     */
+    private const PROHIBITED_RULES = [
+        'prohibited_if',
+        'prohibited_unless',
+        'prohibited_with',
+        'prohibited_without',
+    ];
+
+    /**
+     * Exclude rule names.
+     */
+    private const EXCLUDE_RULES = [
+        'exclude_if',
+        'exclude_unless',
+        'exclude_with',
+        'exclude_without',
+    ];
+
+    /**
+     * @param  string  $type  The rule type (e.g., 'required_if', 'prohibited_unless')
+     * @param  string  $parameters  The rule parameters (e.g., 'status,active')
+     * @param  string  $fullRule  The complete rule string (e.g., 'required_if:status,active')
+     */
+    public function __construct(
+        public string $type,
+        public string $parameters,
+        public string $fullRule,
+    ) {}
+
+    /**
+     * Create from an array.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            type: $data['type'] ?? '',
+            parameters: $data['parameters'] ?? '',
+            fullRule: $data['full_rule'] ?? '',
+        );
+    }
+
+    /**
+     * Convert to array.
+     *
+     * @return array{type: string, parameters: string, full_rule: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => $this->type,
+            'parameters' => $this->parameters,
+            'full_rule' => $this->fullRule,
+        ];
+    }
+
+    /**
+     * Check if this is a required-type rule.
+     */
+    public function isRequiredRule(): bool
+    {
+        return in_array($this->type, self::REQUIRED_RULES, true);
+    }
+
+    /**
+     * Check if this is a prohibited-type rule.
+     */
+    public function isProhibitedRule(): bool
+    {
+        return in_array($this->type, self::PROHIBITED_RULES, true);
+    }
+
+    /**
+     * Check if this is an exclude-type rule.
+     */
+    public function isExcludeRule(): bool
+    {
+        return in_array($this->type, self::EXCLUDE_RULES, true);
+    }
+
+    /**
+     * Get the parameters as an array.
+     *
+     * @return array<int, string>
+     */
+    public function getParametersArray(): array
+    {
+        if ($this->parameters === '') {
+            return [];
+        }
+
+        return explode(',', $this->parameters);
+    }
+}

--- a/tests/Unit/Analyzers/Support/RuleRequirementAnalyzerTest.php
+++ b/tests/Unit/Analyzers/Support/RuleRequirementAnalyzerTest.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Tests\Unit\Analyzers\Support;
 
 use LaravelSpectrum\Analyzers\Support\RuleRequirementAnalyzer;
+use LaravelSpectrum\DTO\ConditionalRuleDetail;
 use LaravelSpectrum\Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -64,9 +67,10 @@ class RuleRequirementAnalyzerTest extends TestCase
         $details = $this->analyzer->extractConditionalRuleDetails($rules);
 
         $this->assertCount(1, $details);
-        $this->assertEquals('required_if', $details[0]['type']);
-        $this->assertEquals('status,active', $details[0]['parameters']);
-        $this->assertEquals('required_if:status,active', $details[0]['full_rule']);
+        $this->assertInstanceOf(ConditionalRuleDetail::class, $details[0]);
+        $this->assertEquals('required_if', $details[0]->type);
+        $this->assertEquals('status,active', $details[0]->parameters);
+        $this->assertEquals('required_if:status,active', $details[0]->fullRule);
     }
 
     #[Test]
@@ -76,8 +80,9 @@ class RuleRequirementAnalyzerTest extends TestCase
         $details = $this->analyzer->extractConditionalRuleDetails($rules);
 
         $this->assertCount(1, $details);
-        $this->assertEquals('prohibited_if', $details[0]['type']);
-        $this->assertEquals('status,inactive', $details[0]['parameters']);
+        $this->assertInstanceOf(ConditionalRuleDetail::class, $details[0]);
+        $this->assertEquals('prohibited_if', $details[0]->type);
+        $this->assertEquals('status,inactive', $details[0]->parameters);
     }
 
     #[Test]
@@ -87,8 +92,9 @@ class RuleRequirementAnalyzerTest extends TestCase
         $details = $this->analyzer->extractConditionalRuleDetails($rules);
 
         $this->assertCount(1, $details);
-        $this->assertEquals('exclude_if', $details[0]['type']);
-        $this->assertEquals('role,guest', $details[0]['parameters']);
+        $this->assertInstanceOf(ConditionalRuleDetail::class, $details[0]);
+        $this->assertEquals('exclude_if', $details[0]->type);
+        $this->assertEquals('role,guest', $details[0]->parameters);
     }
 
     #[Test]
@@ -98,8 +104,10 @@ class RuleRequirementAnalyzerTest extends TestCase
         $details = $this->analyzer->extractConditionalRuleDetails($rules);
 
         $this->assertCount(2, $details);
-        $this->assertEquals('required_if', $details[0]['type']);
-        $this->assertEquals('prohibited_unless', $details[1]['type']);
+        $this->assertInstanceOf(ConditionalRuleDetail::class, $details[0]);
+        $this->assertInstanceOf(ConditionalRuleDetail::class, $details[1]);
+        $this->assertEquals('required_if', $details[0]->type);
+        $this->assertEquals('prohibited_unless', $details[1]->type);
     }
 
     #[Test]
@@ -141,7 +149,8 @@ class RuleRequirementAnalyzerTest extends TestCase
 
         $details = $this->analyzer->extractConditionalRuleDetails('required_with:email|string');
         $this->assertCount(1, $details);
-        $this->assertEquals('required_with', $details[0]['type']);
+        $this->assertInstanceOf(ConditionalRuleDetail::class, $details[0]);
+        $this->assertEquals('required_with', $details[0]->type);
     }
 
     #[Test]
@@ -183,8 +192,10 @@ class RuleRequirementAnalyzerTest extends TestCase
         $details = $this->analyzer->extractConditionalRuleDetails($rules);
 
         $this->assertCount(2, $details);
-        $this->assertEquals('prohibited_with', $details[0]['type']);
-        $this->assertEquals('prohibited_without', $details[1]['type']);
+        $this->assertInstanceOf(ConditionalRuleDetail::class, $details[0]);
+        $this->assertInstanceOf(ConditionalRuleDetail::class, $details[1]);
+        $this->assertEquals('prohibited_with', $details[0]->type);
+        $this->assertEquals('prohibited_without', $details[1]->type);
     }
 
     #[Test]
@@ -194,9 +205,12 @@ class RuleRequirementAnalyzerTest extends TestCase
         $details = $this->analyzer->extractConditionalRuleDetails($rules);
 
         $this->assertCount(3, $details);
-        $this->assertEquals('exclude_unless', $details[0]['type']);
-        $this->assertEquals('exclude_with', $details[1]['type']);
-        $this->assertEquals('exclude_without', $details[2]['type']);
+        $this->assertInstanceOf(ConditionalRuleDetail::class, $details[0]);
+        $this->assertInstanceOf(ConditionalRuleDetail::class, $details[1]);
+        $this->assertInstanceOf(ConditionalRuleDetail::class, $details[2]);
+        $this->assertEquals('exclude_unless', $details[0]->type);
+        $this->assertEquals('exclude_with', $details[1]->type);
+        $this->assertEquals('exclude_without', $details[2]->type);
     }
 
     #[Test]

--- a/tests/Unit/DTO/ConditionalRuleDetailTest.php
+++ b/tests/Unit/DTO/ConditionalRuleDetailTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\DTO;
+
+use LaravelSpectrum\DTO\ConditionalRuleDetail;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ConditionalRuleDetailTest extends TestCase
+{
+    #[Test]
+    public function it_can_be_constructed(): void
+    {
+        $detail = new ConditionalRuleDetail(
+            type: 'required_if',
+            parameters: 'status,active',
+            fullRule: 'required_if:status,active',
+        );
+
+        $this->assertEquals('required_if', $detail->type);
+        $this->assertEquals('status,active', $detail->parameters);
+        $this->assertEquals('required_if:status,active', $detail->fullRule);
+    }
+
+    #[Test]
+    public function it_can_be_constructed_with_empty_parameters(): void
+    {
+        $detail = new ConditionalRuleDetail(
+            type: 'required_with',
+            parameters: '',
+            fullRule: 'required_with',
+        );
+
+        $this->assertEquals('required_with', $detail->type);
+        $this->assertEquals('', $detail->parameters);
+        $this->assertEquals('required_with', $detail->fullRule);
+    }
+
+    #[Test]
+    public function it_creates_from_array(): void
+    {
+        $array = [
+            'type' => 'prohibited_if',
+            'parameters' => 'role,guest',
+            'full_rule' => 'prohibited_if:role,guest',
+        ];
+
+        $detail = ConditionalRuleDetail::fromArray($array);
+
+        $this->assertEquals('prohibited_if', $detail->type);
+        $this->assertEquals('role,guest', $detail->parameters);
+        $this->assertEquals('prohibited_if:role,guest', $detail->fullRule);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_defaults(): void
+    {
+        $array = [
+            'type' => 'exclude_if',
+        ];
+
+        $detail = ConditionalRuleDetail::fromArray($array);
+
+        $this->assertEquals('exclude_if', $detail->type);
+        $this->assertEquals('', $detail->parameters);
+        $this->assertEquals('', $detail->fullRule);
+    }
+
+    #[Test]
+    public function it_converts_to_array(): void
+    {
+        $detail = new ConditionalRuleDetail(
+            type: 'required_unless',
+            parameters: 'status,inactive',
+            fullRule: 'required_unless:status,inactive',
+        );
+
+        $array = $detail->toArray();
+
+        $this->assertArrayHasKey('type', $array);
+        $this->assertArrayHasKey('parameters', $array);
+        $this->assertArrayHasKey('full_rule', $array);
+        $this->assertEquals('required_unless', $array['type']);
+        $this->assertEquals('status,inactive', $array['parameters']);
+        $this->assertEquals('required_unless:status,inactive', $array['full_rule']);
+    }
+
+    #[Test]
+    public function it_checks_if_is_required_rule(): void
+    {
+        $requiredIf = new ConditionalRuleDetail('required_if', 'status,active', 'required_if:status,active');
+        $requiredWith = new ConditionalRuleDetail('required_with', 'email', 'required_with:email');
+        $requiredWithAll = new ConditionalRuleDetail('required_with_all', 'a,b,c', 'required_with_all:a,b,c');
+        $prohibitedIf = new ConditionalRuleDetail('prohibited_if', 'role,guest', 'prohibited_if:role,guest');
+        $excludeIf = new ConditionalRuleDetail('exclude_if', 'type,free', 'exclude_if:type,free');
+
+        $this->assertTrue($requiredIf->isRequiredRule());
+        $this->assertTrue($requiredWith->isRequiredRule());
+        $this->assertTrue($requiredWithAll->isRequiredRule());
+        $this->assertFalse($prohibitedIf->isRequiredRule());
+        $this->assertFalse($excludeIf->isRequiredRule());
+    }
+
+    #[Test]
+    public function it_checks_if_is_prohibited_rule(): void
+    {
+        $prohibitedIf = new ConditionalRuleDetail('prohibited_if', 'role,guest', 'prohibited_if:role,guest');
+        $prohibitedUnless = new ConditionalRuleDetail('prohibited_unless', 'role,admin', 'prohibited_unless:role,admin');
+        $requiredIf = new ConditionalRuleDetail('required_if', 'status,active', 'required_if:status,active');
+
+        $this->assertTrue($prohibitedIf->isProhibitedRule());
+        $this->assertTrue($prohibitedUnless->isProhibitedRule());
+        $this->assertFalse($requiredIf->isProhibitedRule());
+    }
+
+    #[Test]
+    public function it_checks_if_is_exclude_rule(): void
+    {
+        $excludeIf = new ConditionalRuleDetail('exclude_if', 'type,free', 'exclude_if:type,free');
+        $excludeUnless = new ConditionalRuleDetail('exclude_unless', 'type,premium', 'exclude_unless:type,premium');
+        $requiredIf = new ConditionalRuleDetail('required_if', 'status,active', 'required_if:status,active');
+
+        $this->assertTrue($excludeIf->isExcludeRule());
+        $this->assertTrue($excludeUnless->isExcludeRule());
+        $this->assertFalse($requiredIf->isExcludeRule());
+    }
+
+    #[Test]
+    public function it_parses_parameters_to_array(): void
+    {
+        $detail = new ConditionalRuleDetail(
+            type: 'required_if',
+            parameters: 'status,active,1',
+            fullRule: 'required_if:status,active,1',
+        );
+
+        $params = $detail->getParametersArray();
+
+        $this->assertEquals(['status', 'active', '1'], $params);
+    }
+
+    #[Test]
+    public function it_returns_empty_array_for_empty_parameters(): void
+    {
+        $detail = new ConditionalRuleDetail(
+            type: 'required_with',
+            parameters: '',
+            fullRule: 'required_with',
+        );
+
+        $params = $detail->getParametersArray();
+
+        $this->assertEquals([], $params);
+    }
+
+    #[Test]
+    public function it_survives_serialization_round_trip(): void
+    {
+        $original = new ConditionalRuleDetail(
+            type: 'required_without_all',
+            parameters: 'field1,field2,field3',
+            fullRule: 'required_without_all:field1,field2,field3',
+        );
+
+        $restored = ConditionalRuleDetail::fromArray($original->toArray());
+
+        $this->assertEquals($original->type, $restored->type);
+        $this->assertEquals($original->parameters, $restored->parameters);
+        $this->assertEquals($original->fullRule, $restored->fullRule);
+    }
+}


### PR DESCRIPTION
## Summary
- Create `ConditionalRuleDetail` DTO to encapsulate conditional validation rule details
- Update `RuleRequirementAnalyzer::extractConditionalRuleDetails()` to return typed DTOs instead of arrays
- Add backward compatibility support in `ParameterDefinition` for array-based data

## Changes

### New Files
- `src/DTO/ConditionalRuleDetail.php` - DTO with `type`, `parameters`, `fullRule` properties
- `tests/Unit/DTO/ConditionalRuleDetailTest.php` - Comprehensive test coverage

### Modified Files
- `src/Analyzers/Support/RuleRequirementAnalyzer.php` - Returns `ConditionalRuleDetail[]` 
- `src/DTO/ParameterDefinition.php` - Updated to support DTO types
- `tests/Unit/Analyzers/Support/RuleRequirementAnalyzerTest.php` - Updated assertions for DTO properties

### Key Features
- Type classification methods: `isRequiredRule()`, `isProhibitedRule()`, `isExcludeRule()`
- Parameter parsing: `getParametersArray()`
- Serialization: `fromArray()` / `toArray()`

## Test plan
- [x] All 3000 tests pass
- [x] PHPStan passes
- [x] Laravel Pint passes