### PR TITLE
fix: handle keyless array items in ResourceStructureVisitor (#306)

### DIFF
--- a/demo-app/laravel-12-app/app/Http/Resources/ConditionalUserResource.php
+++ b/demo-app/laravel-12-app/app/Http/Resources/ConditionalUserResource.php
@@ -33,13 +33,14 @@ class ConditionalUserResource extends JsonResource
             'comments_count' => $this->whenCounted('comments'),
 
             // Conditional attributes based on request
-            // Note: when() and mergeWhen() patterns cause ResourceStructureVisitor to crash
-            // See issue #306
-            // 'secret_field' => $this->when($request->user()?->isAdmin(), 'secret-value'),
+            // Fixed in issue #306 - when() and mergeWhen() now work correctly
+            'secret_field' => $this->when($request->user()?->isAdmin(), 'secret-value'),
 
-            // Always included timestamps for testing
-            'created_at' => $this->created_at,
-            'updated_at' => $this->updated_at,
+            // mergeWhen pattern - conditionally merge additional fields
+            $this->mergeWhen($request->has('full'), [
+                'created_at' => $this->created_at,
+                'updated_at' => $this->updated_at,
+            ]),
 
             // Always included
             'links' => [

--- a/src/DTO/ResourceFieldInfo.php
+++ b/src/DTO/ResourceFieldInfo.php
@@ -274,6 +274,29 @@ final readonly class ResourceFieldInfo
     }
 
     /**
+     * Create a copy with conditional set to true and a condition type.
+     */
+    public function withConditional(string $condition): self
+    {
+        return new self(
+            type: $this->type,
+            nullable: $this->nullable,
+            source: $this->source,
+            property: $this->property,
+            example: $this->example,
+            format: $this->format,
+            conditional: true,
+            condition: $condition,
+            relation: $this->relation,
+            hasTransformation: $this->hasTransformation,
+            properties: $this->properties,
+            items: $this->items,
+            resource: $this->resource,
+            expression: $this->expression,
+        );
+    }
+
+    /**
      * Create a copy with properties.
      *
      * @param  array<string, mixed>  $properties


### PR DESCRIPTION
## Summary

Fixes #306

The `ResourceStructureVisitor` crashed when analyzing API Resources that use `mergeWhen()` or `merge()` patterns because `$item->key` is `null` for keyless array items.

**Root cause**: In `analyzeArrayStructure()`, the code called `getKeyName($item->key)` without checking if `$item->key` is null.

**Changes:**
- Add null check for keyless array items in `analyzeArrayStructure()`
- Add `analyzeMergeMethod()` to detect `$this->mergeWhen()` and `$this->merge()` calls
- Add `extractMergeProperties()` to extract properties from merge arrays
- Add `withConditional()` method to `ResourceFieldInfo` DTO for immutable builder pattern
- Add 3 tests for mergeWhen, merge, and keyless array patterns

## Test plan

- [x] All 22 ResourceStructureVisitorTest tests pass
- [x] All 3091 tests pass with 9448 assertions
- [x] PHPStan analysis passes
- [x] Laravel Pint formatting passes
- [x] Demo-app generation works with mergeWhen enabled in ConditionalUserResource