### PR TITLE
refactor: Generatorsカテゴリへstrict_typesを追加

### DIFF
--- a/src/Generators/ErrorResponseGenerator.php
+++ b/src/Generators/ErrorResponseGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Generators;
 
 use LaravelSpectrum\DTO\OpenApiResponse;

--- a/src/Generators/ExampleGenerator.php
+++ b/src/Generators/ExampleGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Generators;
 
 use LaravelSpectrum\Contracts\HasCustomExamples;

--- a/src/Generators/HtmlDocumentGenerator.php
+++ b/src/Generators/HtmlDocumentGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Generators;
 
 use Illuminate\Support\Facades\View;

--- a/src/Generators/OpenApiGenerator.php
+++ b/src/Generators/OpenApiGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Generators;
 
 use Illuminate\Support\Facades\Log;

--- a/src/Generators/OperationMetadataGenerator.php
+++ b/src/Generators/OperationMetadataGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Generators;
 
 use Illuminate\Support\Str;

--- a/src/Generators/PaginationSchemaGenerator.php
+++ b/src/Generators/PaginationSchemaGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Generators;
 
 /**

--- a/src/Generators/ParameterGenerator.php
+++ b/src/Generators/ParameterGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Generators;
 
 use LaravelSpectrum\DTO\ControllerInfo;

--- a/src/Generators/RequestBodyGenerator.php
+++ b/src/Generators/RequestBodyGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Generators;
 
 use LaravelSpectrum\Analyzers\FormRequestAnalyzer;

--- a/src/Generators/ResponseSchemaGenerator.php
+++ b/src/Generators/ResponseSchemaGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Generators;
 
 use LaravelSpectrum\DTO\ResponseType;

--- a/src/Generators/SchemaGenerator.php
+++ b/src/Generators/SchemaGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Generators;
 
 use LaravelSpectrum\DTO\Collections\ValidationRuleCollection;

--- a/src/Generators/SecuritySchemeGenerator.php
+++ b/src/Generators/SecuritySchemeGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Generators;
 
 use LaravelSpectrum\DTO\AuthenticationScheme;

--- a/src/Generators/TagGenerator.php
+++ b/src/Generators/TagGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Generators;
 
 use Illuminate\Support\Str;

--- a/src/Generators/ValidationMessageGenerator.php
+++ b/src/Generators/ValidationMessageGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\Generators;
 
 use Illuminate\Support\Str;


### PR DESCRIPTION
## Summary
- issue #437 の段階対応として、`src/Generators` カテゴリの未適用ファイルへ `declare(strict_types=1);` を追加
- 今回は Generators の 13 ファイルを対象化
- ロジック変更や公開挙動の変更はありません

## Files/Components Changed
- `src/Generators/ErrorResponseGenerator.php`
- `src/Generators/ExampleGenerator.php`
- `src/Generators/HtmlDocumentGenerator.php`
- `src/Generators/OpenApiGenerator.php`
- `src/Generators/OperationMetadataGenerator.php`
- `src/Generators/PaginationSchemaGenerator.php`
- `src/Generators/ParameterGenerator.php`
- `src/Generators/RequestBodyGenerator.php`
- `src/Generators/ResponseSchemaGenerator.php`
- `src/Generators/SchemaGenerator.php`
- `src/Generators/SecuritySchemeGenerator.php`
- `src/Generators/TagGenerator.php`
- `src/Generators/ValidationMessageGenerator.php`

## Verification
- `composer format:fix`
- `composer analyze`
- `composer test`

## Risks / Follow-ups
- `src` 配下には未適用ファイルが 24 件残っているため、カテゴリ単位で継続対応

Part of #437