### PR TITLE
fix: generate numeric example for decimal:x,y validation

### DIFF
--- a/src/Support/TypeInference.php
+++ b/src/Support/TypeInference.php
@@ -51,6 +51,9 @@ class TypeInference
             if ($rule === 'numeric' || $rule === 'decimal') {
                 return 19.99;
             }
+            if (Str::startsWith($rule, 'decimal:')) {
+                return $this->generateDecimalExample($rule);
+            }
             if ($rule === 'boolean' || $rule === 'bool') {
                 return true;
             }
@@ -165,6 +168,28 @@ class TypeInference
         }
 
         return min($min + 1, $max);
+    }
+
+    /**
+     * Generate a decimal example based on the decimal rule.
+     *
+     * @param  string  $rule  The decimal rule (e.g., 'decimal:2', 'decimal:0,3')
+     */
+    private function generateDecimalExample(string $rule): float
+    {
+        $params = Str::after($rule, 'decimal:');
+        $parts = explode(',', $params);
+
+        // decimal:2 means exactly 2 decimal places
+        // decimal:0,3 means 0-3 decimal places (use max)
+        $decimalPlaces = count($parts) === 1
+            ? (int) $parts[0]
+            : (int) $parts[1];
+
+        // Generate 19.99... with correct number of decimal places
+        $nines = str_repeat('9', $decimalPlaces);
+
+        return (float) "19.{$nines}";
     }
 
     /**

--- a/tests/Unit/Analyzers/Support/ParameterBuilderTest.php
+++ b/tests/Unit/Analyzers/Support/ParameterBuilderTest.php
@@ -245,6 +245,36 @@ class ParameterBuilderTest extends TestCase
         $this->assertFalse($declineIf->example, 'declined_if rule should generate example: false');
     }
 
+    #[Test]
+    public function it_generates_numeric_example_for_decimal_rule_with_parameters(): void
+    {
+        $rules = [
+            'price' => 'required|decimal:2',
+            'weight' => 'nullable|decimal:0,3',
+            'precise' => 'decimal:4',
+        ];
+
+        $parameters = $this->builder->buildFromRules($rules);
+
+        // decimal:2 should generate example with exactly 2 decimal places
+        $price = $this->findParameter($parameters, 'price');
+        $this->assertNotNull($price);
+        $this->assertEquals('number', $price->type);
+        $this->assertEquals(19.99, $price->example, 'decimal:2 should generate 19.99');
+
+        // decimal:0,3 should generate example with max (3) decimal places
+        $weight = $this->findParameter($parameters, 'weight');
+        $this->assertNotNull($weight);
+        $this->assertEquals('number', $weight->type);
+        $this->assertEquals(19.999, $weight->example, 'decimal:0,3 should generate 19.999');
+
+        // decimal:4 should generate example with exactly 4 decimal places
+        $precise = $this->findParameter($parameters, 'precise');
+        $this->assertNotNull($precise);
+        $this->assertEquals('number', $precise->type);
+        $this->assertEquals(19.9999, $precise->example, 'decimal:4 should generate 19.9999');
+    }
+
     // ========== File upload tests ==========
 
     #[Test]


### PR DESCRIPTION
## Summary
- Fix `decimal:x` and `decimal:x,y` validation rules to generate accurate examples
- Examples now match the specified decimal places from the rule

## Examples
| Rule | Generated Example |
|------|------------------|
| `decimal:2` | `19.99` |
| `decimal:4` | `19.9999` |
| `decimal:0,3` | `19.999` (uses max) |

## Changes
- `TypeInference::generateExample()` - Added `generateDecimalExample()` method
- Parses decimal rule parameters to generate correct number of decimal places

## Test plan
- [x] All existing tests pass (3112 tests)
- [x] PHPStan passes
- [x] Laravel Pint passes

Fixes #320