### PR TITLE
refactor: Consoleカテゴリへstrict_typesを追加

### DIFF
--- a/src/Console/CacheCommand.php
+++ b/src/Console/CacheCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Console;
 
 use Illuminate\Console\Command;

--- a/src/Console/Commands/ExportInsomniaCommand.php
+++ b/src/Console/Commands/ExportInsomniaCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Console\Commands;
 
 use Illuminate\Console\Command;

--- a/src/Console/Commands/ExportPostmanCommand.php
+++ b/src/Console/Commands/ExportPostmanCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Console\Commands;
 
 use Illuminate\Console\Command;

--- a/src/Console/Commands/MockServerCommand.php
+++ b/src/Console/Commands/MockServerCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Console\Commands;
 
 use Illuminate\Console\Command;

--- a/src/Console/GenerateDocsCommand.php
+++ b/src/Console/GenerateDocsCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Console;
 
 use Illuminate\Console\Command;

--- a/src/Console/WatchCommand.php
+++ b/src/Console/WatchCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Console;
 
 use Illuminate\Console\Command;


### PR DESCRIPTION
## Summary
- issue #437 の段階対応として、`src/Console` カテゴリの未適用ファイルへ `declare(strict_types=1);` を追加
- 今回は `Console` 3ファイル + `Console/Commands` 3ファイルを対象化
- ロジック変更や公開挙動の変更はありません

## Files/Components Changed
- `src/Console/CacheCommand.php`
- `src/Console/GenerateDocsCommand.php`
- `src/Console/WatchCommand.php`
- `src/Console/Commands/ExportInsomniaCommand.php`
- `src/Console/Commands/ExportPostmanCommand.php`
- `src/Console/Commands/MockServerCommand.php`

## Verification
- `composer format:fix`
- `composer analyze`
- `composer test`

## Risks / Follow-ups
- `src` 配下には未適用ファイルが 37 件残っているため、カテゴリ単位で継続対応

Part of #437