### PR TITLE
docs: fix postman export option name in ja docs

### DIFF
--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/ci-cd-integration.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/ci-cd-integration.md
@@ -452,7 +452,7 @@ jobs:
           name: Generate Documentation
           command: |
             php artisan spectrum:generate
-            php artisan spectrum:export:postman --environment
+            php artisan spectrum:export:postman --environments=local
             php artisan spectrum:export:insomnia
             
       - store_artifacts:

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/cli-reference.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/cli-reference.md
@@ -330,7 +330,7 @@ docs-mock:
 	php artisan spectrum:mock
 
 docs-export:
-	php artisan spectrum:export:postman --environment
+	php artisan spectrum:export:postman --environments=local
 	php artisan spectrum:export:insomnia
 ```
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/export.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/export.md
@@ -30,13 +30,13 @@ php artisan spectrum:export:postman --output=/path/to/postman_collection.json
 php artisan spectrum:export:postman \
     --include-examples \
     --include-tests \
-    --environment
+    --environments=local
 ```
 
 オプション説明：
 - `--include-examples`: リクエスト/レスポンス例を含める
 - `--include-tests`: 自動テストスクリプトを生成
-- `--environment`: 環境変数ファイルも生成
+- `--environments`: エクスポートする環境（カンマ区切り、デフォルト `local`）
 
 ### 生成される内容
 
@@ -369,7 +369,7 @@ jobs:
         run: |
           php artisan spectrum:export:postman \
             --output=postman/collection.json \
-            --environment
+            --environments=local
             
       - name: Export to Insomnia  
         run: |


### PR DESCRIPTION
## Summary
- Corrected Postman export option typo from `--environment` to `--environments=local` in Japanese docs examples
- Updated option description in export guide to match the actual command signature

## Files/components changed
- docs/i18n/ja/docusaurus-plugin-content-docs/current/export.md
- docs/i18n/ja/docusaurus-plugin-content-docs/current/ci-cd-integration.md
- docs/i18n/ja/docusaurus-plugin-content-docs/current/cli-reference.md

## Verification
- `rg -n -- '--environment\\b|--environment=' docs README.md` (no matches)
- Confirmed command signature uses `--environments` in `src/Console/Commands/ExportPostmanCommand.php`

## Risks or follow-ups
- English docs were already aligned in this repository; this PR scopes only Japanese docs consistency

Closes #434
