### PR TITLE
refactor: introduce TagGroup and TagDefinition DTOs

### DIFF
--- a/src/DTO/TagDefinition.php
+++ b/src/DTO/TagDefinition.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\DTO;
+
+/**
+ * Represents a tag definition for OpenAPI tags section.
+ *
+ * Tag definitions provide metadata about tags used in the API,
+ * including optional descriptions that appear in documentation.
+ */
+final readonly class TagDefinition
+{
+    /**
+     * @param  string  $name  The tag name (must match tags used in operations)
+     * @param  string|null  $description  Optional human-readable description
+     */
+    public function __construct(
+        public string $name,
+        public ?string $description = null,
+    ) {}
+
+    /**
+     * Create from an array.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            name: $data['name'] ?? '',
+            description: $data['description'] ?? null,
+        );
+    }
+
+    /**
+     * Convert to array.
+     *
+     * Returns an array with 'name' key always present.
+     * The 'description' key is only included if description is not null and not empty.
+     *
+     * @return array{name: string, description?: string}
+     */
+    public function toArray(): array
+    {
+        $result = ['name' => $this->name];
+
+        if ($this->hasDescription()) {
+            $result['description'] = $this->description;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if this tag definition has a description.
+     */
+    public function hasDescription(): bool
+    {
+        return $this->description !== null && $this->description !== '';
+    }
+}

--- a/src/DTO/TagGroup.php
+++ b/src/DTO/TagGroup.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\DTO;
+
+/**
+ * Represents a tag group for OpenAPI x-tagGroups extension.
+ *
+ * Tag groups are used by documentation viewers like Redoc to organize
+ * API endpoints into logical categories in the sidebar navigation.
+ */
+final readonly class TagGroup
+{
+    /**
+     * @param  string  $name  The display name of the tag group
+     * @param  array<string>  $tags  List of tag names belonging to this group
+     */
+    public function __construct(
+        public string $name,
+        public array $tags,
+    ) {}
+
+    /**
+     * Create from an array.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            name: $data['name'] ?? '',
+            tags: $data['tags'] ?? [],
+        );
+    }
+
+    /**
+     * Convert to array.
+     *
+     * @return array{name: string, tags: array<string>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'tags' => $this->tags,
+        ];
+    }
+
+    /**
+     * Check if this group has any tags.
+     */
+    public function hasTags(): bool
+    {
+        return count($this->tags) > 0;
+    }
+
+    /**
+     * Get the number of tags in this group.
+     */
+    public function getTagCount(): int
+    {
+        return count($this->tags);
+    }
+
+    /**
+     * Check if this group contains a specific tag.
+     */
+    public function containsTag(string $tag): bool
+    {
+        return in_array($tag, $this->tags, true);
+    }
+}

--- a/src/Generators/OpenApiGenerator.php
+++ b/src/Generators/OpenApiGenerator.php
@@ -100,13 +100,13 @@ class OpenApiGenerator
         // Generate tags section with descriptions
         $tagDefinitions = $this->tagGroupGenerator->generateTagDefinitions($usedTags);
         if (! empty($tagDefinitions)) {
-            $openapi['tags'] = $tagDefinitions;
+            $openapi['tags'] = array_map(fn ($def) => $def->toArray(), $tagDefinitions);
         }
 
         // Generate x-tagGroups if configured
         $tagGroups = $this->tagGroupGenerator->generateTagGroups($usedTags);
         if (! empty($tagGroups)) {
-            $openapi['x-tagGroups'] = $tagGroups;
+            $openapi['x-tagGroups'] = array_map(fn ($group) => $group->toArray(), $tagGroups);
         }
 
         // Populate components.schemas with registered resource schemas

--- a/src/Generators/TagGroupGenerator.php
+++ b/src/Generators/TagGroupGenerator.php
@@ -1,6 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Generators;
+
+use LaravelSpectrum\DTO\TagDefinition;
+use LaravelSpectrum\DTO\TagGroup;
 
 /**
  * Generates OpenAPI tag groups and tag definitions.
@@ -20,7 +25,7 @@ class TagGroupGenerator
      * Generate x-tagGroups structure for OpenAPI specification.
      *
      * @param  array<string>  $usedTags  List of tags actually used in the specification
-     * @return array<array{name: string, tags: array<string>}>
+     * @return array<TagGroup>
      */
     public function generateTagGroups(array $usedTags): array
     {
@@ -53,10 +58,10 @@ class TagGroupGenerator
             $filteredTags = array_values(array_intersect($tags, $usedTags));
 
             if (! empty($filteredTags)) {
-                $result[] = [
-                    'name' => $groupName,
-                    'tags' => $filteredTags,
-                ];
+                $result[] = new TagGroup(
+                    name: $groupName,
+                    tags: $filteredTags,
+                );
                 $groupedTags = array_merge($groupedTags, $filteredTags);
             }
         }
@@ -67,10 +72,10 @@ class TagGroupGenerator
             $ungroupedTags = array_values(array_diff($usedTags, $groupedTags));
 
             if (! empty($ungroupedTags)) {
-                $result[] = [
-                    'name' => $ungroupedGroupName,
-                    'tags' => $ungroupedTags,
-                ];
+                $result[] = new TagGroup(
+                    name: $ungroupedGroupName,
+                    tags: $ungroupedTags,
+                );
             }
         }
 
@@ -81,7 +86,7 @@ class TagGroupGenerator
      * Generate OpenAPI tags section with descriptions.
      *
      * @param  array<string>  $usedTags  List of tags actually used in the specification
-     * @return array<array{name: string, description?: string}>
+     * @return array<TagDefinition>
      */
     public function generateTagDefinitions(array $usedTags): array
     {
@@ -101,13 +106,15 @@ class TagGroupGenerator
 
         $result = [];
         foreach ($usedTags as $tag) {
-            $tagDefinition = ['name' => $tag];
-
+            $description = null;
             if (isset($descriptions[$tag]) && is_string($descriptions[$tag]) && $descriptions[$tag] !== '') {
-                $tagDefinition['description'] = $descriptions[$tag];
+                $description = $descriptions[$tag];
             }
 
-            $result[] = $tagDefinition;
+            $result[] = new TagDefinition(
+                name: $tag,
+                description: $description,
+            );
         }
 
         return $result;

--- a/tests/Unit/DTO/TagDefinitionTest.php
+++ b/tests/Unit/DTO/TagDefinitionTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\DTO;
+
+use LaravelSpectrum\DTO\TagDefinition;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class TagDefinitionTest extends TestCase
+{
+    #[Test]
+    public function it_can_be_constructed_with_description(): void
+    {
+        $tagDefinition = new TagDefinition(
+            name: 'User',
+            description: 'User management endpoints',
+        );
+
+        $this->assertEquals('User', $tagDefinition->name);
+        $this->assertEquals('User management endpoints', $tagDefinition->description);
+    }
+
+    #[Test]
+    public function it_can_be_constructed_without_description(): void
+    {
+        $tagDefinition = new TagDefinition(
+            name: 'Post',
+        );
+
+        $this->assertEquals('Post', $tagDefinition->name);
+        $this->assertNull($tagDefinition->description);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_description(): void
+    {
+        $array = [
+            'name' => 'Comment',
+            'description' => 'Comment operations',
+        ];
+
+        $tagDefinition = TagDefinition::fromArray($array);
+
+        $this->assertEquals('Comment', $tagDefinition->name);
+        $this->assertEquals('Comment operations', $tagDefinition->description);
+    }
+
+    #[Test]
+    public function it_creates_from_array_without_description(): void
+    {
+        $array = [
+            'name' => 'Auth',
+        ];
+
+        $tagDefinition = TagDefinition::fromArray($array);
+
+        $this->assertEquals('Auth', $tagDefinition->name);
+        $this->assertNull($tagDefinition->description);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_defaults(): void
+    {
+        $array = [];
+
+        $tagDefinition = TagDefinition::fromArray($array);
+
+        $this->assertEquals('', $tagDefinition->name);
+        $this->assertNull($tagDefinition->description);
+    }
+
+    #[Test]
+    public function it_converts_to_array_with_description(): void
+    {
+        $tagDefinition = new TagDefinition(
+            name: 'Profile',
+            description: 'User profile endpoints',
+        );
+
+        $array = $tagDefinition->toArray();
+
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayHasKey('description', $array);
+        $this->assertEquals('Profile', $array['name']);
+        $this->assertEquals('User profile endpoints', $array['description']);
+    }
+
+    #[Test]
+    public function it_converts_to_array_without_description(): void
+    {
+        $tagDefinition = new TagDefinition(
+            name: 'Settings',
+        );
+
+        $array = $tagDefinition->toArray();
+
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayNotHasKey('description', $array);
+        $this->assertEquals('Settings', $array['name']);
+    }
+
+    #[Test]
+    public function it_checks_if_has_description(): void
+    {
+        $withDescription = new TagDefinition('Tag1', 'Some description');
+        $withoutDescription = new TagDefinition('Tag2');
+        $withEmptyDescription = new TagDefinition('Tag3', '');
+
+        $this->assertTrue($withDescription->hasDescription());
+        $this->assertFalse($withoutDescription->hasDescription());
+        $this->assertFalse($withEmptyDescription->hasDescription());
+    }
+
+    #[Test]
+    public function it_survives_serialization_round_trip_with_description(): void
+    {
+        $original = new TagDefinition(
+            name: 'Original',
+            description: 'Original description',
+        );
+
+        $restored = TagDefinition::fromArray($original->toArray());
+
+        $this->assertEquals($original->name, $restored->name);
+        $this->assertEquals($original->description, $restored->description);
+    }
+
+    #[Test]
+    public function it_survives_serialization_round_trip_without_description(): void
+    {
+        $original = new TagDefinition(
+            name: 'No Description',
+        );
+
+        $restored = TagDefinition::fromArray($original->toArray());
+
+        $this->assertEquals($original->name, $restored->name);
+        $this->assertNull($restored->description);
+    }
+}

--- a/tests/Unit/DTO/TagGroupTest.php
+++ b/tests/Unit/DTO/TagGroupTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\DTO;
+
+use LaravelSpectrum\DTO\TagGroup;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class TagGroupTest extends TestCase
+{
+    #[Test]
+    public function it_can_be_constructed(): void
+    {
+        $tagGroup = new TagGroup(
+            name: 'User Management',
+            tags: ['User', 'Profile', 'Auth'],
+        );
+
+        $this->assertEquals('User Management', $tagGroup->name);
+        $this->assertEquals(['User', 'Profile', 'Auth'], $tagGroup->tags);
+    }
+
+    #[Test]
+    public function it_can_be_constructed_with_empty_tags(): void
+    {
+        $tagGroup = new TagGroup(
+            name: 'Empty Group',
+            tags: [],
+        );
+
+        $this->assertEquals('Empty Group', $tagGroup->name);
+        $this->assertEquals([], $tagGroup->tags);
+    }
+
+    #[Test]
+    public function it_creates_from_array(): void
+    {
+        $array = [
+            'name' => 'Content',
+            'tags' => ['Post', 'Comment'],
+        ];
+
+        $tagGroup = TagGroup::fromArray($array);
+
+        $this->assertEquals('Content', $tagGroup->name);
+        $this->assertEquals(['Post', 'Comment'], $tagGroup->tags);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_defaults(): void
+    {
+        $array = [
+            'name' => 'Minimal',
+        ];
+
+        $tagGroup = TagGroup::fromArray($array);
+
+        $this->assertEquals('Minimal', $tagGroup->name);
+        $this->assertEquals([], $tagGroup->tags);
+    }
+
+    #[Test]
+    public function it_converts_to_array(): void
+    {
+        $tagGroup = new TagGroup(
+            name: 'API',
+            tags: ['Endpoint', 'Resource'],
+        );
+
+        $array = $tagGroup->toArray();
+
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayHasKey('tags', $array);
+        $this->assertEquals('API', $array['name']);
+        $this->assertEquals(['Endpoint', 'Resource'], $array['tags']);
+    }
+
+    #[Test]
+    public function it_checks_if_has_tags(): void
+    {
+        $withTags = new TagGroup('With Tags', ['User', 'Post']);
+        $withoutTags = new TagGroup('Without Tags', []);
+
+        $this->assertTrue($withTags->hasTags());
+        $this->assertFalse($withoutTags->hasTags());
+    }
+
+    #[Test]
+    public function it_returns_tag_count(): void
+    {
+        $tagGroup = new TagGroup('Group', ['A', 'B', 'C']);
+
+        $this->assertEquals(3, $tagGroup->getTagCount());
+    }
+
+    #[Test]
+    public function it_checks_if_contains_tag(): void
+    {
+        $tagGroup = new TagGroup('Group', ['User', 'Post', 'Comment']);
+
+        $this->assertTrue($tagGroup->containsTag('User'));
+        $this->assertTrue($tagGroup->containsTag('Post'));
+        $this->assertFalse($tagGroup->containsTag('Admin'));
+        $this->assertFalse($tagGroup->containsTag('user')); // Case sensitive
+    }
+
+    #[Test]
+    public function it_survives_serialization_round_trip(): void
+    {
+        $original = new TagGroup(
+            name: 'Original Group',
+            tags: ['Tag1', 'Tag2', 'Tag3'],
+        );
+
+        $restored = TagGroup::fromArray($original->toArray());
+
+        $this->assertEquals($original->name, $restored->name);
+        $this->assertEquals($original->tags, $restored->tags);
+    }
+}

--- a/tests/Unit/Generators/OpenApiGeneratorTest.php
+++ b/tests/Unit/Generators/OpenApiGeneratorTest.php
@@ -18,6 +18,7 @@ use LaravelSpectrum\DTO\OpenApiResponse;
 use LaravelSpectrum\DTO\OpenApiSchema;
 use LaravelSpectrum\DTO\ResourceInfo;
 use LaravelSpectrum\DTO\RouteAuthentication;
+use LaravelSpectrum\DTO\TagDefinition;
 use LaravelSpectrum\Generators\ErrorResponseGenerator;
 use LaravelSpectrum\Generators\ExampleGenerator;
 use LaravelSpectrum\Generators\OpenApiGenerator;
@@ -1336,8 +1337,8 @@ class OpenApiGeneratorTest extends TestCase
             ->once()
             ->with(['Posts', 'Users'])
             ->andReturn([
-                ['name' => 'Posts'],
-                ['name' => 'Users'],
+                new TagDefinition(name: 'Posts'),
+                new TagDefinition(name: 'Users'),
             ]);
         $this->tagGroupGenerator->shouldReceive('generateTagGroups')->andReturn([]);
 
@@ -1433,7 +1434,7 @@ class OpenApiGeneratorTest extends TestCase
         $this->tagGroupGenerator->shouldReceive('generateTagDefinitions')
             ->once()
             ->with(['Users'])
-            ->andReturn([['name' => 'Users']]);
+            ->andReturn([new TagDefinition(name: 'Users')]);
         $this->tagGroupGenerator->shouldReceive('generateTagGroups')->andReturn([]);
 
         // Recreate generator with updated mock

--- a/tests/Unit/Generators/TagGroupGeneratorTest.php
+++ b/tests/Unit/Generators/TagGroupGeneratorTest.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Tests\Unit\Generators;
 
+use LaravelSpectrum\DTO\TagDefinition;
+use LaravelSpectrum\DTO\TagGroup;
 use LaravelSpectrum\Generators\TagGroupGenerator;
 use LaravelSpectrum\Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
@@ -41,10 +45,12 @@ class TagGroupGeneratorTest extends TestCase
         $result = $this->generator->generateTagGroups($usedTags);
 
         $this->assertCount(2, $result);
-        $this->assertEquals('User Management', $result[0]['name']);
-        $this->assertEquals(['User', 'Profile'], $result[0]['tags']);
-        $this->assertEquals('Content', $result[1]['name']);
-        $this->assertEquals(['Post', 'Comment'], $result[1]['tags']);
+        $this->assertInstanceOf(TagGroup::class, $result[0]);
+        $this->assertInstanceOf(TagGroup::class, $result[1]);
+        $this->assertEquals('User Management', $result[0]->name);
+        $this->assertEquals(['User', 'Profile'], $result[0]->tags);
+        $this->assertEquals('Content', $result[1]->name);
+        $this->assertEquals(['Post', 'Comment'], $result[1]->tags);
     }
 
     #[Test]
@@ -62,10 +68,10 @@ class TagGroupGeneratorTest extends TestCase
         $result = $this->generator->generateTagGroups($usedTags);
 
         $this->assertCount(2, $result);
-        $this->assertEquals('User Management', $result[0]['name']);
-        $this->assertEquals(['User'], $result[0]['tags']);
-        $this->assertEquals('Other', $result[1]['name']);
-        $this->assertEqualsCanonicalizing(['Comment', 'Post'], $result[1]['tags']);
+        $this->assertEquals('User Management', $result[0]->name);
+        $this->assertEquals(['User'], $result[0]->tags);
+        $this->assertEquals('Other', $result[1]->name);
+        $this->assertEqualsCanonicalizing(['Comment', 'Post'], $result[1]->tags);
     }
 
     #[Test]
@@ -83,8 +89,8 @@ class TagGroupGeneratorTest extends TestCase
         $result = $this->generator->generateTagGroups($usedTags);
 
         $this->assertCount(2, $result);
-        $this->assertEquals(['User'], $result[0]['tags']);
-        $this->assertEquals(['Post'], $result[1]['tags']);
+        $this->assertEquals(['User'], $result[0]->tags);
+        $this->assertEquals(['Post'], $result[1]->tags);
     }
 
     #[Test]
@@ -102,7 +108,7 @@ class TagGroupGeneratorTest extends TestCase
         $result = $this->generator->generateTagGroups($usedTags);
 
         $this->assertCount(1, $result);
-        $this->assertEquals('User Management', $result[0]['name']);
+        $this->assertEquals('User Management', $result[0]->name);
     }
 
     #[Test]
@@ -116,8 +122,8 @@ class TagGroupGeneratorTest extends TestCase
 
         // Should still create "Other" group for ungrouped tags
         $this->assertCount(1, $result);
-        $this->assertEquals('Other', $result[0]['name']);
-        $this->assertEqualsCanonicalizing(['Post', 'User'], $result[0]['tags']);
+        $this->assertEquals('Other', $result[0]->name);
+        $this->assertEqualsCanonicalizing(['Post', 'User'], $result[0]->tags);
     }
 
     #[Test]
@@ -151,9 +157,9 @@ class TagGroupGeneratorTest extends TestCase
 
         $result = $this->generator->generateTagGroups($usedTags);
 
-        $this->assertEquals('Zebra', $result[0]['name']);
-        $this->assertEquals('Alpha', $result[1]['name']);
-        $this->assertEquals('Middle', $result[2]['name']);
+        $this->assertEquals('Zebra', $result[0]->name);
+        $this->assertEquals('Alpha', $result[1]->name);
+        $this->assertEquals('Middle', $result[2]->name);
     }
 
     #[Test]
@@ -171,7 +177,7 @@ class TagGroupGeneratorTest extends TestCase
         $result = $this->generator->generateTagGroups($usedTags);
 
         $this->assertCount(1, $result);
-        $this->assertEquals('User Management', $result[0]['name']);
+        $this->assertEquals('User Management', $result[0]->name);
     }
 
     #[Test]
@@ -189,9 +195,15 @@ class TagGroupGeneratorTest extends TestCase
         $result = $this->generator->generateTagDefinitions($usedTags);
 
         $this->assertCount(3, $result);
-        $this->assertEquals(['name' => 'User', 'description' => 'User management endpoints'], $result[0]);
-        $this->assertEquals(['name' => 'Post', 'description' => 'Blog post operations'], $result[1]);
-        $this->assertEquals(['name' => 'Comment'], $result[2]);
+        $this->assertInstanceOf(TagDefinition::class, $result[0]);
+        $this->assertInstanceOf(TagDefinition::class, $result[1]);
+        $this->assertInstanceOf(TagDefinition::class, $result[2]);
+        $this->assertEquals('User', $result[0]->name);
+        $this->assertEquals('User management endpoints', $result[0]->description);
+        $this->assertEquals('Post', $result[1]->name);
+        $this->assertEquals('Blog post operations', $result[1]->description);
+        $this->assertEquals('Comment', $result[2]->name);
+        $this->assertNull($result[2]->description);
     }
 
     #[Test]
@@ -204,8 +216,10 @@ class TagGroupGeneratorTest extends TestCase
         $result = $this->generator->generateTagDefinitions($usedTags);
 
         $this->assertCount(2, $result);
-        $this->assertEquals(['name' => 'User'], $result[0]);
-        $this->assertEquals(['name' => 'Post'], $result[1]);
+        $this->assertEquals('User', $result[0]->name);
+        $this->assertNull($result[0]->description);
+        $this->assertEquals('Post', $result[1]->name);
+        $this->assertNull($result[1]->description);
     }
 
     #[Test]
@@ -230,8 +244,10 @@ class TagGroupGeneratorTest extends TestCase
 
         $result = $this->generator->generateTagDefinitions($usedTags);
 
-        $this->assertEquals(['name' => 'User', 'description' => 'User management endpoints'], $result[0]);
-        $this->assertEquals(['name' => 'Post'], $result[1]);
+        $this->assertEquals('User', $result[0]->name);
+        $this->assertEquals('User management endpoints', $result[0]->description);
+        $this->assertEquals('Post', $result[1]->name);
+        $this->assertNull($result[1]->description);
     }
 
     #[Test]
@@ -263,7 +279,7 @@ class TagGroupGeneratorTest extends TestCase
         $result = $this->generator->generateTagGroups($usedTags);
 
         $this->assertCount(2, $result);
-        $this->assertEquals('Miscellaneous', $result[1]['name']);
+        $this->assertEquals('Miscellaneous', $result[1]->name);
     }
 
     #[Test]
@@ -296,10 +312,10 @@ class TagGroupGeneratorTest extends TestCase
 
         // Only valid group should be included, Post goes to Other
         $this->assertCount(2, $result);
-        $this->assertEquals('Valid Group', $result[0]['name']);
-        $this->assertEquals(['User'], $result[0]['tags']);
-        $this->assertEquals('Other', $result[1]['name']);
-        $this->assertEquals(['Post'], $result[1]['tags']);
+        $this->assertEquals('Valid Group', $result[0]->name);
+        $this->assertEquals(['User'], $result[0]->tags);
+        $this->assertEquals('Other', $result[1]->name);
+        $this->assertEquals(['Post'], $result[1]->tags);
     }
 
     #[Test]
@@ -317,8 +333,8 @@ class TagGroupGeneratorTest extends TestCase
         $result = $this->generator->generateTagGroups($usedTags);
 
         $this->assertCount(2, $result);
-        $this->assertEquals(['User'], $result[0]['tags']);
-        $this->assertEquals(['Post'], $result[1]['tags']);
+        $this->assertEquals(['User'], $result[0]->tags);
+        $this->assertEquals(['Post'], $result[1]->tags);
     }
 
     #[Test]
@@ -335,7 +351,7 @@ class TagGroupGeneratorTest extends TestCase
         $result = $this->generator->generateTagGroups($usedTags);
 
         $this->assertCount(1, $result);
-        $this->assertEquals(['User', 'Profile'], $result[0]['tags']);
+        $this->assertEquals(['User', 'Profile'], $result[0]->tags);
     }
 
     #[Test]
@@ -354,7 +370,7 @@ class TagGroupGeneratorTest extends TestCase
 
         // Only the configured group should be present, ungrouped tags are ignored
         $this->assertCount(1, $result);
-        $this->assertEquals('Main', $result[0]['name']);
+        $this->assertEquals('Main', $result[0]->name);
     }
 
     #[Test]
@@ -373,7 +389,7 @@ class TagGroupGeneratorTest extends TestCase
 
         // Only the configured group should be present
         $this->assertCount(1, $result);
-        $this->assertEquals('Main', $result[0]['name']);
+        $this->assertEquals('Main', $result[0]->name);
     }
 
     #[Test]
@@ -387,8 +403,10 @@ class TagGroupGeneratorTest extends TestCase
 
         // Should still return tag definitions without descriptions
         $this->assertCount(2, $result);
-        $this->assertEquals(['name' => 'User'], $result[0]);
-        $this->assertEquals(['name' => 'Post'], $result[1]);
+        $this->assertEquals('User', $result[0]->name);
+        $this->assertNull($result[0]->description);
+        $this->assertEquals('Post', $result[1]->name);
+        $this->assertNull($result[1]->description);
     }
 
     #[Test]
@@ -407,9 +425,12 @@ class TagGroupGeneratorTest extends TestCase
         $result = $this->generator->generateTagDefinitions($usedTags);
 
         $this->assertCount(3, $result);
-        $this->assertEquals(['name' => 'User', 'description' => 'Valid description'], $result[0]);
-        $this->assertEquals(['name' => 'Post'], $result[1]);
-        $this->assertEquals(['name' => 'Comment'], $result[2]);
+        $this->assertEquals('User', $result[0]->name);
+        $this->assertEquals('Valid description', $result[0]->description);
+        $this->assertEquals('Post', $result[1]->name);
+        $this->assertNull($result[1]->description);
+        $this->assertEquals('Comment', $result[2]->name);
+        $this->assertNull($result[2]->description);
     }
 
     #[Test]
@@ -424,7 +445,8 @@ class TagGroupGeneratorTest extends TestCase
 
         // Only 'User' should remain (123 and null and '' are filtered out)
         $this->assertCount(1, $result);
-        $this->assertEquals(['name' => 'User'], $result[0]);
+        $this->assertEquals('User', $result[0]->name);
+        $this->assertNull($result[0]->description);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- Create `TagGroup` DTO with `name` and `tags` properties for x-tagGroups extension
- Create `TagDefinition` DTO with `name` and optional `description` for OpenAPI tags section
- Update `TagGroupGenerator` to return typed DTOs instead of arrays
- Maintain backward compatibility by converting to arrays in `OpenApiGenerator`

## Changes

### New Files
- `src/DTO/TagGroup.php` - DTO for tag groups with helper methods
- `src/DTO/TagDefinition.php` - DTO for tag definitions
- `tests/Unit/DTO/TagGroupTest.php` - 9 test cases
- `tests/Unit/DTO/TagDefinitionTest.php` - 10 test cases

### Modified Files
- `src/Generators/TagGroupGenerator.php` - Returns DTOs
- `src/Generators/OpenApiGenerator.php` - Converts DTOs to arrays
- `tests/Unit/Generators/TagGroupGeneratorTest.php` - Updated assertions
- `tests/Unit/Generators/OpenApiGeneratorTest.php` - Updated mocks

### Key Features

**TagGroup DTO:**
- `hasTags()` - Check if group has any tags
- `getTagCount()` - Get number of tags
- `containsTag(string)` - Check if tag exists
- `fromArray()` / `toArray()` - Serialization

**TagDefinition DTO:**
- `hasDescription()` - Check if description exists
- `fromArray()` / `toArray()` - Serialization (omits description if null/empty)

## Test plan
- [x] All 3019 tests pass
- [x] PHPStan passes
- [x] Laravel Pint passes