### PR TITLE
refactor: continue missingType.iterableValue reduction (phase 5)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,42 +25,6 @@ parameters:
 			path: src/Analyzers/InlineValidationAnalyzer.php
 
 		-
-			message: '#^Method LaravelSpectrum\\Analyzers\\Support\\ValidationDescriptionGenerator\:\:buildFileInfoParts\(\) has parameter \$fileInfo with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Analyzers/Support/ValidationDescriptionGenerator.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Analyzers\\Support\\ValidationDescriptionGenerator\:\:generateConditionalDescription\(\) has parameter \$fieldInfo with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Analyzers/Support/ValidationDescriptionGenerator.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Analyzers\\Support\\ValidationDescriptionGenerator\:\:generateDescription\(\) has parameter \$rules with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Analyzers/Support/ValidationDescriptionGenerator.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Analyzers\\Support\\ValidationDescriptionGenerator\:\:generateDescription\(\) has parameter \$useStatements with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Analyzers/Support/ValidationDescriptionGenerator.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Analyzers\\Support\\ValidationDescriptionGenerator\:\:generateFileDescription\(\) has parameter \$fileInfo with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Analyzers/Support/ValidationDescriptionGenerator.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Analyzers\\Support\\ValidationDescriptionGenerator\:\:generateFileDescriptionWithAttribute\(\) has parameter \$fileInfo with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Analyzers/Support/ValidationDescriptionGenerator.php
-
-		-
 			message: '#^Method LaravelSpectrum\\Console\\Commands\\ExportPostmanCommand\:\:displayImportInstructions\(\) has parameter \$environments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -229,30 +193,6 @@ parameters:
 			path: src/Support/EnumExtractor.php
 
 		-
-			message: '#^Method LaravelSpectrum\\Support\\Example\\ValueProviders\\StaticValueProvider\:\:generate\(\) has parameter \$config with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Support/Example/ValueProviders/StaticValueProvider.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Support\\Example\\ValueProviders\\StaticValueProvider\:\:generateByType\(\) has parameter \$constraints with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Support/Example/ValueProviders/StaticValueProvider.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Support\\Example\\ValueProviders\\StaticValueProvider\:\:generateInteger\(\) has parameter \$constraints with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Support/Example/ValueProviders/StaticValueProvider.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Support\\Example\\ValueProviders\\StaticValueProvider\:\:generateNumber\(\) has parameter \$constraints with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Support/Example/ValueProviders/StaticValueProvider.php
-
-		-
 			message: '#^Method LaravelSpectrum\\Support\\ModelSchemaExtractor\:\:extractSchema\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -281,27 +221,3 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Support/QueryParameterDetector.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Support\\ValidationRules\:\:extractRuleName\(\) has parameter \$rule with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Support/ValidationRules.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Support\\ValidationRules\:\:extractRuleParameters\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Support/ValidationRules.php
-
-		-
-			message: '#^Method LaravelSpectrum\\Support\\ValidationRules\:\:inferFieldType\(\) has parameter \$rules with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Support/ValidationRules.php
-
-		-
-			message: '#^Property LaravelSpectrum\\Support\\ValidationRules\:\:\$messageTemplates type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Support/ValidationRules.php

--- a/src/Analyzers/Support/ValidationDescriptionGenerator.php
+++ b/src/Analyzers/Support/ValidationDescriptionGenerator.php
@@ -12,6 +12,22 @@ use LaravelSpectrum\Support\FileSizeFormatter;
  * Generates human-readable descriptions for validation fields.
  *
  * Extracted from FormRequestAnalyzer to improve single responsibility.
+ *
+ * @phpstan-type ValidationRule string|array<int, mixed>|object
+ * @phpstan-type ValidationRuleList array<int, ValidationRule>
+ * @phpstan-type UseStatements array<string, string>
+ * @phpstan-type FileInfo array{
+ *     mimes?: array<int, string>,
+ *     max_size?: int|null,
+ *     min_size?: int|null,
+ *     dimensions?: array{
+ *         min_width?: int|float|string,
+ *         min_height?: int|float|string,
+ *         max_width?: int|float|string,
+ *         max_height?: int|float|string,
+ *         ratio?: int|float|string
+ *     }
+ * }
  */
 class ValidationDescriptionGenerator
 {
@@ -26,9 +42,9 @@ class ValidationDescriptionGenerator
      * Generate description for a field based on its validation rules.
      *
      * @param  string  $field  The field name
-     * @param  array  $rules  The validation rules
+     * @param  ValidationRuleList  $rules  The validation rules
      * @param  string|null  $namespace  The namespace for enum resolution
-     * @param  array  $useStatements  Use statements for enum resolution
+     * @param  UseStatements  $useStatements  Use statements for enum resolution
      */
     public function generateDescription(string $field, array $rules, ?string $namespace = null, array $useStatements = []): string
     {
@@ -61,6 +77,8 @@ class ValidationDescriptionGenerator
      *
      * This is a convenience method that delegates to generateFileDescriptionWithAttribute
      * with a null attribute, using the formatted field name as the description base.
+     *
+     * @param  FileInfo  $fileInfo
      */
     public function generateFileDescription(string $field, array $fileInfo): string
     {
@@ -69,6 +87,8 @@ class ValidationDescriptionGenerator
 
     /**
      * Generate description for a file field with custom attribute name.
+     *
+     * @param  FileInfo  $fileInfo
      */
     public function generateFileDescriptionWithAttribute(string $field, array $fileInfo, ?string $attribute = null): string
     {
@@ -80,6 +100,8 @@ class ValidationDescriptionGenerator
 
     /**
      * Generate description for a conditional field.
+     *
+     * @param  array<string, mixed>  $fieldInfo
      */
     public function generateConditionalDescription(string $field, array $fieldInfo): string
     {
@@ -179,7 +201,8 @@ class ValidationDescriptionGenerator
     /**
      * Build file info parts for description.
      *
-     * @return array<string>
+     * @param  FileInfo  $fileInfo
+     * @return array<int, string>
      */
     protected function buildFileInfoParts(array $fileInfo): array
     {

--- a/src/Support/Example/ValueProviders/StaticValueProvider.php
+++ b/src/Support/Example/ValueProviders/StaticValueProvider.php
@@ -11,6 +11,9 @@ use LaravelSpectrum\Support\Example\FieldPatternRegistry;
  * Strategy that generates example values using static predefined values.
  *
  * Useful for deterministic output and testing scenarios.
+ *
+ * @phpstan-type ExampleConfig array<string, mixed>
+ * @phpstan-type ConstraintConfig array<string, mixed>
  */
 final class StaticValueProvider implements ExampleGenerationStrategy
 {
@@ -20,6 +23,8 @@ final class StaticValueProvider implements ExampleGenerationStrategy
 
     /**
      * {@inheritDoc}
+     *
+     * @param  ExampleConfig  $config
      */
     public function generate(string $fieldName, array $config): mixed
     {
@@ -65,6 +70,8 @@ final class StaticValueProvider implements ExampleGenerationStrategy
 
     /**
      * {@inheritDoc}
+     *
+     * @param  ConstraintConfig  $constraints
      */
     public function generateByType(string $type, array $constraints = []): mixed
     {
@@ -80,6 +87,8 @@ final class StaticValueProvider implements ExampleGenerationStrategy
 
     /**
      * Generate integer with constraints.
+     *
+     * @param  ConstraintConfig  $constraints
      */
     private function generateInteger(array $constraints): int
     {
@@ -95,6 +104,8 @@ final class StaticValueProvider implements ExampleGenerationStrategy
 
     /**
      * Generate number (float) with constraints.
+     *
+     * @param  ConstraintConfig  $constraints
      */
     private function generateNumber(array $constraints): float
     {

--- a/src/Support/ValidationRules.php
+++ b/src/Support/ValidationRules.php
@@ -8,6 +8,8 @@ class ValidationRules
 {
     /**
      * バリデーションルールからエラーメッセージのテンプレートを取得
+     *
+     * @var array<string, string|array<string, string>>
      */
     protected static array $messageTemplates = [
         'required' => 'The :attribute field is required.',
@@ -61,6 +63,8 @@ class ValidationRules
 
     /**
      * ルール名を抽出（パラメータを除去）
+     *
+     * @param  string|array<int, mixed>|object  $rule
      */
     public static function extractRuleName(string|array|object $rule): string
     {
@@ -97,6 +101,8 @@ class ValidationRules
 
     /**
      * ルールのパラメータを抽出
+     *
+     * @return array<int, string>
      */
     public static function extractRuleParameters(string $rule): array
     {
@@ -130,6 +136,8 @@ class ValidationRules
 
     /**
      * フィールドタイプを推測
+     *
+     * @param  array<int, string|array<int, mixed>|object>  $rules
      */
     public static function inferFieldType(array $rules): string
     {


### PR DESCRIPTION
## Summary
- Continued reducing `missingType.iterableValue` in validation-related support components:
  - `ValidationDescriptionGenerator`
  - `StaticValueProvider`
  - `ValidationRules`
- Added explicit iterable value annotations (array shapes / generic array PHPDoc) for parameters, returns, and property types.
- Removed corresponding resolved entries from `phpstan-baseline.neon`.
- Reduced baseline `missingType.iterableValue` count from **49** to **35** (net **-14**).

## Files/Components Changed
- `src/Analyzers/Support/ValidationDescriptionGenerator.php`
- `src/Support/Example/ValueProviders/StaticValueProvider.php`
- `src/Support/ValidationRules.php`
- `phpstan-baseline.neon`

## Verification
- `composer format:fix`
- `composer analyze`
- `composer test`

## Risks / Follow-ups
- Changes are focused on static typing metadata and baseline cleanup; no intended behavior changes.
- Remaining candidates include `ExampleValueFactory`, `ErrorResponseGenerator`, and `ExportFormatInterface`.
