### PR TITLE
fix: generate valid YAML scalars in spectrum:generate

### DIFF
--- a/src/Console/GenerateDocsCommand.php
+++ b/src/Console/GenerateDocsCommand.php
@@ -10,6 +10,7 @@ use LaravelSpectrum\DTO\OpenApiSpec;
 use LaravelSpectrum\Generators\HtmlDocumentGenerator;
 use LaravelSpectrum\Generators\OpenApiGenerator;
 use LaravelSpectrum\Support\ErrorCollector;
+use Symfony\Component\Yaml\Yaml;
 
 class GenerateDocsCommand extends Command
 {
@@ -258,28 +259,13 @@ class GenerateDocsCommand extends Command
         return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     }
 
-    protected function arrayToYaml(array $array, int $indent = 0): string
+    protected function arrayToYaml(array $array): string
     {
-        // MVP版の簡易実装
-        $yaml = '';
-        foreach ($array as $key => $value) {
-            $yaml .= str_repeat('  ', $indent).$key.': ';
-
-            if (is_array($value)) {
-                $yaml .= "\n".$this->arrayToYaml($value, $indent + 1);
-            } elseif (is_object($value)) {
-                // オブジェクトを配列に変換して再帰処理
-                $yaml .= "\n".$this->arrayToYaml((array) $value, $indent + 1);
-            } elseif (is_bool($value)) {
-                $yaml .= ($value ? 'true' : 'false')."\n";
-            } elseif ($value === null) {
-                $yaml .= "null\n";
-            } else {
-                $yaml .= $value."\n";
-            }
+        if ($array === []) {
+            return '';
         }
 
-        return $yaml;
+        return Yaml::dump($array, 10, 2, Yaml::DUMP_OBJECT_AS_MAP);
     }
 
     private function outputErrorReport(ErrorCollector $errorCollector): void

--- a/tests/Unit/Console/GenerateDocsCommandTest.php
+++ b/tests/Unit/Console/GenerateDocsCommandTest.php
@@ -11,6 +11,7 @@ use LaravelSpectrum\Console\GenerateDocsCommand;
 use LaravelSpectrum\Tests\Fixtures\Controllers\UserController;
 use LaravelSpectrum\Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Yaml\Yaml;
 
 class GenerateDocsCommandTest extends TestCase
 {
@@ -177,11 +178,12 @@ class GenerateDocsCommandTest extends TestCase
         ];
 
         $yaml = $method->invoke($command, $array);
+        $parsed = Yaml::parse($yaml);
 
         $this->assertStringContainsString('openapi: 3.0.0', $yaml);
         $this->assertStringContainsString('info:', $yaml);
-        $this->assertStringContainsString('title: Test API', $yaml);
         $this->assertStringContainsString('version: 1.0.0', $yaml);
+        $this->assertSame($array, $parsed);
     }
 
     #[Test]
@@ -454,10 +456,31 @@ class GenerateDocsCommandTest extends TestCase
         ];
 
         $yaml = $method->invoke($command, $array);
+        $parsed = Yaml::parse($yaml);
 
         // The YAML should properly handle strings with colons
         $this->assertStringContainsString('description:', $yaml);
         $this->assertStringContainsString('multiline:', $yaml);
+        $this->assertSame($array, $parsed);
+    }
+
+    #[Test]
+    public function array_to_yaml_generates_valid_yaml_for_colon_containing_scalars(): void
+    {
+        $command = app(GenerateDocsCommand::class);
+        $reflection = new \ReflectionClass($command);
+        $method = $reflection->getMethod('arrayToYaml');
+        $method->setAccessible(true);
+
+        $array = [
+            'title' => 'API: v1',
+            'description' => 'Base URL: https://api.example.com',
+        ];
+
+        $yaml = $method->invoke($command, $array);
+        $parsed = Yaml::parse($yaml);
+
+        $this->assertSame($array, $parsed);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- replace manual YAML serialization in GenerateDocsCommand arrayToYaml with Symfony YAML dump
- keep empty-array behavior compatible by returning an empty string
- add regression test for scalars containing colon characters (issue #413)
- tighten existing YAML tests by parsing generated YAML and asserting round-trip integrity

## Verification
- composer format
- composer analyze
- vendor/bin/phpunit tests/Unit/Console/GenerateDocsCommandTest.php
- composer test