### PR TITLE
docs: rewrite README for v1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,93 +12,148 @@
   <a href="https://packagist.org/packages/wadakatu/laravel-spectrum"><img src="https://poser.pugx.org/wadakatu/laravel-spectrum/license" alt="License"></a>
 </p>
 
-> 🎯 **Zero-annotation API documentation generator for Laravel**
->
-> Laravel Spectrum analyzes your existing code and automatically generates OpenAPI 3.0 documentation. No annotations required, minimal configuration, ready to use immediately.
+<p align="center">
+  <strong>Zero-annotation OpenAPI documentation generator for Laravel</strong>
+  <br>
+  <em>Generate complete API docs from your existing code in seconds. No annotations required.</em>
+</p>
 
-## ✨ Why Laravel Spectrum?
+<p align="center">
+  <a href="https://wadakatu.github.io/laravel-spectrum/">Documentation</a> •
+  <a href="https://wadakatu.github.io/laravel-spectrum/docs/quick-start">Quick Start</a> •
+  <a href="https://wadakatu.github.io/laravel-spectrum/docs/comparison">Compare</a>
+</p>
 
-**Stop writing documentation. Start generating it.**
+---
 
-- 🚀 **Zero Configuration** - Just install and run the command
-- 🧠 **Smart Detection** - Automatically analyzes FormRequests, validation rules, and API Resources
-- ⚡ **Real-time Updates** - Instantly reflects code changes in documentation
-- 📤 **Export Features** - Direct export to Postman and Insomnia
-- 🎭 **Mock Server** - Automatically launches mock API from OpenAPI documentation
-- 🎯 **Production Ready** - High-performance even for large-scale projects
+## The Problem
 
-## 🚀 Quick Start
+```php
+// ❌ Traditional approach: Annotations everywhere
+/**
+ * @OA\Post(
+ *     path="/api/users",
+ *     @OA\RequestBody(
+ *         @OA\JsonContent(
+ *             @OA\Property(property="name", type="string"),
+ *             @OA\Property(property="email", type="string", format="email"),
+ *             // ... 50 more lines of annotations
+ *         )
+ *     ),
+ *     @OA\Response(response="200", description="Success")
+ * )
+ */
+public function store(StoreUserRequest $request) { ... }
+```
 
-### 1. Installation
+**With Laravel Spectrum: Zero annotations needed.** Your existing `FormRequest` and `Resource` classes are your documentation.
+
+---
+
+## Quick Start (30 seconds)
 
 ```bash
+# Install
 composer require wadakatu/laravel-spectrum --dev
-```
 
-### 2. Generate Documentation
-
-```bash
+# Generate OpenAPI documentation
 php artisan spectrum:generate
+
+# View in browser (HTML with Swagger UI)
+php artisan spectrum:generate --format=html
+# Open: storage/app/spectrum/openapi.html
 ```
 
-### 3. Live Preview (Development)
+**That's it.** Full OpenAPI 3.1 documentation generated from your existing code.
 
+---
+
+## What Gets Analyzed Automatically
+
+| Your Code | Generated Documentation |
+|-----------|------------------------|
+| `FormRequest::rules()` | Request body schemas with validation |
+| `$request->validate([...])` | Inline validation rules |
+| `API Resources` | Response schemas |
+| Auth middleware (`auth:sanctum`) | Security schemes |
+| Route parameters (`{user}`) | Path parameters with types |
+| `@deprecated` PHPDoc | Deprecated operation flags |
+
+---
+
+## Key Features
+
+### Real-time Documentation
 ```bash
 php artisan spectrum:watch
-# Visit http://localhost:8080 to see your documentation
+# Browser auto-refreshes when you change code
 ```
 
-### 4. View in Browser
-
-```html
-<!-- Add to your Blade template -->
-<div id="swagger-ui"></div>
-<script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
-<script>
-SwaggerUIBundle({
-    url: "/storage/app/spectrum/openapi.json",
-    dom_id: '#swagger-ui',
-})
-</script>
-```
-
-### 5. Launch Mock Server
-
+### Built-in Mock Server
 ```bash
 php artisan spectrum:mock
-# Mock API server launches at http://localhost:8081
+# Frontend team can develop without waiting for backend
 ```
 
-**That's it!** Your comprehensive API documentation is ready in seconds.
+### Export to API Clients
+```bash
+php artisan spectrum:export postman    # Postman collection
+php artisan spectrum:export insomnia   # Insomnia workspace
+```
 
-## 📚 Documentation
+### High Performance
+- Parallel processing for large codebases
+- Incremental generation (only changed files)
+- Smart caching
 
-📖 **[View Full Documentation](https://wadakatu.github.io/laravel-spectrum/)**
+---
 
-For detailed usage and advanced features, visit our comprehensive documentation site.
+## Why Laravel Spectrum?
 
-The documentation covers:
+| | Laravel Spectrum | Swagger-PHP | Scribe |
+|---|:---:|:---:|:---:|
+| Zero annotations | ✅ | ❌ | Partial |
+| Setup time | **30 sec** | Hours | ~30 min |
+| FormRequest detection | ✅ | ❌ | ✅ |
+| Mock server | ✅ | ❌ | ❌ |
+| Live reload | ✅ | ❌ | ❌ |
+| Postman/Insomnia export | ✅ | ❌ | ✅ |
+| OpenAPI 3.1 | ✅ | ✅ | ❌ |
 
-- 🔧 **Getting Started** - Installation, configuration, basic usage
-- 🎯 **Features Guide** - Validation detection, response analysis, authentication, mock server
-- ⚡ **Advanced Usage** - Performance optimization, export features, CI/CD integration
-- 📖 **Reference** - CLI commands, configuration options, troubleshooting
-- 🤝 **More** - Comparison with other tools, contribution guide
+---
 
-## 🤝 Contributing
+## Requirements
 
-We welcome bug reports, feature requests, and pull requests! See the [Contribution Guide](./contributing.md) for details.
+- PHP 8.2+
+- Laravel 11.x or 12.x
 
-## 📄 License
+---
 
-Laravel Spectrum is open-source software licensed under the MIT license. See the [LICENSE](../../LICENSE) file for details.
+## Documentation
+
+📖 **[Full Documentation](https://wadakatu.github.io/laravel-spectrum/)**
+
+- [Installation](https://wadakatu.github.io/laravel-spectrum/docs/installation)
+- [Configuration](https://wadakatu.github.io/laravel-spectrum/docs/config-reference)
+- [CLI Commands](https://wadakatu.github.io/laravel-spectrum/docs/cli-reference)
+- [Comparison with Other Tools](https://wadakatu.github.io/laravel-spectrum/docs/comparison)
+
+---
+
+## Contributing
+
+Contributions are welcome! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
+
+## License
+
+Laravel Spectrum is open-source software licensed under the [MIT license](./LICENSE).
 
 ---
 
 <p align="center">
-  Made with ❤️ by <a href="https://github.com/wadakatu">Wadakatu</a>
-  <br><br>
   <a href="https://github.com/wadakatu/laravel-spectrum">
     <img src="https://img.shields.io/github/stars/wadakatu/laravel-spectrum?style=social" alt="Star on GitHub">
   </a>
+  <br><br>
+  Made with ❤️ by <a href="https://github.com/wadakatu">wadakatu</a>
 </p>


### PR DESCRIPTION
## Summary

Complete README rewrite to better communicate Laravel Spectrum's value proposition and make it easier for new users to get started.

## Changes

### Structure Improvements
- **"The Problem" section** - Shows the annotation pain point with a real code example
- **30-second Quick Start** - Reduced from 5 steps to 3 commands
- **"What Gets Analyzed" table** - Immediate clarity on automatic detection capabilities
- **Feature comparison table** - Side-by-side comparison with Swagger-PHP and Scribe
- **Requirements section** - Clear PHP 8.2+ and Laravel 11+ requirements

### Bug Fixes
- Fixed broken link: `contributing.md` → `CONTRIBUTING.md`
- Fixed broken link: `../../LICENSE` → `./LICENSE`

### Removed
- Outdated manual Swagger UI setup instructions (replaced with `--format=html`)
- Redundant feature list (consolidated into comparison table)

## Before/After

**Before:** Generic feature list, 5-step quick start, broken links

**After:** Problem-solution format, 30-second setup, clear value proposition, feature comparison

## Test plan
- [ ] Verify all links work on GitHub
- [ ] Check rendering on GitHub and Packagist
- [ ] Confirm documentation site links are valid