### PR TITLE
fix: switch badges from poser.pugx.org to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 <p align="center">
   <a href="https://github.com/wadakatu/laravel-spectrum/actions"><img src="https://github.com/wadakatu/laravel-spectrum/workflows/Tests/badge.svg" alt="Tests"></a>
   <a href="https://codecov.io/gh/wadakatu/laravel-spectrum"><img src="https://codecov.io/gh/wadakatu/laravel-spectrum/branch/main/graph/badge.svg" alt="Code Coverage"></a>
-  <a href="https://packagist.org/packages/wadakatu/laravel-spectrum"><img src="https://poser.pugx.org/wadakatu/laravel-spectrum/v" alt="Latest Stable Version"></a>
-  <a href="https://packagist.org/packages/wadakatu/laravel-spectrum"><img src="https://poser.pugx.org/wadakatu/laravel-spectrum/downloads" alt="Total Downloads"></a>
-  <a href="https://packagist.org/packages/wadakatu/laravel-spectrum"><img src="https://poser.pugx.org/wadakatu/laravel-spectrum/license" alt="License"></a>
+  <a href="https://packagist.org/packages/wadakatu/laravel-spectrum"><img src="https://img.shields.io/packagist/v/wadakatu/laravel-spectrum" alt="Latest Stable Version"></a>
+  <a href="https://packagist.org/packages/wadakatu/laravel-spectrum"><img src="https://img.shields.io/packagist/dt/wadakatu/laravel-spectrum" alt="Total Downloads"></a>
+  <a href="https://packagist.org/packages/wadakatu/laravel-spectrum"><img src="https://img.shields.io/packagist/l/wadakatu/laravel-spectrum" alt="License"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Switch all README badges from poser.pugx.org to shields.io for faster cache updates.

## Problem

poser.pugx.org was showing "No Release" for the stable version badge even though v1.0.0 has been released and Packagist correctly shows it. This is due to slow cache refresh on poser.pugx.org.

## Solution

Replace all badges with shields.io equivalents:

| Badge | Before (poser) | After (shields.io) |
|-------|----------------|-------------------|
| Version | `poser.pugx.org/.../v` | `img.shields.io/packagist/v/...` |
| Downloads | `poser.pugx.org/.../downloads` | `img.shields.io/packagist/dt/...` |
| License | `poser.pugx.org/.../license` | `img.shields.io/packagist/l/...` |
| Tests | GitHub native | `img.shields.io/github/actions/workflow/status/...` |
| Coverage | Codecov native | `img.shields.io/codecov/c/github/...` |

## Benefits

- Faster cache refresh (shields.io typically updates within minutes)
- Consistent badge styling
- More reliable uptime

## Test plan
- [ ] Verify all badges render correctly on GitHub
- [ ] Confirm version badge shows v1.0.0