### PR TITLE
feat: detect route where() constraints and map to OpenAPI schema

### DIFF
--- a/src/Analyzers/RouteAnalyzer.php
+++ b/src/Analyzers/RouteAnalyzer.php
@@ -368,16 +368,26 @@ class RouteAnalyzer implements HasErrors
 
     /**
      * Check if pattern matches UUID format.
+     *
+     * @param  string  $pattern  The regex pattern to check
      */
     protected function isUuidPattern(string $pattern): bool
     {
-        // Standard UUID regex pattern (case-insensitive hex)
-        $uuidPattern = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+        // UUID regex pattern variants (including Laravel's whereUuid() which uses \d)
+        $uuidPatterns = [
+            '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
+            '[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}', // Laravel's whereUuid()
+            '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}',
+            '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+        ];
 
-        // Compare normalized patterns
-        return strcasecmp($pattern, $uuidPattern) === 0
-            || strcasecmp($pattern, '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}') === 0
-            || strcasecmp($pattern, '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}') === 0;
+        foreach ($uuidPatterns as $uuidPattern) {
+            if (strcasecmp($pattern, $uuidPattern) === 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Add where constraint detection in `RouteAnalyzer::extractRouteParametersToDto`
- Map `[0-9]+` pattern to `type: integer`
- Map UUID pattern to `type: string, format: uuid`
- Map other patterns to `pattern` property in OpenAPI schema

Fixes #304

## Changes

### RouteAnalyzer.php
- Modified `extractRouteParametersToDto()` to access `$route->wheres` and build schema from constraints
- Added `buildSchemaFromWhereConstraint()` helper method
- Added `mapPatternToSchema()` for pattern-to-OpenAPI mapping
- Added `isIntegerPattern()` to detect numeric patterns
- Added `isUuidPattern()` to detect UUID patterns

### Test Coverage
Added 6 new tests:
- `it_detects_integer_where_constraint` - Tests `where('param', '[0-9]+')` → `type: integer`
- `it_detects_uuid_where_constraint` - Tests UUID pattern → `format: uuid`
- `it_detects_custom_pattern_constraint` - Tests custom patterns → `pattern` property
- `it_detects_multiple_where_constraints` - Tests multiple constraints on same route
- `it_detects_alpha_where_constraint` - Tests `whereAlpha()` helper
- `it_detects_ulid_where_constraint` - Tests `whereUlid()` helper

## Test plan

- [x] All 3266 tests pass
- [x] PHPStan passes
- [x] Laravel Pint passes