### PR TITLE
fix: non-GET request fields are no longer emitted as query params

### DIFF
--- a/src/Analyzers/QueryParameterAnalyzer.php
+++ b/src/Analyzers/QueryParameterAnalyzer.php
@@ -119,12 +119,11 @@ class QueryParameterAnalyzer implements ReflectionMethodAnalyzer
      */
     private function isRequired(DetectedQueryParameter $param): bool
     {
-        // If has() is used, it suggests the parameter might be required
+        // has()/filled() are conditional existence checks and do not imply "required".
         if ($param->hasContextFlag('has_check') && $param->context['has_check']) {
-            return true;
+            return false;
         }
 
-        // If filled() is used, parameter is optional but expected to have value
         if ($param->hasContextFlag('filled_check') && $param->context['filled_check']) {
             return false;
         }

--- a/src/Generators/ParameterGenerator.php
+++ b/src/Generators/ParameterGenerator.php
@@ -46,7 +46,7 @@ class ParameterGenerator
         $parameters = $this->addEnumParameters($parameters, $controllerInfo);
 
         // Add query parameters
-        $parameters = $this->addQueryParameters($parameters, $controllerInfo);
+        $parameters = $this->addQueryParameters($parameters, $controllerInfo, $httpMethod);
 
         // Add header parameters
         $parameters = $this->addHeaderParameters($parameters, $controllerInfo);
@@ -122,15 +122,20 @@ class ParameterGenerator
      *
      * @param  array<int, OpenApiParameter>  $parameters  Existing parameters
      * @param  ControllerInfo  $controllerInfo  Controller analysis result
+     * @param  string|null  $httpMethod  HTTP method (get, post, put, patch, delete)
      * @return array<int, OpenApiParameter> Updated parameters
      */
-    protected function addQueryParameters(array $parameters, ControllerInfo $controllerInfo): array
+    protected function addQueryParameters(array $parameters, ControllerInfo $controllerInfo, ?string $httpMethod = null): array
     {
         if (! $controllerInfo->hasQueryParameters()) {
             return $parameters;
         }
 
         foreach ($controllerInfo->queryParameters as $queryParamDTO) {
+            if (! $this->shouldIncludeAsQueryParameter($queryParamDTO, $httpMethod)) {
+                continue;
+            }
+
             $queryParam = $queryParamDTO->toArray();
             $type = $queryParam['type'] ?? 'string';
 
@@ -203,6 +208,22 @@ class ParameterGenerator
         }
 
         return $parameters;
+    }
+
+    /**
+     * Non-GET request methods should only keep parameters explicitly accessed via query().
+     */
+    protected function shouldIncludeAsQueryParameter(QueryParameterInfo $queryParam, ?string $httpMethod): bool
+    {
+        if ($httpMethod === null) {
+            return true;
+        }
+
+        if (! in_array(strtolower($httpMethod), ['post', 'put', 'patch', 'delete'], true)) {
+            return true;
+        }
+
+        return $queryParam->source === 'query';
     }
 
     /**

--- a/tests/Unit/Analyzers/QueryParameterAnalyzerTest.php
+++ b/tests/Unit/Analyzers/QueryParameterAnalyzerTest.php
@@ -127,9 +127,11 @@ class QueryParameterAnalyzerTest extends TestCase
         $this->assertCount(2, $result['parameters']);
 
         $this->assertEquals('required_param', $result['parameters'][0]['name']);
+        $this->assertFalse($result['parameters'][0]['required']);
         $this->assertTrue($result['parameters'][0]['context']['has_check']);
 
         $this->assertEquals('optional_param', $result['parameters'][1]['name']);
+        $this->assertFalse($result['parameters'][1]['required']);
         $this->assertTrue($result['parameters'][1]['context']['filled_check']);
     }
 

--- a/tests/Unit/Generators/ParameterGeneratorTest.php
+++ b/tests/Unit/Generators/ParameterGeneratorTest.php
@@ -710,6 +710,68 @@ class ParameterGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function it_does_not_add_non_query_source_parameters_for_post_request(): void
+    {
+        $route = [
+            'parameters' => [],
+            'methods' => ['POST'],
+        ];
+
+        $controllerInfo = ControllerInfo::fromArray([
+            'queryParameters' => [
+                [
+                    'name' => 'name',
+                    'type' => 'string',
+                    'required' => false,
+                    'source' => 'input',
+                ],
+                [
+                    'name' => 'is_beta_user',
+                    'type' => 'boolean',
+                    'required' => false,
+                    'source' => 'boolean',
+                ],
+            ],
+        ]);
+
+        $parameters = $this->generator->generate($route, $controllerInfo, 'post');
+
+        $this->assertCount(0, $parameters);
+    }
+
+    #[Test]
+    public function it_keeps_explicit_query_source_parameters_for_post_request(): void
+    {
+        $route = [
+            'parameters' => [],
+            'methods' => ['POST'],
+        ];
+
+        $controllerInfo = ControllerInfo::fromArray([
+            'queryParameters' => [
+                [
+                    'name' => 'via_query',
+                    'type' => 'string',
+                    'required' => false,
+                    'source' => 'query',
+                ],
+                [
+                    'name' => 'via_input',
+                    'type' => 'string',
+                    'required' => false,
+                    'source' => 'input',
+                ],
+            ],
+        ]);
+
+        $parameters = $this->generator->generate($route, $controllerInfo, 'post');
+
+        $this->assertCount(1, $parameters);
+        $this->assertEquals('via_query', $parameters[0]->name);
+        $this->assertEquals('query', $parameters[0]->in);
+    }
+
+    #[Test]
     public function it_converts_nested_validation_rules_to_bracket_notation_for_get(): void
     {
         $route = [


### PR DESCRIPTION
## Summary
- filter detected request parameters for non-GET methods so only explicit `->query()` sources become OpenAPI query parameters
- keep `->input()` / `->get()` / `->boolean()` derived fields out of query parameters for POST/PUT/PATCH/DELETE
- treat `->has()` / `->filled()` checks as optional (`required: false`)

Closes #456

## Files changed
- `src/Generators/ParameterGenerator.php`
- `src/Analyzers/QueryParameterAnalyzer.php`
- `tests/Unit/Generators/ParameterGeneratorTest.php`
- `tests/Unit/Analyzers/QueryParameterAnalyzerTest.php`

## Verification
- `vendor/bin/phpunit tests/Unit/Generators/ParameterGeneratorTest.php`
- `vendor/bin/phpunit tests/Unit/Analyzers/QueryParameterAnalyzerTest.php`
- `composer format`
- `composer analyze`
- `composer test`

## Risks / Follow-ups
- this fix intentionally keeps explicit `query()` access as query parameters on non-GET methods; if any endpoint uses mixed styles, reviewers should confirm that behavior is desired.
