### PR TITLE
refactor: apply ValidationRuleCollection across codebase

### DIFF
--- a/src/Analyzers/Support/ParameterBuilder.php
+++ b/src/Analyzers/Support/ParameterBuilder.php
@@ -4,6 +4,7 @@ namespace LaravelSpectrum\Analyzers\Support;
 
 use LaravelSpectrum\Analyzers\EnumAnalyzer;
 use LaravelSpectrum\Analyzers\FileUploadAnalyzer;
+use LaravelSpectrum\DTO\Collections\ValidationRuleCollection;
 use LaravelSpectrum\DTO\EnumInfo;
 use LaravelSpectrum\DTO\FileUploadInfo;
 use LaravelSpectrum\DTO\ParameterDefinition;
@@ -49,7 +50,7 @@ class ParameterBuilder
                 continue;
             }
 
-            $ruleArray = is_array($rule) ? $rule : explode('|', $rule);
+            $ruleArray = ValidationRuleCollection::from($rule)->all();
 
             // Check if this is a file upload field
             if (isset($fileFields[$field])) {
@@ -127,7 +128,7 @@ class ParameterBuilder
 
                 $processedFields[$field]['rules_by_condition'][] = [
                     'conditions' => $ruleSet['conditions'] ?? [],
-                    'rules' => is_array($rule) ? $rule : explode('|', $rule),
+                    'rules' => ValidationRuleCollection::from($rule)->all(),
                 ];
             }
         }

--- a/src/Analyzers/Support/RuleRequirementAnalyzer.php
+++ b/src/Analyzers/Support/RuleRequirementAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaravelSpectrum\Analyzers\Support;
 
+use LaravelSpectrum\DTO\Collections\ValidationRuleCollection;
 use LaravelSpectrum\DTO\ConditionalRuleDetail;
 
 /**
@@ -143,18 +144,15 @@ class RuleRequirementAnalyzer
     /**
      * Normalize rules to array format.
      *
-     * @param  string|array|null  $rules
+     * @param  string|array<mixed>|null  $rules
+     * @return array<mixed>
      */
-    private function normalizeRules($rules): array
+    private function normalizeRules(string|array|null $rules): array
     {
-        if (is_string($rules)) {
-            return $rules === '' ? [] : explode('|', $rules);
+        if ($rules === null) {
+            return [];
         }
 
-        if (is_array($rules)) {
-            return $rules;
-        }
-
-        return [];
+        return ValidationRuleCollection::from($rules)->all();
     }
 }

--- a/src/Generators/SchemaGenerator.php
+++ b/src/Generators/SchemaGenerator.php
@@ -2,6 +2,7 @@
 
 namespace LaravelSpectrum\Generators;
 
+use LaravelSpectrum\DTO\Collections\ValidationRuleCollection;
 use LaravelSpectrum\DTO\ConditionResult;
 use LaravelSpectrum\DTO\ResourceInfo;
 use LaravelSpectrum\Generators\Support\SchemaPropertyMapper;
@@ -349,7 +350,7 @@ class SchemaGenerator
         $required = [];
 
         foreach ($ruleSet['rules'] as $field => $rules) {
-            $rulesList = is_string($rules) ? explode('|', $rules) : $rules;
+            $rulesList = ValidationRuleCollection::from($rules)->all();
 
             $property = [
                 'type' => $this->typeInference->inferFromRules($rulesList),

--- a/src/Generators/ValidationMessageGenerator.php
+++ b/src/Generators/ValidationMessageGenerator.php
@@ -3,6 +3,7 @@
 namespace LaravelSpectrum\Generators;
 
 use Illuminate\Support\Str;
+use LaravelSpectrum\DTO\Collections\ValidationRuleCollection;
 use LaravelSpectrum\Support\ValidationRules;
 
 class ValidationMessageGenerator
@@ -29,14 +30,12 @@ class ValidationMessageGenerator
         $messages = [];
 
         // ルールを配列に正規化
-        if (is_string($rules)) {
-            $rules = explode('|', $rules);
-        }
+        $ruleCollection = ValidationRuleCollection::from($rules);
 
-        $fieldType = ValidationRules::inferFieldType($rules);
+        $fieldType = ValidationRules::inferFieldType($ruleCollection->all());
         $humanField = $this->humanizeFieldName($field);
 
-        foreach ($rules as $rule) {
+        foreach ($ruleCollection as $rule) {
             // Rule::unique() のようなオブジェクトの場合はスキップ
             if (! is_string($rule)) {
                 continue;


### PR DESCRIPTION
## Summary

Apply `ValidationRuleCollection` to eliminate manual string|array rule normalization patterns across the codebase.

- **ParameterBuilder**: Use `ValidationRuleCollection::from()` for rule normalization in `buildFromRules()` and `buildFromConditionalRules()`
- **SchemaGenerator**: Use `ValidationRuleCollection::from()` in `generateSchemaForRuleSet()`
- **ValidationMessageGenerator**: Use `ValidationRuleCollection` for iterating over rules in field message generation
- **RuleRequirementAnalyzer**: Simplify `normalizeRules()` method using `ValidationRuleCollection`

This follows up on PR #277 which introduced the `AbstractCollection` and `ValidationRuleCollection` classes.

## Test plan

- [x] All existing tests pass
- [x] PHPStan analysis passes
- [x] Code formatting passes