### PR TITLE
feat: add @phpstan-type RouteDefinition for route arrays

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -859,18 +859,6 @@ parameters:
 			path: src/Formatters/InsomniaFormatter.php
 
 		-
-			message: '#^Method LaravelSpectrum\\Formatters\\InsomniaFormatter\:\:groupRoutesByTag\(\) has parameter \$paths with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Formatters/InsomniaFormatter.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Formatters\\InsomniaFormatter\:\:groupRoutesByTag\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Formatters/InsomniaFormatter.php
-
-		-
 			message: '#^Method LaravelSpectrum\\Formatters\\PostmanFormatter\:\:formatAuth\(\) has parameter \$security with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -944,18 +932,6 @@ parameters:
 
 		-
 			message: '#^Method LaravelSpectrum\\Formatters\\PostmanFormatter\:\:getParameterExample\(\) has parameter \$param with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Formatters/PostmanFormatter.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Formatters\\PostmanFormatter\:\:groupRoutesByTag\(\) has parameter \$paths with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Formatters/PostmanFormatter.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Formatters\\PostmanFormatter\:\:groupRoutesByTag\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Formatters/PostmanFormatter.php

--- a/src/DTO/OpenApiOperation.php
+++ b/src/DTO/OpenApiOperation.php
@@ -20,6 +20,11 @@ namespace LaravelSpectrum\DTO;
  *     x-middleware?: array<int, string>,
  *     x-rate-limit?: array{limit: int, period: string}
  * }
+ * @phpstan-type RouteDefinition array{
+ *     path: string,
+ *     method: string,
+ *     operation: OpenApiOperationType
+ * }
  */
 final readonly class OpenApiOperation
 {

--- a/src/Exporters/InsomniaExporter.php
+++ b/src/Exporters/InsomniaExporter.php
@@ -9,6 +9,7 @@ use LaravelSpectrum\Formatters\RequestExampleFormatter;
 
 /**
  * @phpstan-import-type OpenApiOperationType from OpenApiOperation
+ * @phpstan-import-type RouteDefinition from OpenApiOperation
  */
 class InsomniaExporter implements ExportFormatInterface
 {
@@ -112,7 +113,7 @@ class InsomniaExporter implements ExportFormatInterface
     /**
      * Create a request resource.
      *
-     * @param  array<string, mixed>  $route
+     * @param  RouteDefinition  $route
      * @return array<string, mixed>
      */
     private function createRequest(array $route, string $parentId, string $environmentId, int $sortKey): array

--- a/src/Exporters/PostmanExporter.php
+++ b/src/Exporters/PostmanExporter.php
@@ -10,6 +10,7 @@ use LaravelSpectrum\Formatters\RequestExampleFormatter;
 
 /**
  * @phpstan-import-type OpenApiOperationType from OpenApiOperation
+ * @phpstan-import-type RouteDefinition from OpenApiOperation
  */
 class PostmanExporter implements ExportFormatInterface
 {
@@ -72,7 +73,7 @@ class PostmanExporter implements ExportFormatInterface
     /**
      * Convert a route to Postman item format.
      *
-     * @param  array<string, mixed>  $route  Route definition
+     * @param  RouteDefinition  $route  Route definition
      * @param  array<string, mixed>  $openapi  OpenAPI specification
      * @return array<string, mixed> Postman item
      */

--- a/src/Formatters/InsomniaFormatter.php
+++ b/src/Formatters/InsomniaFormatter.php
@@ -3,7 +3,13 @@
 namespace LaravelSpectrum\Formatters;
 
 use Illuminate\Support\Str;
+use LaravelSpectrum\DTO\OpenApiOperation;
 
+/**
+ * Formats OpenAPI data for Insomnia collection export.
+ *
+ * @phpstan-import-type RouteDefinition from OpenApiOperation
+ */
 class InsomniaFormatter
 {
     /**
@@ -86,7 +92,10 @@ class InsomniaFormatter
     }
 
     /**
-     * Group routes by tag
+     * Group routes by tag.
+     *
+     * @param  array<string, array<string, mixed>>  $paths
+     * @return array<string, array<int, RouteDefinition>>
      */
     public function groupRoutesByTag(array $paths): array
     {

--- a/src/Formatters/PostmanFormatter.php
+++ b/src/Formatters/PostmanFormatter.php
@@ -2,6 +2,13 @@
 
 namespace LaravelSpectrum\Formatters;
 
+use LaravelSpectrum\DTO\OpenApiOperation;
+
+/**
+ * Formats OpenAPI data for Postman collection export.
+ *
+ * @phpstan-import-type RouteDefinition from OpenApiOperation
+ */
 class PostmanFormatter
 {
     /**
@@ -167,7 +174,10 @@ class PostmanFormatter
     }
 
     /**
-     * Group routes by tag
+     * Group routes by tag.
+     *
+     * @param  array<string, array<string, mixed>>  $paths
+     * @return array<string, array<int, RouteDefinition>>
      */
     public function groupRoutesByTag(array $paths): array
     {


### PR DESCRIPTION
## Summary

- Add `@phpstan-type RouteDefinition` to define structured type for route definition arrays
- Import and use the type in exporters and formatters
- Remove obsolete PHPStan baseline entries (4 entries removed)

## Changes

| File | Change |
|------|--------|
| `src/DTO/OpenApiOperation.php` | Add `RouteDefinition` type definition |
| `src/Exporters/PostmanExporter.php` | Import type, annotate `$route` param |
| `src/Exporters/InsomniaExporter.php` | Import type, annotate `$route` param |
| `src/Formatters/PostmanFormatter.php` | Import type, add class description, annotate return type |
| `src/Formatters/InsomniaFormatter.php` | Import type, add class description, annotate return type |
| `phpstan-baseline.neon` | Remove 4 obsolete entries |

## Type Definition

```php
@phpstan-type RouteDefinition array{
    path: string,
    method: string,
    operation: OpenApiOperationType
}
```

## Test plan

- [x] `composer format:fix` passes
- [x] `composer analyze` passes (baseline reduced by 4 entries)
- [x] `composer test` passes (3350 tests)

Closes #365