### PR TITLE
refactor: continue missingType.iterableValue reduction (phase 3)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -199,48 +199,6 @@ parameters:
 			path: src/Generators/ParameterGenerator.php
 
 		-
-			message: '#^Method LaravelSpectrum\\Generators\\RequestBodyGenerator\:\:generate\(\) has parameter \$route with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Generators/RequestBodyGenerator.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Generators\\RequestBodyGenerator\:\:generateFileUploadDescription\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Generators/RequestBodyGenerator.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Generators\\RequestBodyGenerator\:\:generateFileUploadRequestBody\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Generators/RequestBodyGenerator.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Generators\\RequestBodyGenerator\:\:generateSchema\(\) has parameter \$conditionalRules with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Generators/RequestBodyGenerator.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Generators\\RequestBodyGenerator\:\:generateSchema\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Generators/RequestBodyGenerator.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Generators\\RequestBodyGenerator\:\:generateSchema\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Generators/RequestBodyGenerator.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Generators\\RequestBodyGenerator\:\:hasFileUploadParameters\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Generators/RequestBodyGenerator.php
-
-		-
 			message: '#^Method LaravelSpectrum\\Generators\\SchemaGenerator\:\:applyRuleConstraints\(\) has parameter \$property with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -341,48 +299,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Support/EnumExtractor.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Support\\Example\\ValueProviders\\FakerValueProvider\:\:executeMethodChain\(\) has parameter \$args with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Support/Example/ValueProviders/FakerValueProvider.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Support\\Example\\ValueProviders\\FakerValueProvider\:\:generate\(\) has parameter \$config with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Support/Example/ValueProviders/FakerValueProvider.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Support\\Example\\ValueProviders\\FakerValueProvider\:\:generateByType\(\) has parameter \$constraints with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Support/Example/ValueProviders/FakerValueProvider.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Support\\Example\\ValueProviders\\FakerValueProvider\:\:generateInteger\(\) has parameter \$constraints with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Support/Example/ValueProviders/FakerValueProvider.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Support\\Example\\ValueProviders\\FakerValueProvider\:\:generateNumber\(\) has parameter \$constraints with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Support/Example/ValueProviders/FakerValueProvider.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Support\\Example\\ValueProviders\\FakerValueProvider\:\:generateString\(\) has parameter \$constraints with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Support/Example/ValueProviders/FakerValueProvider.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Support\\Example\\ValueProviders\\FakerValueProvider\:\:handleUnknownType\(\) has parameter \$constraints with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Support/Example/ValueProviders/FakerValueProvider.php
 
 		-
 			message: '#^Method LaravelSpectrum\\Support\\Example\\ValueProviders\\StaticValueProvider\:\:generate\(\) has parameter \$config with no value type specified in iterable type array\.$#'

--- a/src/Generators/RequestBodyGenerator.php
+++ b/src/Generators/RequestBodyGenerator.php
@@ -17,6 +17,11 @@ use LaravelSpectrum\DTO\OpenApiRequestBody;
  * - Inline controller validation
  * - Conditional validation rules
  * - File upload parameters
+ *
+ * @phpstan-type RouteInfo array<string, mixed>
+ * @phpstan-type RequestParameter array<string, mixed>
+ * @phpstan-type RequestParameters array<int, RequestParameter>
+ * @phpstan-type ConditionalRules array<string, mixed>
  */
 class RequestBodyGenerator
 {
@@ -30,7 +35,7 @@ class RequestBodyGenerator
      * Generate request body for an API operation.
      *
      * @param  ControllerInfo  $controllerInfo  Controller analysis result
-     * @param  array  $route  Route information
+     * @param  RouteInfo  $route  Route information
      * @return OpenApiRequestBody|null Request body DTO or null if no validation
      */
     public function generate(ControllerInfo $controllerInfo, array $route): ?OpenApiRequestBody
@@ -89,7 +94,7 @@ class RequestBodyGenerator
     /**
      * Check if parameters contain file uploads.
      *
-     * @param  array  $parameters  Request parameters
+     * @param  RequestParameters  $parameters  Request parameters
      * @return bool True if file upload parameters exist
      */
     protected function hasFileUploadParameters(array $parameters): bool
@@ -106,7 +111,7 @@ class RequestBodyGenerator
     /**
      * Generate request body for file upload endpoints.
      *
-     * @param  array  $parameters  Request parameters
+     * @param  RequestParameters  $parameters  Request parameters
      * @return OpenApiRequestBody|null Request body with multipart/form-data content
      */
     protected function generateFileUploadRequestBody(array $parameters): ?OpenApiRequestBody
@@ -129,9 +134,9 @@ class RequestBodyGenerator
     /**
      * Generate schema from parameters, handling conditional rules.
      *
-     * @param  array  $parameters  Request parameters
-     * @param  array|null  $conditionalRules  Conditional validation rules
-     * @return array Generated schema
+     * @param  RequestParameters  $parameters  Request parameters
+     * @param  ConditionalRules|null  $conditionalRules  Conditional validation rules
+     * @return array<string, mixed> Generated schema
      */
     protected function generateSchema(array $parameters, ?array $conditionalRules): array
     {
@@ -145,7 +150,7 @@ class RequestBodyGenerator
     /**
      * Generate description for file upload endpoints.
      *
-     * @param  array  $parameters  Request parameters
+     * @param  RequestParameters  $parameters  Request parameters
      * @return string Description text
      */
     protected function generateFileUploadDescription(array $parameters): string

--- a/src/Support/Example/ValueProviders/FakerValueProvider.php
+++ b/src/Support/Example/ValueProviders/FakerValueProvider.php
@@ -12,6 +12,10 @@ use LaravelSpectrum\Support\Example\FieldPatternRegistry;
 
 /**
  * Strategy that generates example values using Faker.
+ *
+ * @phpstan-type ExampleConfig array<string, mixed>
+ * @phpstan-type ConstraintConfig array<string, mixed>
+ * @phpstan-type FakerMethodArgs array<int, mixed>
  */
 final class FakerValueProvider implements ExampleGenerationStrategy
 {
@@ -22,6 +26,8 @@ final class FakerValueProvider implements ExampleGenerationStrategy
 
     /**
      * {@inheritDoc}
+     *
+     * @param  ExampleConfig  $config
      */
     public function generate(string $fieldName, array $config): mixed
     {
@@ -74,6 +80,8 @@ final class FakerValueProvider implements ExampleGenerationStrategy
 
     /**
      * {@inheritDoc}
+     *
+     * @param  ConstraintConfig  $constraints
      */
     public function generateByType(string $type, array $constraints = []): mixed
     {
@@ -90,6 +98,8 @@ final class FakerValueProvider implements ExampleGenerationStrategy
 
     /**
      * Handle unknown OpenAPI types with logging.
+     *
+     * @param  ConstraintConfig  $constraints
      */
     private function handleUnknownType(string $type, array $constraints): string
     {
@@ -156,6 +166,8 @@ final class FakerValueProvider implements ExampleGenerationStrategy
 
     /**
      * Execute a Faker method chain.
+     *
+     * @param  FakerMethodArgs  $args
      */
     private function executeMethodChain(string $method, array $args): mixed
     {
@@ -179,6 +191,8 @@ final class FakerValueProvider implements ExampleGenerationStrategy
 
     /**
      * Generate integer with constraints.
+     *
+     * @param  ConstraintConfig  $constraints
      */
     private function generateInteger(array $constraints): int
     {
@@ -190,6 +204,8 @@ final class FakerValueProvider implements ExampleGenerationStrategy
 
     /**
      * Generate number (float) with constraints.
+     *
+     * @param  ConstraintConfig  $constraints
      */
     private function generateNumber(array $constraints): float
     {
@@ -201,6 +217,8 @@ final class FakerValueProvider implements ExampleGenerationStrategy
 
     /**
      * Generate string with constraints.
+     *
+     * @param  ConstraintConfig  $constraints
      */
     private function generateString(array $constraints): string
     {


### PR DESCRIPTION
## Summary
- Continued reducing `missingType.iterableValue` by adding explicit iterable value types in:
  - `RequestBodyGenerator`
  - `FakerValueProvider`
- Added focused `@phpstan-type` aliases and parameter/return PHPDoc without changing runtime behavior.
- Removed corresponding resolved entries from `phpstan-baseline.neon`.
- Reduced baseline `missingType.iterableValue` count from **75** to **61** (net **-14**).

## Files/Components Changed
- `src/Generators/RequestBodyGenerator.php`
- `src/Support/Example/ValueProviders/FakerValueProvider.php`
- `phpstan-baseline.neon`

## Verification
- `composer format:fix`
- `composer analyze`
- `composer test`

## Risks / Follow-ups
- This change is type-annotation/baseline cleanup only; no intended functional behavior changes.
- Next high-frequency candidates are `FileWatcher` and `ParallelProcessor` for further baseline reduction.
