### PR TITLE
docs: improve SEO for documentation site

### DIFF
--- a/docs/docs/comparison.md
+++ b/docs/docs/comparison.md
@@ -1,3 +1,10 @@
+---
+id: comparison
+title: Comparison with Other Tools
+description: Compare Laravel Spectrum with Swagger-PHP, L5-Swagger, and Scribe. See feature differences, setup time, and find the best API documentation tool for your Laravel project.
+keywords: [Laravel Spectrum vs Swagger-PHP, Laravel Spectrum vs Scribe, API documentation comparison, Laravel]
+---
+
 # Comparison with Other Tools
 
 A detailed comparison between Laravel Spectrum and other API documentation generation tools for Laravel.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,3 +1,10 @@
+---
+id: index
+title: Laravel Spectrum Documentation
+description: Complete documentation for Laravel Spectrum - the zero-annotation OpenAPI documentation generator for Laravel. Learn how to automatically generate API docs from your existing code.
+keywords: [Laravel, OpenAPI, Swagger, API documentation, PHP]
+---
+
 # Laravel Spectrum Documentation
 
 Welcome to the complete documentation for Laravel Spectrum. This directory contains detailed guides to help you make the most of Laravel Spectrum.

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -1,3 +1,10 @@
+---
+id: installation
+title: Installation and Configuration
+description: Step-by-step guide to install Laravel Spectrum via Composer and configure it for your Laravel application. Includes requirements and troubleshooting tips.
+keywords: [Laravel Spectrum, installation, setup, configuration, Composer]
+---
+
 # Installation and Configuration
 
 This guide provides detailed instructions from installing Laravel Spectrum to initial configuration.

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -1,3 +1,10 @@
+---
+id: quickstart
+title: Quick Start Guide
+description: Get started with Laravel Spectrum in under 5 minutes. Learn how to install and generate your first OpenAPI documentation with just 3 commands.
+keywords: [Laravel Spectrum, quick start, tutorial, getting started]
+---
+
 # Quick Start Guide
 
 Get started with Laravel Spectrum in 5 minutes.

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -9,6 +9,31 @@ const config: Config = {
   tagline: 'Zero-annotation API documentation generator for Laravel',
   favicon: 'img/favicon.svg',
 
+  // SEO metadata
+  headTags: [
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'keywords',
+        content: 'Laravel, OpenAPI, Swagger, API documentation, PHP, zero-annotation, automatic documentation, REST API',
+      },
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'author',
+        content: 'wadakatu',
+      },
+    },
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'canonical',
+        href: 'https://wadakatu.github.io/laravel-spectrum/',
+      },
+    },
+  ],
+
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
   future: {
     v4: true, // Improve compatibility with the upcoming Docusaurus v4

--- a/docs/static/robots.txt
+++ b/docs/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://wadakatu.github.io/laravel-spectrum/sitemap.xml


### PR DESCRIPTION
## Summary

Improve SEO for the documentation site to increase discoverability through search engines.

## Changes

### Global SEO (docusaurus.config.ts)
- Add `headTags` with:
  - `keywords` meta tag for search engines
  - `author` meta tag
  - `canonical` link for URL normalization

### robots.txt
- Added `static/robots.txt` allowing all crawlers
- Includes sitemap reference

### Page-level SEO
Added frontmatter with `description` and `keywords` to key pages:
- `index.md` - Main documentation landing page
- `quickstart.md` - High-traffic getting started page
- `installation.md` - Installation guide
- `comparison.md` - Comparison page (good for "vs" searches)

## Related

- #389 - Algolia DocSearch application (tracked separately)

## Test plan
- [ ] Build docs locally: `cd docs && npm run build`
- [ ] Verify meta tags in generated HTML
- [ ] Check robots.txt is accessible at /robots.txt