### PR TITLE
fix: correct type definitions in AST Visitors

### DIFF
--- a/src/Analyzers/AST/Visitors/ArrayReturnExtractorVisitor.php
+++ b/src/Analyzers/AST/Visitors/ArrayReturnExtractorVisitor.php
@@ -7,8 +7,8 @@ use PhpParser\NodeVisitorAbstract;
 use PhpParser\PrettyPrinter;
 
 /**
- * @phpstan-type ArrayValue string|int|array<string, mixed>
- * @phpstan-type ExtractedArray array<string, ArrayValue>
+ * @phpstan-type ArrayValue string|int|array<string|int, mixed>
+ * @phpstan-type ExtractedArray array<string|int, ArrayValue>
  */
 class ArrayReturnExtractorVisitor extends NodeVisitorAbstract
 {

--- a/src/Analyzers/AST/Visitors/ConditionalRulesExtractorVisitor.php
+++ b/src/Analyzers/AST/Visitors/ConditionalRulesExtractorVisitor.php
@@ -13,7 +13,7 @@ use PhpParser\PrettyPrinter;
 /**
  * @phpstan-type ValidationRulesArray array<string, string|array<int, mixed>>
  * @phpstan-type RuleSetEntry array{conditions: array<ConditionResult>, rules: ValidationRulesArray, probability?: float}
- * @phpstan-type RuleSetsResult array{rules_sets: array<RuleSetEntry>, merged_rules: array<string, array<int, string>>, has_conditions: bool}
+ * @phpstan-type RuleSetsResult array{rules_sets: array<RuleSetEntry>, merged_rules: array<string, array<int, mixed>>, has_conditions: bool}
  */
 class ConditionalRulesExtractorVisitor extends NodeVisitorAbstract
 {
@@ -732,7 +732,7 @@ class ConditionalRulesExtractorVisitor extends NodeVisitorAbstract
     }
 
     /**
-     * @return array<string, array<int, string>>
+     * @return array<string, array<int, mixed>>
      */
     private function mergeAllRules(): array
     {


### PR DESCRIPTION
## Summary

Fix type accuracy issues identified during PR #378 review.

### Changes

1. **ConditionalRulesExtractorVisitor.php**:
   - Changed `RuleSetsResult.merged_rules` from `array<int, string>` to `array<int, mixed>`
   - Changed `mergeAllRules()` return type to match (rules can contain mixed values, not just strings)

2. **ArrayReturnExtractorVisitor.php**:
   - Changed `ExtractedArray` to `array<string|int, ArrayValue>` (int keys are valid in PHP arrays)
   - Changed `ArrayValue` nested array type to `array<string|int, mixed>`

### Why These Fixes?

The comment-analyzer agent identified that the original type definitions were inaccurate:
- When validation rules contain arrays (not strings), the values are `mixed`, not `string`
- PHP arrays can have integer keys, so restricting to string-only keys was incorrect

## Test plan

- [x] `composer format:fix` - passes
- [x] `composer analyze` - passes  
- [x] `composer test` - passes