### PR TITLE
fix: exclude fields with exclude validation rule from schema

### DIFF
--- a/tests/Unit/Analyzers/ConditionalValidationRulesTest.php
+++ b/tests/Unit/Analyzers/ConditionalValidationRulesTest.php
@@ -194,15 +194,16 @@ class ConditionalValidationRulesTest extends TestCase
         // Act
         $parameters = $this->analyzer->analyze(get_class($testRequestClass));
 
-        // Assert
+        // Assert - Conditional excludes should be included in the schema
         $metadataParam = $this->findParameterByName($parameters, 'metadata');
         $this->assertContains('exclude_if:include_metadata,false', $metadataParam['validation']);
 
         $xmlOptionsParam = $this->findParameterByName($parameters, 'xml_options');
         $this->assertContains('exclude_unless:format,xml', $xmlOptionsParam['validation']);
 
+        // Plain exclude should NOT appear in the schema
         $tempParam = $this->findParameterByName($parameters, 'temporary_field');
-        $this->assertContains('exclude', $tempParam['validation']);
+        $this->assertNull($tempParam, 'Fields with plain exclude rule should not appear in schema');
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Fields with the plain `exclude` validation rule are now excluded from the OpenAPI schema
- Conditional excludes (`exclude_if`, `exclude_unless`, `exclude_with`, `exclude_without`) remain in the schema since they may include the field depending on conditions

## Changes

- Added `hasExcludeRule()` method to `ParameterBuilder` to detect plain `exclude` rules
- Updated `buildFromRules()` to skip fields with `exclude` rule
- Updated `buildFromConditionalRules()` to skip fields with `exclude` rule in merged rules
- Updated tests to verify correct behavior

## Test Plan

- [x] Added unit test for `buildFromRules` with exclude rules
- [x] Added unit test for `buildFromConditionalRules` with exclude rules
- [x] Updated existing `it_handles_exclude_rules` test to verify plain exclude is removed
- [x] Verified in demo-app that `internal_notes` (with `exclude`) is NOT in schema
- [x] Verified conditional excludes (`debug_info`, `legacy_field`) remain in schema
- [x] All tests pass (`composer test`)
- [x] Static analysis passes (`composer analyze`)
- [x] Code style passes (`composer format:fix`)

Fixes #324