### PR TITLE
refactor: enhance ValidationRuleCollection::from() to accept null

### DIFF
--- a/src/Analyzers/Support/RuleRequirementAnalyzer.php
+++ b/src/Analyzers/Support/RuleRequirementAnalyzer.php
@@ -149,10 +149,6 @@ class RuleRequirementAnalyzer
      */
     private function normalizeRules(string|array|null $rules): array
     {
-        if ($rules === null) {
-            return [];
-        }
-
         return ValidationRuleCollection::from($rules)->all();
     }
 }

--- a/src/DTO/Collections/ValidationRuleCollection.php
+++ b/src/DTO/Collections/ValidationRuleCollection.php
@@ -57,12 +57,16 @@ final readonly class ValidationRuleCollection extends AbstractCollection
     }
 
     /**
-     * Create a collection from either string or array input.
+     * Create a collection from string, array, or null input.
      *
-     * @param  string|array<mixed>  $rules
+     * @param  string|array<mixed>|null  $rules
      */
-    public static function from(string|array $rules): self
+    public static function from(string|array|null $rules): self
     {
+        if ($rules === null) {
+            return self::empty();
+        }
+
         return is_string($rules)
             ? self::fromString($rules)
             : self::fromArray($rules);

--- a/tests/Unit/DTO/Collections/ValidationRuleCollectionTest.php
+++ b/tests/Unit/DTO/Collections/ValidationRuleCollectionTest.php
@@ -79,6 +79,15 @@ class ValidationRuleCollectionTest extends TestCase
     }
 
     #[Test]
+    public function it_creates_empty_from_null_using_from(): void
+    {
+        $collection = ValidationRuleCollection::from(null);
+
+        $this->assertTrue($collection->isEmpty());
+        $this->assertCount(0, $collection);
+    }
+
+    #[Test]
     public function it_detects_file_rule_in_string_rules(): void
     {
         $collection = ValidationRuleCollection::fromString('required|file|max:1024');


### PR DESCRIPTION
## Summary
- Enhanced `ValidationRuleCollection::from()` method to accept null input
- Simplified `RuleRequirementAnalyzer::normalizeRules()` by removing redundant null check
- Added test for null handling in `ValidationRuleCollection`

## Changes
- `from()` now accepts `string|array|null` and returns an empty collection for null input
- Simplified code in `RuleRequirementAnalyzer` by delegating null handling to the collection

## Test plan
- Added `it_creates_empty_from_null_using_from` test
- All existing tests pass (3082 tests, 9431 assertions)