### PR TITLE
feat: integrate validateReferences() into OpenAPI generation

### DIFF
--- a/src/Generators/OpenApiGenerator.php
+++ b/src/Generators/OpenApiGenerator.php
@@ -2,6 +2,7 @@
 
 namespace LaravelSpectrum\Generators;
 
+use Illuminate\Support\Facades\Log;
 use LaravelSpectrum\Analyzers\AuthenticationAnalyzer;
 use LaravelSpectrum\Analyzers\ControllerAnalyzer;
 use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
@@ -117,6 +118,14 @@ class OpenApiGenerator
             foreach ($registeredSchemas as $name => $schema) {
                 $openapi['components']['schemas'][$name] = $schema;
             }
+        }
+
+        // Validate that all schema references are resolved
+        $brokenReferences = $this->schemaRegistry->validateReferences();
+        if (! empty($brokenReferences)) {
+            Log::warning(
+                'OpenAPI generation completed with unresolved schema references: '.implode(', ', $brokenReferences)
+            );
         }
 
         // Convert to OpenAPI 3.1.0 format if enabled


### PR DESCRIPTION
## Summary

- Integrate `SchemaRegistry::validateReferences()` into the OpenAPI generation process
- Log warnings when unresolved schema references (`$ref`) are detected
- This helps identify potential issues where `$ref` points to non-existent schemas

## Changes

- Added `validateReferences()` call in `OpenApiGenerator::generate()` after populating schemas
- Added 3 tests for the integration:
  - `it_logs_warning_for_broken_schema_references` - verifies warning is logged for broken refs
  - `it_does_not_log_warning_when_all_references_are_valid` - verifies no warning when all refs valid
  - `it_logs_warning_for_multiple_broken_references` - verifies multiple broken refs are listed
- Updated existing test `it_uses_injected_schema_registry` to expect `validateReferences()` call

## Test plan

- [x] All existing tests pass (3307 tests, 10198 assertions)
- [x] PHPStan analysis passes with no errors
- [x] Laravel Pint formatting applied
- [x] Demo app generation works correctly

Fixes #292