### PR TITLE
fix: infer static transformer method return types in Fractal analyzer

### DIFF
--- a/src/Analyzers/FractalTransformerAnalyzer.php
+++ b/src/Analyzers/FractalTransformerAnalyzer.php
@@ -354,6 +354,13 @@ class FractalTransformerAnalyzer implements ClassAnalyzer, HasErrors
             }
         }
 
+        if ($class !== null && $expression instanceof Node\Expr\StaticCall) {
+            $staticCallType = $this->inferTypeFromTransformerStaticCall($expression, $class, $methodStack, $modelPropertyTypes);
+            if ($staticCallType !== null) {
+                return $staticCallType;
+            }
+        }
+
         if ($expression instanceof Node\Expr\FuncCall) {
             $arrayMapType = $this->inferTypeFromArrayMapCall(
                 $expression,
@@ -403,6 +410,59 @@ class FractalTransformerAnalyzer implements ClassAnalyzer, HasErrors
         }
 
         $methodName = $methodCall->name->toString();
+        if (isset($methodStack[$methodName])) {
+            return null;
+        }
+
+        $method = $this->astHelper->findMethodNode($class, $methodName);
+        if (! $method) {
+            return null;
+        }
+
+        $returnExpression = $this->extractMethodReturnExpression($method);
+        if (! $returnExpression) {
+            return null;
+        }
+
+        $nextStack = $methodStack;
+        $nextStack[$methodName] = true;
+
+        $methodVariableTypeHints = $this->extractMethodVariableTypeHints($method, $class, $nextStack, $modelPropertyTypes);
+
+        return $this->inferTypeFromExpression(
+            $returnExpression,
+            $class,
+            $nextStack,
+            $modelPropertyTypes,
+            $methodVariableTypeHints
+        );
+    }
+
+    /**
+     * @param  array<string, bool>  $methodStack
+     * @param  array<string, array<string, array{type: string, format?: string}>>  $modelPropertyTypes
+     * @return array{type?: string, format?: string, properties?: array<string, mixed>, items?: array<string, mixed>}|null
+     */
+    protected function inferTypeFromTransformerStaticCall(Node\Expr\StaticCall $staticCall, Node\Stmt\Class_ $class, array $methodStack, array $modelPropertyTypes = []): ?array
+    {
+        if (! $staticCall->class instanceof Node\Name) {
+            return null;
+        }
+
+        $isSameClassReference = in_array(strtolower($staticCall->class->toString()), ['self', 'static'], true);
+        if (! $isSameClassReference && $class->name instanceof Node\Identifier) {
+            $isSameClassReference = strtolower($staticCall->class->getLast()) === strtolower($class->name->toString());
+        }
+
+        if (! $isSameClassReference) {
+            return null;
+        }
+
+        if (! $staticCall->name instanceof Node\Identifier) {
+            return null;
+        }
+
+        $methodName = $staticCall->name->toString();
         if (isset($methodStack[$methodName])) {
             return null;
         }

--- a/tests/Fixtures/Transformers/Issue467ProjectTransformer.php
+++ b/tests/Fixtures/Transformers/Issue467ProjectTransformer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Fixtures\Transformers;
+
+use League\Fractal\TransformerAbstract;
+
+class Issue467ProjectTransformer extends TransformerAbstract
+{
+    public function transform($project): array
+    {
+        return [
+            'project_users' => self::transformProjectUsers($project->project_users),
+        ];
+    }
+
+    /**
+     * @return array<int, array{id: int, email: mixed, is_invited: bool}>
+     */
+    private static function transformProjectUsers($projectUsers): array
+    {
+        return array_map(
+            static function ($projectUser): array {
+                return [
+                    'id' => (int) $projectUser['id'],
+                    'email' => $projectUser['email'],
+                    'is_invited' => false,
+                ];
+            },
+            $projectUsers
+        );
+    }
+}

--- a/tests/Unit/Analyzers/FractalTransformerAnalyzerTest.php
+++ b/tests/Unit/Analyzers/FractalTransformerAnalyzerTest.php
@@ -10,6 +10,7 @@ use LaravelSpectrum\Tests\Fixtures\Transformers\ExampleGenerationTransformer;
 use LaravelSpectrum\Tests\Fixtures\Transformers\GetterBasedUserTransformer;
 use LaravelSpectrum\Tests\Fixtures\Transformers\Issue458ProjectTransformer;
 use LaravelSpectrum\Tests\Fixtures\Transformers\Issue465ProjectTransformer;
+use LaravelSpectrum\Tests\Fixtures\Transformers\Issue467ProjectTransformer;
 use LaravelSpectrum\Tests\Fixtures\Transformers\MinimalTransformer;
 use LaravelSpectrum\Tests\Fixtures\Transformers\MissingIncludeMethodTransformer;
 use LaravelSpectrum\Tests\Fixtures\Transformers\PostTransformer;
@@ -412,5 +413,19 @@ class FractalTransformerAnalyzerTest extends TestCase
         $this->assertSame('array', $result['properties']['notification_codes']['type']);
         $this->assertArrayHasKey('items', $result['properties']['notification_codes']);
         $this->assertSame('string', $result['properties']['notification_codes']['items']['type']);
+    }
+
+    #[Test]
+    public function it_infers_issue_467_types_for_static_method_calls_returning_array_map_of_objects(): void
+    {
+        $result = $this->analyzer->analyze(Issue467ProjectTransformer::class);
+
+        $this->assertSame('array', $result['properties']['project_users']['type']);
+        $this->assertArrayHasKey('items', $result['properties']['project_users']);
+        $this->assertSame('object', $result['properties']['project_users']['items']['type']);
+        $this->assertArrayHasKey('properties', $result['properties']['project_users']['items']);
+        $this->assertSame('integer', $result['properties']['project_users']['items']['properties']['id']['type']);
+        $this->assertSame('string', $result['properties']['project_users']['items']['properties']['email']['type']);
+        $this->assertSame('boolean', $result['properties']['project_users']['items']['properties']['is_invited']['type']);
     }
 }


### PR DESCRIPTION
## Summary
- support Fractal transformer type inference for `self::method()` / `static::method()` calls in transform payloads
- follow static method return expressions and reuse existing variable/array_map inference pipeline
- add Issue #467 fixture and regression test for `array_map` returning array-of-object

## Changed Files
- `src/Analyzers/FractalTransformerAnalyzer.php`
- `tests/Fixtures/Transformers/Issue467ProjectTransformer.php`
- `tests/Unit/Analyzers/FractalTransformerAnalyzerTest.php`

## Verification
- `composer format:fix`
- `composer analyze`
- `composer test`

## Risk / Follow-up
- current fix resolves same-class static calls; external class static calls are intentionally out of scope for this PR.

Closes #467