### PR TITLE
fix: generate correct example for accepted/declined rules

### DIFF
--- a/src/Support/TypeInference.php
+++ b/src/Support/TypeInference.php
@@ -54,6 +54,14 @@ class TypeInference
             if ($rule === 'boolean' || $rule === 'bool') {
                 return true;
             }
+            // accepted/accepted_if rules should return true as they validate truthy values
+            if ($rule === 'accepted' || Str::startsWith($rule, 'accepted_if:')) {
+                return true;
+            }
+            // declined/declined_if rules should return false as they validate falsy values
+            if ($rule === 'declined' || Str::startsWith($rule, 'declined_if:')) {
+                return false;
+            }
             if ($rule === 'array') {
                 return [];
             }

--- a/tests/Unit/Analyzers/Support/ParameterBuilderTest.php
+++ b/tests/Unit/Analyzers/Support/ParameterBuilderTest.php
@@ -208,6 +208,43 @@ class ParameterBuilderTest extends TestCase
         $this->assertIsInt($age->example);
     }
 
+    #[Test]
+    public function it_generates_boolean_example_for_accepted_rule(): void
+    {
+        $rules = [
+            'terms' => 'required|accepted',
+            'terms_if' => 'accepted_if:other_field,value',
+            'decline_test' => 'declined',
+            'decline_if_test' => 'declined_if:other_field,value',
+        ];
+
+        $parameters = $this->builder->buildFromRules($rules);
+
+        // accepted should generate true
+        $terms = $this->findParameter($parameters, 'terms');
+        $this->assertNotNull($terms);
+        $this->assertEquals('boolean', $terms->type);
+        $this->assertTrue($terms->example, 'accepted rule should generate example: true');
+
+        // accepted_if should also generate true
+        $termsIf = $this->findParameter($parameters, 'terms_if');
+        $this->assertNotNull($termsIf);
+        $this->assertEquals('boolean', $termsIf->type);
+        $this->assertTrue($termsIf->example, 'accepted_if rule should generate example: true');
+
+        // declined should generate false
+        $decline = $this->findParameter($parameters, 'decline_test');
+        $this->assertNotNull($decline);
+        $this->assertEquals('boolean', $decline->type);
+        $this->assertFalse($decline->example, 'declined rule should generate example: false');
+
+        // declined_if should also generate false
+        $declineIf = $this->findParameter($parameters, 'decline_if_test');
+        $this->assertNotNull($declineIf);
+        $this->assertEquals('boolean', $declineIf->type);
+        $this->assertFalse($declineIf->example, 'declined_if rule should generate example: false');
+    }
+
     // ========== File upload tests ==========
 
     #[Test]


### PR DESCRIPTION
## Summary
- Fix `accepted` rule generating wrong example (`"string"` instead of `true`)
- `accepted` and `accepted_if` rules now generate `true` as example
- `declined` and `declined_if` rules now generate `false` as example

## Changes
- `TypeInference::generateExample()` - Added handling for accepted/declined rules

## Test plan
- [x] All existing tests pass (3111 tests)
- [x] PHPStan passes
- [x] Laravel Pint passes
- [x] Demo-app verification: `/api/custom-rules/register` terms field now shows `"example": true`

Fixes #321