### PR TITLE
fix: add ulid format mapping and tests for validation rule formats

### DIFF
--- a/src/Support/ValidationRuleTypeMapper.php
+++ b/src/Support/ValidationRuleTypeMapper.php
@@ -59,6 +59,7 @@ final class ValidationRuleTypeMapper
         'email' => 'email',
         'url' => 'uri',
         'uuid' => 'uuid',
+        'ulid' => 'ulid',
         'ip' => 'ipv4',
         'ipv4' => 'ipv4',
         'ipv6' => 'ipv6',

--- a/tests/Unit/Analyzers/Support/ParameterBuilderTest.php
+++ b/tests/Unit/Analyzers/Support/ParameterBuilderTest.php
@@ -332,6 +332,75 @@ class ParameterBuilderTest extends TestCase
         $this->assertEquals('date', $birthDate->format, 'date_format:Y-m-d should set format to "date"');
     }
 
+    #[Test]
+    public function it_generates_format_for_ip_rules(): void
+    {
+        $rules = [
+            'ip_address' => 'required|ip',
+            'server_ipv4' => 'required|ipv4',
+            'server_ipv6' => 'required|ipv6',
+        ];
+
+        $parameters = $this->builder->buildFromRules($rules);
+
+        // ip rule should have format: ipv4
+        $ipAddress = $this->findParameter($parameters, 'ip_address');
+        $this->assertNotNull($ipAddress);
+        $this->assertEquals('string', $ipAddress->type);
+        $this->assertEquals('ipv4', $ipAddress->format, 'ip rule should set format to "ipv4"');
+
+        // ipv4 rule should have format: ipv4
+        $serverIpv4 = $this->findParameter($parameters, 'server_ipv4');
+        $this->assertNotNull($serverIpv4);
+        $this->assertEquals('string', $serverIpv4->type);
+        $this->assertEquals('ipv4', $serverIpv4->format, 'ipv4 rule should set format to "ipv4"');
+
+        // ipv6 rule should have format: ipv6
+        $serverIpv6 = $this->findParameter($parameters, 'server_ipv6');
+        $this->assertNotNull($serverIpv6);
+        $this->assertEquals('string', $serverIpv6->type);
+        $this->assertEquals('ipv6', $serverIpv6->format, 'ipv6 rule should set format to "ipv6"');
+    }
+
+    #[Test]
+    public function it_generates_format_for_ulid_and_uuid_rules(): void
+    {
+        $rules = [
+            'external_id' => 'required|uuid',
+            'tracking_id' => 'required|ulid',
+        ];
+
+        $parameters = $this->builder->buildFromRules($rules);
+
+        // uuid rule should have format: uuid
+        $externalId = $this->findParameter($parameters, 'external_id');
+        $this->assertNotNull($externalId);
+        $this->assertEquals('string', $externalId->type);
+        $this->assertEquals('uuid', $externalId->format, 'uuid rule should set format to "uuid"');
+
+        // ulid rule should have format: ulid
+        $trackingId = $this->findParameter($parameters, 'tracking_id');
+        $this->assertNotNull($trackingId);
+        $this->assertEquals('string', $trackingId->type);
+        $this->assertEquals('ulid', $trackingId->format, 'ulid rule should set format to "ulid"');
+    }
+
+    #[Test]
+    public function it_generates_format_for_mac_address_rule(): void
+    {
+        $rules = [
+            'device_mac' => 'required|mac_address',
+        ];
+
+        $parameters = $this->builder->buildFromRules($rules);
+
+        // mac_address rule should have format
+        $deviceMac = $this->findParameter($parameters, 'device_mac');
+        $this->assertNotNull($deviceMac);
+        $this->assertEquals('string', $deviceMac->type);
+        $this->assertEquals('mac', $deviceMac->format, 'mac_address rule should set format to "mac"');
+    }
+
     // ========== File upload tests ==========
 
     #[Test]


### PR DESCRIPTION
## Summary

- Add `ulid` to `FORMAT_RULES` in `ValidationRuleTypeMapper`
- Add tests verifying existing format mappings work correctly:
  - `ip` → `ipv4`
  - `ipv4` → `ipv4`
  - `ipv6` → `ipv6`
  - `uuid` → `uuid`
  - `ulid` → `ulid`
  - `mac_address` → `mac`

## Background

Issue #305 reported that additional validation rules were missing OpenAPI format mapping. Investigation revealed that most mappings (`ip`, `ipv4`, `ipv6`, `mac_address`) were already implemented in `FORMAT_RULES`. Only `ulid` was missing.

## Test Plan

- [x] Test ip rule maps to format: ipv4
- [x] Test ipv4 rule maps to format: ipv4
- [x] Test ipv6 rule maps to format: ipv6
- [x] Test uuid rule maps to format: uuid
- [x] Test ulid rule maps to format: ulid
- [x] Test mac_address rule maps to format: mac

Closes #305