### PR TITLE
feat(openapi): add root-level webhooks support for OpenAPI 3.1

### DIFF
--- a/config/spectrum.php
+++ b/config/spectrum.php
@@ -933,6 +933,38 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Webhooks Configuration (OpenAPI 3.1.0)
+    |--------------------------------------------------------------------------
+    |
+    | Define root-level webhook operations for OpenAPI 3.1.0 output.
+    | This section maps webhook names to Path Item objects.
+    |
+    | Example:
+    |   'newUser' => [
+    |       'post' => [
+    |           'summary' => 'New user event',
+    |           'requestBody' => [
+    |               'required' => true,
+    |               'content' => [
+    |                   'application/json' => [
+    |                       'schema' => [
+    |                           'type' => 'object',
+    |                           'properties' => ['id' => ['type' => 'string']],
+    |                       ],
+    |                   ],
+    |               ],
+    |           ],
+    |           'responses' => [
+    |               '200' => ['description' => 'Webhook processed'],
+    |           ],
+    |       ],
+    |   ],
+    |
+    */
+    'webhooks' => [],
+
+    /*
+    |--------------------------------------------------------------------------
     | Mock Server Settings
     |--------------------------------------------------------------------------
     */

--- a/src/Generators/OpenApiGenerator.php
+++ b/src/Generators/OpenApiGenerator.php
@@ -141,6 +141,14 @@ class OpenApiGenerator
             $openapi['components']['callbacks'] = $componentCallbacks;
         }
 
+        // Populate root-level webhooks definitions (OpenAPI 3.1.0 feature)
+        if (config('spectrum.openapi.version') === '3.1.0') {
+            $webhooks = $this->generateWebhooks();
+            if (! empty($webhooks)) {
+                $openapi['webhooks'] = $webhooks;
+            }
+        }
+
         // Validate that all schema references are resolved
         $brokenReferences = $this->schemaRegistry->validateReferences();
         if (! empty($brokenReferences)) {
@@ -245,6 +253,26 @@ class OpenApiGenerator
         }
 
         return $this->callbackGenerator->generateComponentCallbacks($callbackInfos);
+    }
+
+    /**
+     * Generate root-level webhooks from config (OpenAPI 3.1.0).
+     *
+     * @return array<string, mixed>
+     */
+    protected function generateWebhooks(): array
+    {
+        $webhooks = config('spectrum.webhooks', []);
+
+        if (! is_array($webhooks)) {
+            Log::warning('Invalid webhooks configuration detected: expected array.', [
+                'type' => gettype($webhooks),
+            ]);
+
+            return [];
+        }
+
+        return $webhooks;
     }
 
     /**


### PR DESCRIPTION
## Summary
- add support for root-level `webhooks` generation from `spectrum.webhooks` when OpenAPI 3.1.0 is enabled
- extend `OpenApi31Converter` to convert schemas inside `webhooks` (requestBody/responses/parameters/callbacks)
- add defensive handling for invalid webhook config values
- add feature and unit tests covering positive paths and boundary conditions

## Why
OpenAPI 3.1 defines a dedicated root-level `webhooks` object. Previously Laravel Spectrum emitted an empty object only, without a way to populate actual webhook operations.

## Tests
- `vendor/bin/phpunit tests/Unit/Generators/OpenApiGeneratorTest.php`
- `vendor/bin/phpunit tests/Unit/Converters/OpenApi31ConverterTest.php`
- `vendor/bin/phpunit tests/Feature/CallbackIntegrationTest.php`
- `vendor/bin/phpunit tests/Feature/OpenApiSnapshotTest.php --filter openapi_31_generates_consistent_output`

Closes #296
