### PR TITLE
fix: add format property to conditional parameters

### DIFF
--- a/src/Analyzers/Support/ParameterBuilder.php
+++ b/src/Analyzers/Support/ParameterBuilder.php
@@ -243,7 +243,7 @@ class ParameterBuilder
      * @param  array<string, string>  $attributes
      * @param  array<string, string>  $useStatements
      */
-    protected function buildConditionalParameter(
+    private function buildConditionalParameter(
         string $field,
         array $mergedRules,
         array $processedField,
@@ -253,6 +253,9 @@ class ParameterBuilder
     ): ParameterDefinition {
         // Check for enum rules
         $enumInfo = $this->findEnumInfo($mergedRules, $namespace, $useStatements);
+
+        // Determine format
+        $format = $this->formatInferrer->inferFormat($mergedRules);
 
         // Extract rules_by_condition with fallback for safety
         $rulesByCondition = $processedField['rules_by_condition'] ?? [];
@@ -268,6 +271,7 @@ class ParameterBuilder
             ),
             example: $this->typeInference->generateExample($field, $mergedRules),
             validation: $mergedRules,
+            format: $format,
             conditionalRules: $rulesByCondition,
             enum: $enumInfo,
         );

--- a/tests/Feature/__snapshots__/OpenApiSnapshotTest__basic_crud_routes_generate_consistent_output__1.json
+++ b/tests/Feature/__snapshots__/OpenApiSnapshotTest__basic_crud_routes_generate_consistent_output__1.json
@@ -14,7 +14,6 @@
     "paths": {
         "/api/snapshot/users": {
             "get": {
-                "summary": "List all User",
                 "operationId": "getApiSnapshotUsers",
                 "tags": [
                     "Snapshot",
@@ -63,10 +62,10 @@
                             }
                         }
                     }
-                }
+                },
+                "summary": "List all User"
             },
             "head": {
-                "summary": "Head User",
                 "operationId": "headApiSnapshotUsers",
                 "tags": [
                     "Snapshot",
@@ -115,10 +114,10 @@
                             }
                         }
                     }
-                }
+                },
+                "summary": "Head User"
             },
             "post": {
-                "summary": "Create a new User",
                 "operationId": "postApiSnapshotUsers",
                 "tags": [
                     "Snapshot",
@@ -223,6 +222,7 @@
                         }
                     }
                 },
+                "summary": "Create a new User",
                 "requestBody": {
                     "required": true,
                     "content": {
@@ -238,7 +238,8 @@
                                     "email": {
                                         "type": "string",
                                         "description": "メールアドレス",
-                                        "example": "user@example.com"
+                                        "example": "user@example.com",
+                                        "format": "email"
                                     },
                                     "password": {
                                         "type": "string",
@@ -264,7 +265,6 @@
         },
         "/api/snapshot/users/{user}": {
             "get": {
-                "summary": "Get User by ID",
                 "operationId": "getApiSnapshotUsersUser",
                 "tags": [
                     "Snapshot",
@@ -273,8 +273,8 @@
                 "parameters": [
                     {
                         "name": "user",
-                        "required": true,
                         "in": "path",
+                        "required": true,
                         "schema": {
                             "type": "string"
                         }
@@ -329,10 +329,10 @@
                             }
                         }
                     }
-                }
+                },
+                "summary": "Get User by ID"
             },
             "head": {
-                "summary": "Head User",
                 "operationId": "headApiSnapshotUsersUser",
                 "tags": [
                     "Snapshot",
@@ -341,8 +341,8 @@
                 "parameters": [
                     {
                         "name": "user",
-                        "required": true,
                         "in": "path",
+                        "required": true,
                         "schema": {
                             "type": "string"
                         }
@@ -397,7 +397,8 @@
                             }
                         }
                     }
-                }
+                },
+                "summary": "Head User"
             }
         }
     },

--- a/tests/Feature/__snapshots__/OpenApiSnapshotTest__openapi_31_generates_consistent_output__1.json
+++ b/tests/Feature/__snapshots__/OpenApiSnapshotTest__openapi_31_generates_consistent_output__1.json
@@ -14,7 +14,6 @@
     "paths": {
         "/api/snapshot/users": {
             "get": {
-                "summary": "List all User",
                 "operationId": "getApiSnapshotUsers",
                 "tags": [
                     "Snapshot",
@@ -63,10 +62,10 @@
                             }
                         }
                     }
-                }
+                },
+                "summary": "List all User"
             },
             "head": {
-                "summary": "Head User",
                 "operationId": "headApiSnapshotUsers",
                 "tags": [
                     "Snapshot",
@@ -115,10 +114,10 @@
                             }
                         }
                     }
-                }
+                },
+                "summary": "Head User"
             },
             "post": {
-                "summary": "Create a new User",
                 "operationId": "postApiSnapshotUsers",
                 "tags": [
                     "Snapshot",
@@ -223,6 +222,7 @@
                         }
                     }
                 },
+                "summary": "Create a new User",
                 "requestBody": {
                     "required": true,
                     "content": {
@@ -238,7 +238,8 @@
                                     "email": {
                                         "type": "string",
                                         "description": "メールアドレス",
-                                        "example": "user@example.com"
+                                        "example": "user@example.com",
+                                        "format": "email"
                                     },
                                     "password": {
                                         "type": "string",


### PR DESCRIPTION
## Summary

- Fixed missing `format` property in OpenAPI schema for conditional parameters
- The `buildConditionalParameter` method was missing the format inference call that `buildStandardParameter` already had
- Now date, email, datetime, url, uuid and other validation rules correctly include their OpenAPI format property even when used in FormRequests with conditional validation

## Changes

- Added `$format = $this->formatInferrer->inferFormat($mergedRules);` to `ParameterBuilder::buildConditionalParameter()`
- Added `format: $format` to the ParameterDefinition constructor call
- Added tests to verify format is correctly set for conditional parameters
- Updated snapshot tests to reflect the new format property

## Test plan

- [x] Added unit test `it_generates_format_for_conditional_parameters_with_date_rules`
- [x] Added integration test `it_integrates_parameter_builder_with_schema_generator_for_date_format`
- [x] All 3116 tests pass
- [x] Verified in demo-app that `publish_at` now has `"format": "date"` in OpenAPI output

Fixes #322