### PR TITLE
feat: generate confirmation field for confirmed validation rule

### DIFF
--- a/tests/Feature/__snapshots__/OpenApiSnapshotTest__basic_crud_routes_generate_consistent_output__1.json
+++ b/tests/Feature/__snapshots__/OpenApiSnapshotTest__basic_crud_routes_generate_consistent_output__1.json
@@ -248,6 +248,12 @@
                                         "example": "password123",
                                         "minLength": 8
                                     },
+                                    "password_confirmation": {
+                                        "type": "string",
+                                        "description": "Password Confirmation",
+                                        "example": "password123",
+                                        "minLength": 8
+                                    },
                                     "age": {
                                         "type": "integer",
                                         "description": "年齢",
@@ -259,7 +265,8 @@
                                 "required": [
                                     "name",
                                     "email",
-                                    "password"
+                                    "password",
+                                    "password_confirmation"
                                 ]
                             }
                         }

--- a/tests/Feature/__snapshots__/OpenApiSnapshotTest__openapi_31_generates_consistent_output__1.json
+++ b/tests/Feature/__snapshots__/OpenApiSnapshotTest__openapi_31_generates_consistent_output__1.json
@@ -248,6 +248,12 @@
                                         "example": "password123",
                                         "minLength": 8
                                     },
+                                    "password_confirmation": {
+                                        "type": "string",
+                                        "description": "Password Confirmation",
+                                        "example": "password123",
+                                        "minLength": 8
+                                    },
                                     "age": {
                                         "type": "integer",
                                         "description": "年齢",
@@ -259,7 +265,8 @@
                                 "required": [
                                     "name",
                                     "email",
-                                    "password"
+                                    "password",
+                                    "password_confirmation"
                                 ]
                             }
                         }

--- a/tests/Unit/Analyzers/Support/ParameterBuilderTest.php
+++ b/tests/Unit/Analyzers/Support/ParameterBuilderTest.php
@@ -1479,6 +1479,48 @@ class ParameterBuilderTest extends TestCase
         $this->assertEquals($secret->maxLength, $secretConfirmation->maxLength);
     }
 
+    #[Test]
+    public function it_generates_optional_confirmation_field_for_optional_field(): void
+    {
+        $rules = [
+            'password' => 'nullable|string|confirmed',
+        ];
+
+        $parameters = $this->builder->buildFromRules($rules);
+
+        $passwordConfirmation = $this->findParameter($parameters, 'password_confirmation');
+        $this->assertNotNull($passwordConfirmation);
+        $this->assertFalse($passwordConfirmation->required);
+        $this->assertEquals(['nullable', 'same:password'], $passwordConfirmation->validation);
+    }
+
+    #[Test]
+    public function it_generates_confirmation_field_in_conditional_rules(): void
+    {
+        $conditionalRules = [
+            'rules_sets' => [
+                [
+                    'conditions' => ['is_register' => true],
+                    'rules' => [
+                        'password' => 'required|string|min:8|confirmed',
+                    ],
+                ],
+            ],
+            'merged_rules' => [
+                'password' => ['required', 'string', 'min:8', 'confirmed'],
+            ],
+        ];
+
+        $parameters = $this->builder->buildFromConditionalRules($conditionalRules);
+
+        $password = $this->findParameter($parameters, 'password');
+        $this->assertNotNull($password);
+
+        $passwordConfirmation = $this->findParameter($parameters, 'password_confirmation');
+        $this->assertNotNull($passwordConfirmation, 'Confirmation field should be generated in conditional rules');
+        $this->assertEquals($password->type, $passwordConfirmation->type);
+    }
+
     // ========== Helper methods ==========
 
     /**


### PR DESCRIPTION
## Summary

When a field has the `confirmed` validation rule, Laravel expects a corresponding `{field}_confirmation` field. This change automatically documents this confirmation field in the OpenAPI schema.

- Adds `hasConfirmedRule()` method to detect the `confirmed` rule
- Adds `buildConfirmationField()` method to generate the confirmation field
- Confirmation field inherits type and constraints (minLength, maxLength, format, pattern) from the original field
- Confirmation field is marked as required if the original field is required

## Test plan

- [x] Add tests for confirmation field generation
- [x] Verify confirmation field has same type as original
- [x] Verify confirmation field has same constraints as original
- [x] Run `composer format:fix && composer analyze && composer test`

Closes #325