### PR TITLE
fix: fallback incremental generation when no changes tracked

### DIFF
--- a/src/Console/Commands/OptimizedGenerateCommand.php
+++ b/src/Console/Commands/OptimizedGenerateCommand.php
@@ -243,9 +243,7 @@ class OptimizedGenerateCommand extends Command
         $invalidated = array_values(array_unique($cache->getInvalidatedItems()));
 
         if ($invalidated === []) {
-            if (isset($this->output)) {
-                $this->warn('No tracked incremental changes found. Falling back to processing all routes.');
-            }
+            $this->warn('No tracked incremental changes found. Falling back to processing all routes.');
 
             return $routes;
         }

--- a/tests/Unit/Console/Commands/OptimizedGenerateCommandTest.php
+++ b/tests/Unit/Console/Commands/OptimizedGenerateCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Console\Commands;
 
+use Illuminate\Console\OutputStyle;
 use LaravelSpectrum\Analyzers\RouteAnalyzer;
 use LaravelSpectrum\Console\Commands\OptimizedGenerateCommand;
 use LaravelSpectrum\DTO\OpenApiSpec;
@@ -15,6 +16,8 @@ use LaravelSpectrum\Performance\ParallelProcessor;
 use Mockery;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 class OptimizedGenerateCommandTest extends TestCase
 {
@@ -413,6 +416,7 @@ class OptimizedGenerateCommandTest extends TestCase
         $command = new OptimizedGenerateCommand(
             dependencyGraph: Mockery::mock(DependencyGraph::class)
         );
+        $command->setOutput(new OutputStyle(new ArrayInput([]), new BufferedOutput));
 
         $routes = [
             [


### PR DESCRIPTION
## Summary
- fix issue #410 where optimized incremental generation could process 0 routes when no change log exists
- add fallback behavior to process all routes when no tracked incremental changes are available
- add regression tests for route filtering behavior and artisan command path

## Testing
- vendor/bin/phpunit tests/Unit/Console/Commands/OptimizedGenerateCommandTest.php tests/Unit/Cache/IncrementalCacheTest.php
- vendor/bin/phpunit tests/Unit/Console

Closes #410