### PR TITLE
fix: deduplicate duplicate query parameters from validation and input usage

### DIFF
--- a/src/Generators/ParameterGenerator.php
+++ b/src/Generators/ParameterGenerator.php
@@ -341,13 +341,13 @@ class ParameterGenerator
      * @param  array<int, OpenApiParameter>  $parameters
      * @return array<int, OpenApiParameter>
      */
-    protected function deduplicateParameters(array $parameters): array
+    private function deduplicateParameters(array $parameters): array
     {
         $result = [];
         $indexByKey = [];
 
         foreach ($parameters as $parameter) {
-            $key = $parameter->in.':'.$parameter->name;
+            $key = sprintf('%s:%s', $parameter->in, $parameter->name);
 
             if (! array_key_exists($key, $indexByKey)) {
                 $indexByKey[$key] = count($result);
@@ -363,7 +363,7 @@ class ParameterGenerator
         return $result;
     }
 
-    protected function mergeParameters(OpenApiParameter $base, OpenApiParameter $incoming): OpenApiParameter
+    private function mergeParameters(OpenApiParameter $base, OpenApiParameter $incoming): OpenApiParameter
     {
         return new OpenApiParameter(
             name: $base->name,
@@ -378,7 +378,7 @@ class ParameterGenerator
         );
     }
 
-    protected function mergeSchemas(OpenApiSchema $base, OpenApiSchema $incoming): OpenApiSchema
+    private function mergeSchemas(OpenApiSchema $base, OpenApiSchema $incoming): OpenApiSchema
     {
         $type = $base->type;
         if ($type === 'string' && $incoming->type !== 'string') {

--- a/tests/Unit/Generators/ParameterGeneratorTest.php
+++ b/tests/Unit/Generators/ParameterGeneratorTest.php
@@ -916,6 +916,7 @@ class ParameterGeneratorTest extends TestCase
         $this->assertCount(1, $parameters);
         $this->assertEquals('email', $parameters[0]->name);
         $this->assertEquals('query', $parameters[0]->in);
+        $this->assertFalse($parameters[0]->required);
         $this->assertEquals('Email', $parameters[0]->description);
         $this->assertEquals(255, $parameters[0]->schema->maxLength);
     }
@@ -960,6 +961,161 @@ class ParameterGeneratorTest extends TestCase
         $this->assertTrue($parameters[0]->required);
         $this->assertEquals('Search term', $parameters[0]->description);
         $this->assertEquals(3, $parameters[0]->schema->minLength);
+    }
+
+    #[Test]
+    public function it_preserves_first_parameter_metadata_when_deduplicating(): void
+    {
+        $route = [
+            'parameters' => [
+                [
+                    'name' => 'filters',
+                    'in' => 'query',
+                    'required' => false,
+                    'description' => 'Base description',
+                    'style' => 'pipeDelimited',
+                    'explode' => false,
+                    'deprecated' => false,
+                    'allowEmptyValue' => false,
+                    'schema' => [
+                        'type' => 'array',
+                        'format' => 'base-format',
+                        'default' => ['base'],
+                        'enum' => [['base']],
+                        'minimum' => 1,
+                        'maximum' => 10,
+                        'minLength' => 2,
+                        'maxLength' => 20,
+                        'pattern' => '^base$',
+                        'items' => ['type' => 'string'],
+                        'nullable' => true,
+                    ],
+                ],
+                [
+                    'name' => 'filters',
+                    'in' => 'query',
+                    'required' => true,
+                    'description' => 'Incoming description',
+                    'style' => 'form',
+                    'explode' => true,
+                    'deprecated' => true,
+                    'allowEmptyValue' => true,
+                    'schema' => [
+                        'type' => 'array',
+                        'format' => 'incoming-format',
+                        'default' => ['incoming'],
+                        'enum' => [['incoming']],
+                        'minimum' => 5,
+                        'maximum' => 50,
+                        'minLength' => 6,
+                        'maxLength' => 60,
+                        'pattern' => '^incoming$',
+                        'items' => ['type' => 'integer'],
+                        'nullable' => false,
+                    ],
+                ],
+            ],
+        ];
+
+        $parameters = $this->generator->generate($route, ControllerInfo::empty(), 'get');
+
+        $this->assertCount(1, $parameters);
+        $merged = $parameters[0];
+        $this->assertTrue($merged->required);
+        $this->assertEquals('Base description', $merged->description);
+        $this->assertEquals('pipeDelimited', $merged->style);
+        $this->assertFalse($merged->explode);
+        $this->assertFalse($merged->deprecated);
+        $this->assertFalse($merged->allowEmptyValue);
+        $this->assertEquals('array', $merged->schema->type);
+        $this->assertEquals('base-format', $merged->schema->format);
+        $this->assertEquals(['base'], $merged->schema->default);
+        $this->assertEquals([['base']], $merged->schema->enum);
+        $this->assertEquals(1, $merged->schema->minimum);
+        $this->assertEquals(10, $merged->schema->maximum);
+        $this->assertEquals(2, $merged->schema->minLength);
+        $this->assertEquals(20, $merged->schema->maxLength);
+        $this->assertEquals('^base$', $merged->schema->pattern);
+        $this->assertEquals('string', $merged->schema->items?->type);
+        $this->assertTrue($merged->schema->nullable);
+    }
+
+    #[Test]
+    public function it_prefers_non_string_schema_type_from_incoming_duplicate(): void
+    {
+        $route = [
+            'parameters' => [
+                [
+                    'name' => 'score',
+                    'in' => 'query',
+                    'required' => false,
+                    'schema' => ['type' => 'string'],
+                ],
+                [
+                    'name' => 'score',
+                    'in' => 'query',
+                    'required' => false,
+                    'schema' => ['type' => 'integer'],
+                ],
+            ],
+        ];
+
+        $parameters = $this->generator->generate($route, ControllerInfo::empty(), 'get');
+
+        $this->assertCount(1, $parameters);
+        $this->assertEquals('integer', $parameters[0]->schema->type);
+    }
+
+    #[Test]
+    public function it_keeps_base_non_string_schema_type_when_incoming_is_different_non_string(): void
+    {
+        $route = [
+            'parameters' => [
+                [
+                    'name' => 'price',
+                    'in' => 'query',
+                    'required' => false,
+                    'schema' => ['type' => 'integer'],
+                ],
+                [
+                    'name' => 'price',
+                    'in' => 'query',
+                    'required' => false,
+                    'schema' => ['type' => 'number'],
+                ],
+            ],
+        ];
+
+        $parameters = $this->generator->generate($route, ControllerInfo::empty(), 'get');
+
+        $this->assertCount(1, $parameters);
+        $this->assertEquals('integer', $parameters[0]->schema->type);
+    }
+
+    #[Test]
+    public function it_keeps_base_non_string_schema_type_when_incoming_is_string(): void
+    {
+        $route = [
+            'parameters' => [
+                [
+                    'name' => 'status_code',
+                    'in' => 'query',
+                    'required' => false,
+                    'schema' => ['type' => 'integer'],
+                ],
+                [
+                    'name' => 'status_code',
+                    'in' => 'query',
+                    'required' => false,
+                    'schema' => ['type' => 'string'],
+                ],
+            ],
+        ];
+
+        $parameters = $this->generator->generate($route, ControllerInfo::empty(), 'get');
+
+        $this->assertCount(1, $parameters);
+        $this->assertEquals('integer', $parameters[0]->schema->type);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- deduplicate generated OpenAPI parameters by `in + name` in `ParameterGenerator`
- merge duplicate parameter metadata so validation constraints/required flags are preserved
- add regression tests for duplicate query parameter scenarios (`$request->input()` + inline validation)

## Verification
- composer format:fix
- composer analyze
- composer test

Closes #455