### PR TITLE
refactor: MockServerカテゴリへstrict_typesを追加

### DIFF
--- a/src/MockServer/AuthenticationSimulator.php
+++ b/src/MockServer/AuthenticationSimulator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\MockServer;
 
 use Workerman\Protocols\Http\Request;

--- a/src/MockServer/MockServer.php
+++ b/src/MockServer/MockServer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\MockServer;
 
 use Workerman\Connection\TcpConnection;

--- a/src/MockServer/RequestHandler.php
+++ b/src/MockServer/RequestHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\MockServer;
 
 use Workerman\Protocols\Http\Request;

--- a/src/MockServer/ResponseGenerator.php
+++ b/src/MockServer/ResponseGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\MockServer;
 
 use LaravelSpectrum\DTO\OpenApiOperation;

--- a/src/MockServer/RouteResolver.php
+++ b/src/MockServer/RouteResolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\MockServer;
 
 use Illuminate\Support\Str;

--- a/src/MockServer/ValidationSimulator.php
+++ b/src/MockServer/ValidationSimulator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaravelSpectrum\MockServer;
 
 use LaravelSpectrum\DTO\OpenApiOperation;


### PR DESCRIPTION
## Summary
- issue #437 の段階対応として、`src/MockServer` カテゴリの未適用ファイルへ `declare(strict_types=1);` を追加
- 今回は MockServer の 6 ファイルを対象化
- ロジック変更や公開挙動の変更はありません

## Files/Components Changed
- `src/MockServer/AuthenticationSimulator.php`
- `src/MockServer/MockServer.php`
- `src/MockServer/RequestHandler.php`
- `src/MockServer/ResponseGenerator.php`
- `src/MockServer/RouteResolver.php`
- `src/MockServer/ValidationSimulator.php`

## Verification
- `composer format:fix`
- `composer analyze`
- `composer test`

## Risks / Follow-ups
- `src` 配下には未適用ファイルが 18 件残っているため、カテゴリ単位で継続対応

Part of #437