### PR TITLE
chore: add Renovate for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":separateMajorMinorFromPatch"
+  ],
+  "labels": ["dependencies"],
+  "schedule": ["before 9am on monday"],
+  "timezone": "Asia/Tokyo",
+  "prHourlyLimit": 3,
+  "prConcurrentLimit": 5,
+  "minimumReleaseAge": "3 days",
+  "ignorePaths": [
+    "demo-app/**"
+  ],
+  "packageRules": [
+    {
+      "description": "Auto-merge patch updates for production dependencies",
+      "matchUpdateTypes": ["patch"],
+      "matchDepTypes": ["require"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    },
+    {
+      "description": "Auto-merge minor and patch updates for dev dependencies",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["require-dev", "devDependencies"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    },
+    {
+      "description": "Group Laravel framework packages",
+      "matchPackagePatterns": ["^illuminate/", "^laravel/"],
+      "groupName": "Laravel packages"
+    },
+    {
+      "description": "Group Symfony packages",
+      "matchPackagePatterns": ["^symfony/"],
+      "groupName": "Symfony packages"
+    },
+    {
+      "description": "Group PHPUnit and testing packages",
+      "matchPackageNames": ["phpunit/phpunit", "phpstan/phpstan", "infection/infection"],
+      "groupName": "PHP testing tools"
+    },
+    {
+      "description": "Group Docusaurus packages",
+      "matchPackagePatterns": ["^@docusaurus/"],
+      "groupName": "Docusaurus packages"
+    },
+    {
+      "description": "Group GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "automerge": true
+    },
+    {
+      "description": "Disable major updates for core dependencies (require manual review)",
+      "matchPackagePatterns": ["^illuminate/", "^nikic/php-parser"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "schedule": ["at any time"]
+  }
+}


### PR DESCRIPTION
## Summary

Add Renovate bot configuration for automated dependency updates.

Closes #284

## Configuration

### Schedule
- **Weekly**: Monday before 9am (JST)
- **Security alerts**: Immediate (at any time)

### Auto-merge Rules
| Dependency Type | Update Type | Auto-merge |
|-----------------|-------------|------------|
| Production (`require`) | Patch | ✅ Yes |
| Development (`require-dev`) | Minor, Patch | ✅ Yes |
| GitHub Actions | All | ✅ Yes |
| Major updates | - | ❌ No (manual review) |

### Grouping
- Laravel packages (`illuminate/*`, `laravel/*`)
- Symfony packages (`symfony/*`)
- PHP testing tools (PHPUnit, PHPStan, Infection)
- Docusaurus packages (`@docusaurus/*`)
- GitHub Actions

### Ignored Paths
- `demo-app/**` - Demo apps are for testing only

## Setup Required

After merging this PR, you need to enable the Renovate GitHub App:

1. Go to [Renovate GitHub App](https://github.com/apps/renovate)
2. Click "Install" or "Configure"
3. Select the `wadakatu/laravel-spectrum` repository
4. Renovate will create a "Dependency Dashboard" issue
5. Initial onboarding PR will be created automatically

## Test plan
- [x] JSON schema validates correctly
- [ ] Enable Renovate GitHub App after merge
- [ ] Verify Dependency Dashboard issue is created