### PR TITLE
fix: extract enum values from Rule::in() objects

### DIFF
--- a/tests/Unit/Support/ValidationRuleTypeMapperTest.php
+++ b/tests/Unit/Support/ValidationRuleTypeMapperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaravelSpectrum\Tests\Unit\Support;
 
+use Illuminate\Validation\Rule;
 use LaravelSpectrum\Support\ValidationRuleTypeMapper;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -156,6 +157,24 @@ class ValidationRuleTypeMapperTest extends TestCase
     {
         $this->assertNull($this->mapper->extractEnumValues(['required']));
         $this->assertNull($this->mapper->extractEnumValues([]));
+    }
+
+    #[Test]
+    public function it_extracts_enum_values_from_rule_in_object(): void
+    {
+        $rule = Rule::in(['low', 'medium', 'high', 'critical']);
+        $values = $this->mapper->extractEnumValues([$rule]);
+
+        $this->assertEquals(['low', 'medium', 'high', 'critical'], $values);
+    }
+
+    #[Test]
+    public function it_extracts_enum_values_from_rule_in_with_mixed_rules(): void
+    {
+        $rule = Rule::in(['active', 'inactive', 'pending']);
+        $values = $this->mapper->extractEnumValues(['required', 'string', $rule]);
+
+        $this->assertEquals(['active', 'inactive', 'pending'], $values);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Update `extractEnumValues` in `ValidationRuleTypeMapper` to handle `Rule::in()` objects
- Add `parseInRuleValues` helper method to handle both quoted and unquoted formats
- `Rule::in(['a','b','c'])` now correctly extracts to `enum: ['a','b','c']`

## Background

`Rule::in()` returns an `Illuminate\Validation\Rules\In` object that converts to string as `in:"a","b","c"` (with quoted values). The existing `extractEnumValues` only handled the plain string `in:a,b,c` format.

## Test Plan

- [x] Test extracting enum values from `Rule::in()` object
- [x] Test extracting enum values from mixed rules (string + object)
- [x] Verify existing `in:a,b,c` string format still works

Closes #311