### PR TITLE
docs: CLIリファレンスと実装オプションの不整合を解消

### DIFF
--- a/docs/docs/ci-cd-integration.md
+++ b/docs/docs/ci-cd-integration.md
@@ -180,7 +180,7 @@ jobs:
 
       - name: Generate documentation
         run: |
-          php artisan spectrum:generate --dry-run
+          php artisan spectrum:generate --fail-on-error --error-report=storage/logs/spectrum-errors.json
           
       - name: Check for errors
         run: |
@@ -446,7 +446,7 @@ jobs:
           name: Generate Documentation
           command: |
             php artisan spectrum:generate
-            php artisan spectrum:export:postman --environment
+            php artisan spectrum:export:postman --environments=local
             php artisan spectrum:export:insomnia
             
       - store_artifacts:

--- a/docs/docs/cli-reference.md
+++ b/docs/docs/cli-reference.md
@@ -85,9 +85,9 @@ php artisan spectrum:generate:optimized [options]
 | `--format` | json | Output format (json/yaml) |
 | `--output` | storage/app/spectrum/openapi.json | Output file path |
 | `--parallel` | false | Enable parallel processing |
-| `--workers` | auto | Number of parallel workers (auto for CPU cores) |
-| `--chunk-size` | auto | Number of routes processed by each worker |
-| `--memory-limit` | 512M | Memory limit for each worker |
+| `--workers` | none | Number of parallel workers |
+| `--chunk-size` | auto | Number of routes processed per chunk |
+| `--memory-limit` | none | Memory limit override (example: `1G`) |
 | `--incremental` | false | Process only changed files |
 
 ### Examples
@@ -324,7 +324,7 @@ docs-mock:
 	php artisan spectrum:mock
 
 docs-export:
-	php artisan spectrum:export:postman --environment
+	php artisan spectrum:export:postman --environments=local
 	php artisan spectrum:export:insomnia
 ```
 

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -177,10 +177,10 @@ See the [Performance Optimization Guide](./performance.md) for details.
 ],
 ```
 
-You can also specify in the command:
+After updating route patterns, regenerate documentation:
 
 ```bash
-php artisan spectrum:generate --pattern="api/v1/*"
+php artisan spectrum:generate --clear-cache
 ```
 
 ### Q: I'm using custom authentication middleware

--- a/docs/docs/migration-guide.md
+++ b/docs/docs/migration-guide.md
@@ -392,8 +392,8 @@ git tag pre-spectrum-migration
 // Check details in debug mode
 php artisan spectrum:generate -vvv
 
-// Generate with specific pattern
-php artisan spectrum:generate --pattern="api/users/*"
+// Regenerate after configuration updates
+php artisan spectrum:generate --clear-cache
 ```
 
 ### Schema Mismatches

--- a/docs/docs/performance.md
+++ b/docs/docs/performance.md
@@ -102,17 +102,24 @@ php artisan spectrum:generate:optimized --incremental
 
 ### 4. Selective Generation
 
-Generate only specific route patterns:
+Control target routes from configuration:
+
+```php
+// config/spectrum.php
+'route_patterns' => [
+    'api/v2/*',
+    'api/users/*',
+    'api/posts/*',
+],
+'excluded_routes' => [
+    'api/admin/*',
+    'api/debug/*',
+],
+```
 
 ```bash
-# Specific version only
-php artisan spectrum:generate --pattern="api/v2/*"
-
-# Multiple patterns
-php artisan spectrum:generate --pattern="api/users/*" --pattern="api/posts/*"
-
-# Exclusion patterns
-php artisan spectrum:generate --exclude="api/admin/*" --exclude="api/debug/*"
+# Apply updated route filters
+php artisan spectrum:generate --clear-cache
 ```
 
 ## 🔧 Configuration Optimization
@@ -201,11 +208,9 @@ php artisan spectrum:generate:optimized --workers=1
 ### Cache Issues
 
 ```bash
-# Clear cache
+# Clear cache and regenerate
 php artisan spectrum:cache clear
-
-# Generate without cache
-php artisan spectrum:generate:optimized --no-cache
+php artisan spectrum:generate:optimized
 ```
 
 ## 💡 Best Practices

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -183,8 +183,8 @@ php artisan spectrum:generate
 # Regenerate without cache
 php artisan spectrum:generate --no-cache
 
-# Specific route patterns only
-php artisan spectrum:generate --pattern="api/v2/*"
+# Generate YAML output
+php artisan spectrum:generate --format=yaml --output=docs/openapi.yaml
 
 # Real-time preview
 php artisan spectrum:watch

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -218,14 +218,14 @@ Authentication is required but not shown in documentation.
 ### Debug Commands
 
 ```bash
-# Generate with specific pattern
-php artisan spectrum:generate --pattern="api/users/*" -vvv
+# Generate with full debug output and error report
+php artisan spectrum:generate --no-cache --error-report=storage/logs/spectrum-errors.json -vvv
 
 # Verbose output
 php artisan spectrum:generate -vvv
 
-# Dry run (no file generation)
-php artisan spectrum:generate --dry-run
+# Clear cache before rerun
+php artisan spectrum:generate --clear-cache
 ```
 
 ### Check Log Files
@@ -359,9 +359,15 @@ Recommended extensions:
 
 ### File Size Too Large
 
-1. **Split Output**
-   ```bash
-   php artisan spectrum:generate --split-by-tag
+1. **Limit analyzed routes**
+   ```php
+   // config/spectrum.php
+   'route_patterns' => [
+       'api/public/*',
+   ],
+   'excluded_routes' => [
+       'api/internal/*',
+   ],
    ```
 
 2. **Exclude Unnecessary Information**


### PR DESCRIPTION
## Summary
- `spectrum:generate` の実装に存在しないオプション記載（`--pattern`, `--exclude`, `--dry-run`, `--split-by-tag`）をドキュメントから除去/置換
- `spectrum:export:postman` の誤記 `--environment` を実装準拠の `--environments` に統一
- `quickstart`, `performance`, `troubleshooting`, `cli-reference` を中心に、関連ドキュメントのコマンド例を実行可能な形へ整合

## Changed Files
- `docs/docs/quickstart.md`
- `docs/docs/performance.md`
- `docs/docs/troubleshooting.md`
- `docs/docs/cli-reference.md`
- `docs/docs/faq.md`
- `docs/docs/migration-guide.md`
- `docs/docs/ci-cd-integration.md`

## Verification
- `composer test`
  - Result: `OK, but some tests were skipped!`
  - Tests: 3623, Assertions: 11276, Skipped: 1
- `rg -n -- "--pattern|--exclude|--dry-run|--split-by-tag|--environment\b|spectrum:generate:optimized --no-cache" docs/docs`
  - Result: no matches

## Risks / Follow-ups
- 今回は docs の整合修正のみで、実装コードの変更はなし
- docs 全体で同種の誤オプション記載が残らないことを `rg` で確認済み

Closes #433