### PR TITLE
test: add regression coverage for non-standard route patterns

### DIFF
--- a/tests/Unit/RouteAnalyzerWithPrefixTest.php
+++ b/tests/Unit/RouteAnalyzerWithPrefixTest.php
@@ -88,6 +88,30 @@ class RouteAnalyzerWithPrefixTest extends TestCase
     }
 
     #[Test]
+    public function it_includes_non_standard_api_prefixes_when_pattern_is_configured(): void
+    {
+        // Arrange
+        config(['spectrum.route_patterns' => ['data_proxy_api/v2/*']]);
+
+        Route::prefix('data_proxy_api/v2')->group(function () {
+            Route::get('users', [UserController::class, 'index']);
+            Route::post('users', [UserController::class, 'store']);
+        });
+
+        Route::get('web/about', function () {
+            return 'about';
+        });
+
+        // Act
+        $routes = $this->analyzer->analyze();
+
+        // Assert
+        $this->assertCount(2, $routes);
+        $this->assertEquals('data_proxy_api/v2/users', $routes[0]['uri']);
+        $this->assertEquals('data_proxy_api/v2/users', $routes[1]['uri']);
+    }
+
+    #[Test]
     public function it_respects_custom_route_patterns_with_prefix()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- add regression coverage for non-standard API prefixes when `spectrum.route_patterns` is explicitly configured
- verify `data_proxy_api/v2/*` routes are included and non-API routes remain excluded in the same scenario
- keep runtime behavior unchanged (configuration-based support)

## Files/components changed
- tests/Unit/RouteAnalyzerWithPrefixTest.php

## Verification commands run
- composer format
- vendor/bin/phpunit tests/Unit/RouteAnalyzerWithPrefixTest.php
- composer test

## Risks or follow-ups
- no runtime risk (test-only change)

Refs #459
