### PR TITLE
fix: DefaultWorkerCountResolver の sysctl 呼び出しノイズを抑制

### DIFF
--- a/src/Performance/Support/DefaultWorkerCountResolver.php
+++ b/src/Performance/Support/DefaultWorkerCountResolver.php
@@ -60,9 +60,14 @@ class DefaultWorkerCountResolver implements WorkerCountResolverInterface
         }
 
         if (PHP_OS_FAMILY === 'Darwin') {
-            $result = shell_exec('sysctl -n hw.ncpu');
+            $result = shell_exec('sysctl -n hw.ncpu 2>/dev/null');
+            if ($result === null) {
+                return 1;
+            }
 
-            return $result !== null ? (int) $result : 1;
+            $cores = (int) trim($result);
+
+            return $cores > 0 ? $cores : 1;
         }
 
         if (PHP_OS_FAMILY === 'Windows') {

--- a/tests/Unit/Performance/Support/DefaultWorkerCountResolverTest.php
+++ b/tests/Unit/Performance/Support/DefaultWorkerCountResolverTest.php
@@ -218,7 +218,42 @@ class DefaultWorkerCountResolverTest extends TestCase
             {
                 $result = null;  // Simulating shell_exec returning null
 
-                return $result !== null ? (int) $result : 1;
+                if ($result === null) {
+                    return 1;
+                }
+
+                $cores = (int) trim($result);
+
+                return $cores > 0 ? $cores : 1;
+            }
+        };
+
+        $cores = $resolver->getDetectedCores();
+        $this->assertEquals(1, $cores);
+    }
+
+    #[Test]
+    public function detect_cpu_cores_handles_darwin_non_positive_shell_exec_result(): void
+    {
+        // Simulate macOS where shell_exec returns non-positive value
+        $resolver = new class extends DefaultWorkerCountResolver
+        {
+            public function getDetectedCores(): int
+            {
+                return $this->simulateDarwinNonPositiveResult();
+            }
+
+            private function simulateDarwinNonPositiveResult(): int
+            {
+                $result = "0\n";  // Simulating shell_exec returning invalid core count
+
+                if ($result === null) {
+                    return 1;
+                }
+
+                $cores = (int) trim($result);
+
+                return $cores > 0 ? $cores : 1;
             }
         };
 


### PR DESCRIPTION
## Summary
- Darwin での CPU コア検出コマンドを `sysctl -n hw.ncpu 2>/dev/null` に変更し、stderr ノイズを抑制
- `shell_exec` が `null` または非正数を返した場合に `1` へフォールバックするガードを追加
- フォールバック挙動を検証するユニットテストを更新・追加

## Verification
- vendor/bin/phpunit tests/Unit/Performance/Support/DefaultWorkerCountResolverTest.php
- composer format
- composer analyze
- composer test

Closes #436