### PR TITLE
feat: add @phpstan-type for Postman and Insomnia export formats

### DIFF
--- a/src/Exporters/InsomniaExporter.php
+++ b/src/Exporters/InsomniaExporter.php
@@ -10,6 +10,41 @@ use LaravelSpectrum\Formatters\RequestExampleFormatter;
 /**
  * @phpstan-import-type OpenApiOperationType from OpenApiOperation
  * @phpstan-import-type RouteDefinition from OpenApiOperation
+ *
+ * @phpstan-type InsomniaResource array{
+ *     _id: string,
+ *     _type: string,
+ *     parentId?: string,
+ *     name?: string,
+ *     description?: string,
+ *     url?: string,
+ *     method?: string,
+ *     body?: array<string, mixed>,
+ *     parameters?: array<int, array{name: string, value: string}>,
+ *     headers?: array<int, array{name: string, value: string}>,
+ *     authentication?: array<string, mixed>,
+ *     metaSortKey?: int,
+ *     isPrivate?: bool,
+ *     scope?: string,
+ *     data?: array<string, string>,
+ *     dataPropertyOrder?: array<int, string>|null,
+ *     color?: string|null,
+ *     environment?: array<string, mixed>,
+ *     environmentPropertyOrder?: array<string, mixed>|null,
+ *     settingStoreCookies?: bool,
+ *     settingSendCookies?: bool,
+ *     settingDisableRenderRequestBody?: bool,
+ *     settingEncodeUrl?: bool,
+ *     settingRebuildPath?: bool,
+ *     settingFollowRedirects?: string
+ * }
+ * @phpstan-type InsomniaExport array{
+ *     _type: string,
+ *     __export_format: int,
+ *     __export_date: string,
+ *     __export_source: string,
+ *     resources: array<int, InsomniaResource>
+ * }
  */
 class InsomniaExporter implements ExportFormatInterface
 {
@@ -30,7 +65,7 @@ class InsomniaExporter implements ExportFormatInterface
      *
      * @param  OpenApiSpec|array<string, mixed>  $openapi
      * @param  array<string, mixed>  $options
-     * @return array<string, mixed>
+     * @return InsomniaExport
      */
     public function export(OpenApiSpec|array $openapi, array $options = []): array
     {

--- a/src/Exporters/PostmanExporter.php
+++ b/src/Exporters/PostmanExporter.php
@@ -11,6 +11,26 @@ use LaravelSpectrum\Formatters\RequestExampleFormatter;
 /**
  * @phpstan-import-type OpenApiOperationType from OpenApiOperation
  * @phpstan-import-type RouteDefinition from OpenApiOperation
+ *
+ * @phpstan-type PostmanInfo array{
+ *     _postman_id: string,
+ *     name: string,
+ *     description: string,
+ *     schema: string,
+ *     _exporter_id: string
+ * }
+ * @phpstan-type PostmanVariable array{
+ *     key: string,
+ *     value: string,
+ *     type: string
+ * }
+ * @phpstan-type PostmanCollection array{
+ *     info: PostmanInfo,
+ *     item: array<int, array<string, mixed>>,
+ *     auth: array<string, mixed>,
+ *     event: array<int, array<string, mixed>>,
+ *     variable: array<int, PostmanVariable>
+ * }
  */
 class PostmanExporter implements ExportFormatInterface
 {
@@ -31,7 +51,7 @@ class PostmanExporter implements ExportFormatInterface
      *
      * @param  OpenApiSpec|array<string, mixed>  $openapi  OpenAPI specification
      * @param  array<string, mixed>  $options  Export options
-     * @return array<string, mixed> Postman collection
+     * @return PostmanCollection Postman collection
      */
     public function export(OpenApiSpec|array $openapi, array $options = []): array
     {


### PR DESCRIPTION
## Summary

- Add structured PHPStan types for Postman and Insomnia export formats
- Replace generic `array<string, mixed>` return types with specific types
- Improve static analysis for export functionality

## Changes

| File | Types Added |
|------|-------------|
| `src/Exporters/PostmanExporter.php` | `PostmanInfo`, `PostmanVariable`, `PostmanCollection` |
| `src/Exporters/InsomniaExporter.php` | `InsomniaResource`, `InsomniaExport` |

## Type Definitions

### PostmanCollection
```php
@phpstan-type PostmanCollection array{
    info: PostmanInfo,
    item: array<int, array<string, mixed>>,
    auth: array<string, mixed>,
    event: array<int, array<string, mixed>>,
    variable: array<int, PostmanVariable>
}
```

### InsomniaExport
```php
@phpstan-type InsomniaExport array{
    _type: string,
    __export_format: int,
    __export_date: string,
    __export_source: string,
    resources: array<int, InsomniaResource>
}
```

## Test plan

- [x] `composer format:fix` passes
- [x] `composer analyze` passes
- [x] `composer test` passes (3350 tests)

Closes #366